### PR TITLE
Remove use master in sp_pressure_detector.sql

### DIFF
--- a/sp_pressure_detector/sp_pressure_detector.sql
+++ b/sp_pressure_detector/sp_pressure_detector.sql
@@ -1,7 +1,3 @@
-USE master;
-GO
-
-
 CREATE OR ALTER PROCEDURE dbo.sp_pressure_detector
 AS 
 BEGIN


### PR DESCRIPTION
Remove `use master` database in `sp_pressure_detector.sql`, so it is easier for copy paster (like me) to install the stored procedure in any database.