### PR TITLE
Include plan_handle in output

### DIFF
--- a/sp_pressure_detector/sp_pressure_detector.sql
+++ b/sp_pressure_detector/sp_pressure_detector.sql
@@ -198,7 +198,7 @@ SELECT @version = '1.0', @versiondate = '20200301';
                     dest.text, ( der.statement_start_offset / 2 ) + 1,
                     (( CASE der.statement_end_offset WHEN -1 THEN DATALENGTH(dest.text) ELSE der.statement_end_offset END
                        - der.statement_start_offset ) / 2 ) + 1) AS query_text,
-       deqp.query_plan,
+           deqp.query_plan,
            der.plan_handle,
            der.status,
            der.blocking_session_id,

--- a/sp_pressure_detector/sp_pressure_detector.sql
+++ b/sp_pressure_detector/sp_pressure_detector.sql
@@ -117,7 +117,8 @@ SELECT @version = '1.0', @versiondate = '20200301';
                        ELSE N''
                 END
                 + N'
-                deqp.query_plan
+                deqp.query_plan,
+                deqmg.plan_handle
     FROM        sys.dm_exec_query_memory_grants AS deqmg
     OUTER APPLY ( SELECT   TOP (1) *
                   FROM     sys.dm_os_waiting_tasks AS dowt
@@ -198,6 +199,7 @@ SELECT @version = '1.0', @versiondate = '20200301';
                     (( CASE der.statement_end_offset WHEN -1 THEN DATALENGTH(dest.text) ELSE der.statement_end_offset END
                        - der.statement_start_offset ) / 2 ) + 1) AS query_text,
        deqp.query_plan,
+           der.plan_handle,
            der.status,
            der.blocking_session_id,
            der.wait_type,


### PR DESCRIPTION
Added `plan_handle` alongside the `query_plan` for those times when you want to **DBCC FREEPROCCACHE** a bad plan that can't be recompiled by other means