### PR TITLE
Resolve insert failure on not NULLable column on <=SQL Server 2017 

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -302,7 +302,7 @@ CREATE TABLE
     last_execution_time datetimeoffset(7) NULL,
     avg_compile_duration_ms float NULL,
     last_compile_duration_ms bigint NULL,
-    plan_forcing_type int NOT NULL,
+    plan_forcing_type int NULL,
     plan_forcing_type_desc nvarchar(60) NULL
 );
 


### PR DESCRIPTION
When @new = 0 (SQL Server 2017 Enterprise), an attempted insert of NULL into the NOT NULLable column #query_store_plan.plan_forcing_type causes a query failure. By changing the column to NOT NULL, the insert succeeds and the query appears to be returning the expected results.

The INSERT EXEC statement directly above the line below

/* This gets some query information */ 

attempts to INSERT NULL into #query_store_plan.plan_forcing_type. This column is defined as NOT NULL, and the statement fails with the below.

Msg 515, Level 16, State 2, Procedure sp_QuickieStore, Line 1393 [Batch Start Line 0]
Cannot insert the value NULL into column 'plan_forcing_type', table 'tempdb.dbo.#query_store_plan___________________________________________________________________________________________________000000013E0C'; column does not allow nulls. INSERT fails.

The NULLs are specified in the IF statement below the IF block containing the line

qsp.plan_forcing_type_desc';


The full error message output this resolves is below.

Msg 50000, Level 11, State 1, Procedure sp_QuickieStore, Line 2917 [Batch Start Line 0]
error while inserting #query_store_plan
Msg 50000, Level 11, State 1, Procedure sp_QuickieStore, Line 2920 [Batch Start Line 0]
offending query:

SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
SELECT
    qsp.plan_id,
    qsp.query_id,
    all_plan_ids = 
        STUFF
            (
                (
                    SELECT DISTINCT 
                        ', ' + 
                        RTRIM
                            (qsp_plans.plan_id)
                    FROM [SIMS4].sys.query_store_plan AS qsp_plans
                    WHERE qsp.query_id = qsp_plans.query_id
                    FOR XML PATH(''), TYPE
                ).value('.[1]', 'varchar(MAX)'), 
                1, 
                2, 
                ''
            ),    
    qsp.plan_group_id,
    qsp.engine_version,
    qsp.compatibility_level,
    qsp.query_plan_hash,
    qsp.query_plan,
    qsp.is_online_index_plan,
    qsp.is_trivial_plan,
    qsp.is_parallel_plan,
    qsp.is_forced_plan,
    qsp.is_natively_compiled,
    qsp.force_failure_count,
    qsp.last_force_failure_reason,
    qsp.last_force_failure_reason_desc,
    qsp.count_compiles,
    qsp.initial_compile_start_time,
    qsp.last_compile_start_time,
    qsp.last_execution_time,
    (qsp.avg_compile_duration / 1000.),
    (qsp.last_compile_duration / 1000.),
    NULL,
    NULL
FROM #query_store_runtime_stats AS qsrs
CROSS APPLY
(
    SELECT TOP (@plans_top) 
        qsp.*
    FROM [SIMS4].sys.query_store_plan AS qsp
    WHERE qsp.plan_id = qsrs.plan_id
    AND   qsp.last_execution_time >= qsrs.last_execution_time
    AND   qsp.is_online_index_plan = 0
    ORDER BY qsp.last_execution_time DESC
) AS qsp
OPTION(RECOMPILE);
Msg 515, Level 16, State 2, Procedure sp_QuickieStore, Line 1393 [Batch Start Line 0]
Cannot insert the value NULL into column 'plan_forcing_type', table 'tempdb.dbo.#query_store_plan___________________________________________________________________________________________________000000013E0C'; column does not allow nulls. INSERT fails.

Completion time: 2021-04-13T08:41:39.3152462+12:00