### PR TITLE
Add validation and examples

### DIFF
--- a/sp_QuickieStore/Examples.sql
+++ b/sp_QuickieStore/Examples.sql
@@ -109,6 +109,13 @@ EXEC dbo.sp_QuickieStore
     @format_output = 1;
 
 
+--Use wait filter to search for queries responsible for high waits
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @wait_filter = 'memory',
+    @sort_order = 'memory';
+
+
 --Troubleshoot performance
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',


### PR DESCRIPTION
I need to make sure we're on a version that supports searching for waits and that the feature is enabled. I also moved the wait search validation up higher to avoid unnecessary work and added the variables to debug output.

There's also a new example query that shows people how to search.