### PR TITLE
Update sp_HumanEvents.sql

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -1085,11 +1085,8 @@ AND  EXISTS
 BEGIN
         RAISERROR(N'You need to set up the blocked process report in order to use this:
     EXEC sys.sp_configure ''show advanced options'', 1;
-    GO
     RECONFIGURE
-    GO
     EXEC sys.sp_configure ''blocked process threshold'', 5; /* Seconds of blocking before a report is generated */
-    GO
     RECONFIGURE
     GO', 1, 0) WITH NOWAIT;
     RETURN;


### PR DESCRIPTION
I'm deploying sp_HumanEvents to about 600 servers via Invoke-DbaQuery using the -File parameter. I get the error below unless the GO statements are removed in this section or some semicolons are added so I removed the semicolons. I thought I would share it with others.

WARNING: [21:46:51][Invoke-DbaQuery] [MyServer] Failed during execution | Unclosed quotation mark after the characte
r string 'You need to set up the blocked process report in order to use this:
    EXEC sys.sp_configure 'show advanced options', 1;   
'.
Incorrect syntax near 'You need to set up the blocked process report in order to use this:
    EXEC sys.sp_configure 'show advanced options', 1;   
'.