### PR TITLE
Update sp_HumanEvents.sql

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -1085,11 +1085,8 @@ AND  EXISTS
 BEGIN
         RAISERROR(N'You need to set up the blocked process report in order to use this:
     EXEC sys.sp_configure ''show advanced options'', 1;
-    GO
     RECONFIGURE
-    GO
     EXEC sys.sp_configure ''blocked process threshold'', 5; /* Seconds of blocking before a report is generated */
-    GO
     RECONFIGURE
     GO', 1, 0) WITH NOWAIT;
     RETURN;


### PR DESCRIPTION
Removed three GO statements that started on line 1088 after sp_configure. It was either this or add some semicolons. This resolves an error returned when deploying the stored procedure using Invoke-DbaQuery.