### PR TITLE
Add filter by execution_type_desc & fix AGs validation @ Azure SQL DB

### DIFF
--- a/sp_QuickieStore/Examples.sql
+++ b/sp_QuickieStore/Examples.sql
@@ -80,6 +80,11 @@ EXEC dbo.sp_QuickieStore
     @top = 10,
     @duration_ms = 10000;
 
+/*Search for queries with a specific execution type*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @top = 10,
+    @execution_type_desc = 'aborted';
 
 /*Search for a specific stored procedure*/
 EXEC dbo.sp_QuickieStore

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -46,7 +46,7 @@ https://github.com/erikdarlingdata/DarlingData
 */
 
 CREATE OR ALTER PROCEDURE 
-   dbo.sp_QuickieStore
+    dbo.sp_QuickieStore
 (
     @database_name sysname = NULL,
     @sort_order varchar(20) = 'cpu',
@@ -55,7 +55,7 @@ CREATE OR ALTER PROCEDURE
     @end_date datetime = NULL,
     @execution_count bigint = NULL,
     @duration_ms bigint = NULL,
-	@execution_type_desc nvarchar(60) = NULL,
+    @execution_type_desc nvarchar(60) = NULL,
     @procedure_schema sysname = NULL,
     @procedure_name sysname = NULL,
     @include_plan_ids nvarchar(4000) = NULL,
@@ -150,7 +150,7 @@ BEGIN
                 WHEN '@end_date' THEN 'the end date of your search'
                 WHEN '@execution_count' THEN 'the minimum number of executions a query must have'
                 WHEN '@duration_ms' THEN 'the minimum duration a query must have'
-				WHEN '@execution_type_desc' THEN 'the type of execution you want to filter'
+                WHEN '@execution_type_desc' THEN 'the type of execution you want to filter'
                 WHEN '@procedure_schema' THEN 'the schema of the procedure you''re searching for'
                 WHEN '@procedure_name' THEN 'the name of the programmable object you''re searching for'
                 WHEN '@include_plan_ids' THEN 'a list of plan ids to search for'
@@ -183,7 +183,7 @@ BEGIN
                 WHEN '@end_date' THEN 'January 1, 1753, through December 31, 9999'
                 WHEN '@execution_count' THEN 'a positive integer between 1 and 9,223,372,036,854,775,807'
                 WHEN '@duration_ms' THEN 'a positive integer between 1 and 9,223,372,036,854,775,807'
-				WHEN '@execution_type_desc' THEN 'regular, aborted, exception'
+                WHEN '@execution_type_desc' THEN 'regular, aborted, exception'
                 WHEN '@procedure_schema' THEN 'a valid schema in your database'
                 WHEN '@procedure_name' THEN 'a valid programmable object in your database'
                 WHEN '@include_plan_ids' THEN 'a string; comma separated for multiple ids'
@@ -216,7 +216,7 @@ BEGIN
                 WHEN '@end_date' THEN 'NULL'
                 WHEN '@execution_count' THEN 'NULL'
                 WHEN '@duration_ms' THEN 'NULL'
-				WHEN '@execution_type_desc' THEN 'NULL'
+                WHEN '@execution_type_desc' THEN 'NULL'
                 WHEN '@procedure_schema' THEN 'NULL; dbo if NULL and procedure name is not NULL'
                 WHEN '@procedure_name' THEN 'NULL'
                 WHEN '@include_plan_ids' THEN 'NULL'
@@ -1070,7 +1070,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;',
           @end_date datetime,
           @execution_count bigint,
           @duration_ms bigint,
-		  @execution_type_desc nvarchar(60)',
+          @execution_type_desc nvarchar(60)',
     @plans_top =
         CASE
             WHEN @include_plan_ids IS NULL
@@ -3072,7 +3072,7 @@ EXEC sys.sp_executesql
     @end_date,
     @execution_count,
     @duration_ms,
-	@execution_type_desc;
+    @execution_type_desc;
 
 IF @troubleshoot_performance = 1
 BEGIN
@@ -3255,7 +3255,7 @@ EXEC sys.sp_executesql
     @end_date,
     @execution_count,
     @duration_ms,
-	@execution_type_desc;
+    @execution_type_desc;
 
 IF @troubleshoot_performance = 1
 BEGIN
@@ -6389,8 +6389,8 @@ BEGIN
             @execution_count,
         duration_ms =
             @duration_ms,
-		execution_type_desc =
-			@execution_type_desc,
+        execution_type_desc =
+            @execution_type_desc,
         procedure_schema =
             @procedure_schema,
         procedure_name =

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -1653,19 +1653,27 @@ OPTION(RECOMPILE);
 /*
 See if AGs are a thing so we can skip the checks for replica stuff
 */
-SELECT
-    @ags_present = 
-        CASE 
-            WHEN EXISTS 
-                 (
-                     SELECT 
-                         1/0
-                     FROM sys.availability_groups AS ag
-                 )
-            THEN 1
-            ELSE 0
-        END
-OPTION(RECOMPILE);
+IF (@azure = 1)
+BEGIN
+	SELECT
+		@ags_present = 0
+END
+ELSE
+BEGIN 
+	SELECT
+		@ags_present = 
+            CASE 
+                WHEN EXISTS 
+                        (
+                            SELECT 
+                                1/0
+                            FROM sys.availability_groups AS ag
+                        )
+                THEN 1
+                ELSE 0
+            END
+		OPTION(RECOMPILE);
+END
 
 /*
 Get filters ready, or whatever

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -46,7 +46,7 @@ https://github.com/erikdarlingdata/DarlingData
 */
 
 CREATE OR ALTER PROCEDURE 
-    dbo.sp_QuickieStore
+   dbo.sp_QuickieStore
 (
     @database_name sysname = NULL,
     @sort_order varchar(20) = 'cpu',
@@ -54,7 +54,8 @@ CREATE OR ALTER PROCEDURE
     @start_date datetime = NULL,
     @end_date datetime = NULL,
     @execution_count bigint = NULL,
-    @duration_ms bigint = NULL ,
+    @duration_ms bigint = NULL,
+	@execution_type_desc nvarchar(60) = NULL,
     @procedure_schema sysname = NULL,
     @procedure_name sysname = NULL,
     @include_plan_ids nvarchar(4000) = NULL,
@@ -149,6 +150,7 @@ BEGIN
                 WHEN '@end_date' THEN 'the end date of your search'
                 WHEN '@execution_count' THEN 'the minimum number of executions a query must have'
                 WHEN '@duration_ms' THEN 'the minimum duration a query must have'
+				WHEN '@execution_type_desc' THEN 'the type of execution you want to filter'
                 WHEN '@procedure_schema' THEN 'the schema of the procedure you''re searching for'
                 WHEN '@procedure_name' THEN 'the name of the programmable object you''re searching for'
                 WHEN '@include_plan_ids' THEN 'a list of plan ids to search for'
@@ -181,6 +183,7 @@ BEGIN
                 WHEN '@end_date' THEN 'January 1, 1753, through December 31, 9999'
                 WHEN '@execution_count' THEN 'a positive integer between 1 and 9,223,372,036,854,775,807'
                 WHEN '@duration_ms' THEN 'a positive integer between 1 and 9,223,372,036,854,775,807'
+				WHEN '@execution_type_desc' THEN 'regular, aborted, exception'
                 WHEN '@procedure_schema' THEN 'a valid schema in your database'
                 WHEN '@procedure_name' THEN 'a valid programmable object in your database'
                 WHEN '@include_plan_ids' THEN 'a string; comma separated for multiple ids'
@@ -213,6 +216,7 @@ BEGIN
                 WHEN '@end_date' THEN 'NULL'
                 WHEN '@execution_count' THEN 'NULL'
                 WHEN '@duration_ms' THEN 'NULL'
+				WHEN '@execution_type_desc' THEN 'NULL'
                 WHEN '@procedure_schema' THEN 'NULL; dbo if NULL and procedure name is not NULL'
                 WHEN '@procedure_name' THEN 'NULL'
                 WHEN '@include_plan_ids' THEN 'NULL'
@@ -1065,7 +1069,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;',
           @start_date datetime,
           @end_date datetime,
           @execution_count bigint,
-          @duration_ms bigint',
+          @duration_ms bigint,
+		  @execution_type_desc nvarchar(60)',
     @plans_top =
         CASE
             WHEN @include_plan_ids IS NULL
@@ -1696,6 +1701,13 @@ BEGIN
     SELECT
         @where_clause += N'AND   qsrs.avg_duration >= (@duration_ms * 1000.)' + @nc10;
 END;
+
+IF @execution_type_desc IS NOT NULL
+BEGIN
+    SELECT
+        @where_clause += N'AND   qsrs.execution_type_desc = @execution_type_desc' + @nc10;
+END;
+
 
 /*
 In this section we set up the filter if someone's searching for
@@ -3051,7 +3063,8 @@ EXEC sys.sp_executesql
     @start_date,
     @end_date,
     @execution_count,
-    @duration_ms;
+    @duration_ms,
+	@execution_type_desc;
 
 IF @troubleshoot_performance = 1
 BEGIN
@@ -3233,7 +3246,8 @@ EXEC sys.sp_executesql
     @start_date,
     @end_date,
     @execution_count,
-    @duration_ms;
+    @duration_ms,
+	@execution_type_desc;
 
 IF @troubleshoot_performance = 1
 BEGIN
@@ -6367,6 +6381,8 @@ BEGIN
             @execution_count,
         duration_ms =
             @duration_ms,
+		execution_type_desc =
+			@execution_type_desc,
         procedure_schema =
             @procedure_schema,
         procedure_name =


### PR DESCRIPTION
Hey @erikdarlingdata 

I was working on a system where I could not open the dashboards and see data quickly but I was able to get data (quickly) with sp_QuickStore 💪

## 1st
Due to some analysis, I found myself trying to find timeout queries, AFAIK best bet is the `aborted` execution type that we can find on `execution_type_desc`.

Thus I decided to submit this PR to include a new parameter `@execution_type_desc` to help filter out any of the existing types `regular`, `aborted`, `exception` or as off today keep it `NULL` and get everything.

NOTE: Out of curiosity, before that and because I knew the timeout was 30 seconds, I was playing with `@duration` parameter by using 29000 as a value. However, queries that don't timeout and take longer would appear too.

## 2nd
This system is an Azure SQL DB. 
The `sp_QuickieStore` doesn't run as it is because it's checking `sys.availability_groups` system table and thus it fails. 
I overcome that by wrapping that on an if statement using the `@azure` variable for that


## 3rd
I have also updated the examples file with one call using this new parameter.


Let me know if this change seems ok or if I need to adjust something else.

Thanks!