### PR TITLE
Add blocking tree to sp_HumanEventsBlockViewer

### DIFF
--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -548,7 +548,7 @@ SELECT
     clientoption2 = bd.value('(process/@clientoption1)[1]', 'bigint'),
     currentdbname = bd.value('(process/@currentdbname)[1]', 'nvarchar(128)'),
     blocking_level = 0,
-    sort_order = cast('' as varchar(max)),
+    sort_order = cast('' as varchar(400)),
     activity = CASE WHEN oa.c.exist('//blocked-process-report/blocked-process') = 1 THEN 'blocked' END,
     blocked_process_report = c.query('.')
 INTO #blocked
@@ -571,9 +571,12 @@ PERSISTED;
 
 ALTER TABLE #blocked
 ADD blocking_desc AS 
-    ISNULL('(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')', 'unresolved process') PERSISTED,
+    ISNULL('(' + CAST(blocking_spid AS VARCHAR(10)) + ':' + CAST(blocking_ecid AS VARCHAR(10)) + ')', 'unresolved process') PERSISTED,
     blocked_desc AS
-    '(' + CAST(blocked_spid AS VARCHAR(max)) + ':' + CAST(blocked_ecid AS VARCHAR(max)) + ')' PERSISTED;
+    '(' + CAST(blocked_spid AS VARCHAR(10)) + ':' + CAST(blocked_ecid AS VARCHAR(10)) + ')' PERSISTED;
+
+CREATE CLUSTERED INDEX ix_blocking on #blocked(monitor_loop, blocking_desc);
+CREATE NONCLUSTERED INDEX ix_blocked on #blocked(monitor_loop, blocked_desc);    
 
 IF @debug = 1 BEGIN SELECT '#blocked' AS table_name, * FROM #blocked AS wa OPTION(RECOMPILE); END;
 
@@ -619,7 +622,7 @@ SELECT
     clientoption2 = bg.value('(process/@clientoption1)[1]', 'bigint'),
     currentdbname = bg.value('(process/@currentdbname)[1]', 'nvarchar(128)'),
     blocking_level = 0,
-    sort_order = cast('' as varchar(max)),
+    sort_order = cast('' as varchar(400)),
     activity = CASE WHEN oa.c.exist('//blocked-process-report/blocking-process') = 1 THEN 'blocking' END,
     blocked_process_report = c.query('.')
 INTO #blocking
@@ -642,10 +645,12 @@ PERSISTED;
 
 ALTER TABLE #blocking
 ADD blocking_desc AS 
-    ISNULL('(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')', 'unresolved process') PERSISTED,
+    ISNULL('(' + CAST(blocking_spid AS VARCHAR(10)) + ':' + CAST(blocking_ecid AS VARCHAR(10)) + ')', 'unresolved process') PERSISTED,
     blocked_desc AS
-    '(' + CAST(blocked_spid AS VARCHAR(max)) + ':' + CAST(blocked_ecid AS VARCHAR(max)) + ')' PERSISTED;
-    
+    '(' + CAST(blocked_spid AS VARCHAR(10)) + ':' + CAST(blocked_ecid AS VARCHAR(10)) + ')' PERSISTED;
+
+CREATE CLUSTERED INDEX ix_blocking on #blocking(monitor_loop, blocking_desc);
+CREATE NONCLUSTERED INDEX ix_blocked on #blocking(monitor_loop, blocked_desc);    
 
 IF @debug = 1 BEGIN SELECT '#blocking' AS table_name, * FROM #blocking AS wa OPTION(RECOMPILE); END;
 
@@ -656,7 +661,7 @@ WITH hierarchy AS
         blocking_desc,
         blocked_desc,
         level = 0,
-        sort_order = blocking_desc + ' <-- ' + blocked_desc
+        sort_order = cast(blocking_desc + ' <-- ' + blocked_desc as varchar(400))
     FROM #blocking b
     WHERE NOT EXISTS (
         SELECT *
@@ -672,7 +677,7 @@ WITH hierarchy AS
         bg.blocking_desc,
         bg.blocked_desc,
         h.level + 1,
-        h.sort_order + ' ' + bg.blocking_desc + ' <-- ' + bg.blocked_desc
+        cast(h.sort_order + ' ' + bg.blocking_desc + ' <-- ' + bg.blocked_desc as varchar(400))
     FROM hierarchy h
     JOIN #blocking bg
         ON bg.monitor_loop = h.monitor_loop

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -90,7 +90,7 @@ BEGIN
     SELECT  'you can use me in conjunction with sp_HumanEvents to quickly parse the sqlserver.blocked_process_report event' UNION ALL
     SELECT  'EXEC sp_HumanEvents @event_type = N''blocking'', @keep_alive = 1;' UNION ALL
     SELECT  'it will also work with another extended event session using the ring buffer as a target to capture blocking' UNION ALL
-    SELECT  'all scripts and documentation are available here: 0' UNION ALL
+    SELECT  'all scripts and documentation are available here: https://github.com/erikdarlingdata/DarlingData/tree/main/sp_HumanEvents' UNION ALL
     SELECT  'from your loving sql server consultant, erik darling: erikdarlingdata.com';
 
     SELECT

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -626,15 +626,13 @@ PERSISTED;
 
 IF @debug = 1 BEGIN SELECT '#blocking' AS table_name, * FROM #blocking AS wa OPTION(RECOMPILE); END;
 
-SELECT 
+SELECT DISTINCT
     monitor_loop = c.value('(//@monitorLoop)[1]', 'int'), 
     blocking_spid = blocking.value('(process/@spid)[1]', 'int'),
     blocking_ecid = blocking.value('(process/@ecid)[1]', 'int'),
     blocked_spid = blocked.value('(process/@spid)[1]', 'int'),
     blocked_ecid = blocked.value('(process/@ecid)[1]', 'int'),
-    level = 0,
-    order_string = cast('' as varchar(max)),
-    blocked_process_report = c.query('.')
+    level = 0
 INTO #blocking_hierarchy
 FROM #blocking_xml AS bx
 OUTER APPLY bx.human_events_xml.nodes('/event') AS oa(c)
@@ -655,8 +653,7 @@ hierarchy AS
         monitor_loop, 
         spid = blocking_spid, 
         ecid = blocking_ecid, 
-        level = 0,
-        order_string = cast(monitor_loop as varchar(max)) + ':' + cast(blocking_spid as varchar(max))
+        level = 1
     FROM blockheads
 
     UNION ALL
@@ -665,8 +662,7 @@ hierarchy AS
         bh.monitor_loop, 
         bh.blocked_spid, 
         bh.blocked_ecid, 
-        h.level + 1,
-        h.order_string + '/' + cast(blocked_spid as varchar(max))
+        h.level + 1
     FROM hierarchy h
     JOIN #blocking_hierarchy bh 
         ON bh.monitor_loop = h.monitor_loop
@@ -674,8 +670,7 @@ hierarchy AS
         AND bh.blocking_ecid = h.ecid
 )
 UPDATE #blocking_hierarchy
-SET level = h.level,
-    order_string = h.order_string
+SET level = h.level
 FROM #blocking_hierarchy bs
 JOIN hierarchy h
     ON h.monitor_loop = bs.monitor_loop
@@ -698,6 +693,16 @@ SELECT
             RTRIM(kheb.object_id)
         ),
     kheb.activity,
+    blocking_tree = 
+        CASE
+            WHEN bh.level is null 
+            THEN  '(' + CAST(kheb.spid as varchar(max)) + ':' + CAST((kheb.ecid) as varchar(max)) + ') Lead Blocker'
+            ELSE 
+                REPLICATE(' > ', bh.[level]) + 
+                '(' + CAST(kheb.spid as varchar(max)) + ':' + CAST((kheb.ecid) as varchar(max)) 
+                + ') blocked by (' 
+                + CAST(bh.blocking_spid as varchar(max)) + ':' + CAST((bh.blocking_ecid) as varchar(max)) + ')' 
+        END,
     kheb.spid,
     kheb.ecid,
     query_text =
@@ -847,6 +852,11 @@ FROM
     WHERE (bd.database_name = @database_name
            OR @database_name IS NULL)
 ) AS kheb
+LEFT JOIN #blocking_hierarchy bh
+    ON bh.monitor_loop = kheb.monitor_loop
+    AND bh.blocked_spid = kheb.spid
+    AND bh.blocked_ecid = kheb.ecid
+
 OPTION(RECOMPILE);
 
 SELECT
@@ -857,6 +867,7 @@ SELECT
     b.currentdbname,
     b.contentious_object,
     b.activity,
+    b.blocking_tree,
     b.spid,
     b.ecid,
     b.query_text,

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -571,7 +571,7 @@ PERSISTED;
 
 ALTER TABLE #blocked
 ADD blocking_desc AS 
-    '(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')' PERSISTED,
+    ISNULL('(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')', 'unresolved process') PERSISTED,
     blocked_desc AS
     '(' + CAST(blocked_spid AS VARCHAR(max)) + ':' + CAST(blocked_ecid AS VARCHAR(max)) + ')' PERSISTED;
 
@@ -642,7 +642,7 @@ PERSISTED;
 
 ALTER TABLE #blocking
 ADD blocking_desc AS 
-    '(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')' PERSISTED,
+    ISNULL('(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')', 'unresolved process') PERSISTED,
     blocked_desc AS
     '(' + CAST(blocked_spid AS VARCHAR(max)) + ':' + CAST(blocked_ecid AS VARCHAR(max)) + ')' PERSISTED;
     

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -525,8 +525,10 @@ SELECT
     transaction_id = c.value('(data[@name="transaction_id"]/value/text())[1]', 'bigint'),
     resource_owner_type = c.value('(data[@name="resource_owner_type"]/text)[1]', 'nvarchar(256)'),
     monitor_loop = c.value('(//@monitorLoop)[1]', 'int'),
-    spid = bd.value('(process/@spid)[1]', 'int'),
-    ecid = bd.value('(process/@ecid)[1]', 'int'),           
+    blocking_spid = bg.value('(process/@spid)[1]', 'int'),
+    blocking_ecid = bg.value('(process/@ecid)[1]', 'int'),
+    blocked_spid = bd.value('(process/@spid)[1]', 'int'),
+    blocked_ecid = bd.value('(process/@ecid)[1]', 'int'),
     query_text_pre = bd.value('(process/inputbuf/text())[1]', 'nvarchar(MAX)'),
     wait_time = bd.value('(process/@waittime)[1]', 'bigint'),
     transaction_name = bd.value('(process/@transactionname)[1]', 'nvarchar(256)'),
@@ -545,12 +547,15 @@ SELECT
     clientoption1 = bd.value('(process/@clientoption1)[1]', 'bigint'),
     clientoption2 = bd.value('(process/@clientoption1)[1]', 'bigint'),
     currentdbname = bd.value('(process/@currentdbname)[1]', 'nvarchar(128)'),
+    blocking_level = 0,
+    sort_order = cast('' as varchar(max)),
     activity = CASE WHEN oa.c.exist('//blocked-process-report/blocked-process') = 1 THEN 'blocked' END,
     blocked_process_report = c.query('.')
 INTO #blocked
 FROM #blocking_xml AS bx
 OUTER APPLY bx.human_events_xml.nodes('/event') AS oa(c)
 OUTER APPLY oa.c.nodes('//blocked-process-report/blocked-process') AS bd(bd)
+OUTER APPLY oa.c.nodes('//blocked-process-report/blocking-process') AS bg(bg)
 OPTION(RECOMPILE);
 
 ALTER TABLE #blocked
@@ -563,6 +568,12 @@ ADD query_text AS
    NCHAR(21),N'?'),NCHAR(20),N'?'),NCHAR(19),N'?'),NCHAR(18),N'?'),NCHAR(17),N'?'),NCHAR(16),N'?'),NCHAR(15),N'?'),NCHAR(14),N'?'),NCHAR(12),N'?'),
    NCHAR(11),N'?'),NCHAR(8),N'?'),NCHAR(7),N'?'),NCHAR(6),N'?'),NCHAR(5),N'?'),NCHAR(4),N'?'),NCHAR(3),N'?'),NCHAR(2),N'?'),NCHAR(1),N'?'),NCHAR(0),N'?')
 PERSISTED;
+
+ALTER TABLE #blocked
+ADD blocking_desc AS 
+    '(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')' PERSISTED,
+    blocked_desc AS
+    '(' + CAST(blocked_spid AS VARCHAR(max)) + ':' + CAST(blocked_ecid AS VARCHAR(max)) + ')' PERSISTED;
 
 IF @debug = 1 BEGIN SELECT '#blocked' AS table_name, * FROM #blocked AS wa OPTION(RECOMPILE); END;
 
@@ -585,8 +596,10 @@ SELECT
     transaction_id = c.value('(data[@name="transaction_id"]/value/text())[1]', 'bigint'),
     resource_owner_type = c.value('(data[@name="resource_owner_type"]/text)[1]', 'nvarchar(256)'),
     monitor_loop = c.value('(//@monitorLoop)[1]', 'int'),
-    spid = bg.value('(process/@spid)[1]', 'int'),
-    ecid = bg.value('(process/@ecid)[1]', 'int'),
+    blocking_spid = bg.value('(process/@spid)[1]', 'int'),
+    blocking_ecid = bg.value('(process/@ecid)[1]', 'int'),
+    blocked_spid = bd.value('(process/@spid)[1]', 'int'),
+    blocked_ecid = bd.value('(process/@ecid)[1]', 'int'),
     query_text_pre = bg.value('(process/inputbuf/text())[1]', 'nvarchar(MAX)'),
     wait_time = bg.value('(process/@waittime)[1]', 'bigint'),
     transaction_name = bg.value('(process/@transactionname)[1]', 'nvarchar(256)'),
@@ -605,11 +618,14 @@ SELECT
     clientoption1 = bg.value('(process/@clientoption1)[1]', 'bigint'),
     clientoption2 = bg.value('(process/@clientoption1)[1]', 'bigint'),
     currentdbname = bg.value('(process/@currentdbname)[1]', 'nvarchar(128)'),
+    blocking_level = 0,
+    sort_order = cast('' as varchar(max)),
     activity = CASE WHEN oa.c.exist('//blocked-process-report/blocking-process') = 1 THEN 'blocking' END,
     blocked_process_report = c.query('.')
 INTO #blocking
 FROM #blocking_xml AS bx
 OUTER APPLY bx.human_events_xml.nodes('/event') AS oa(c)
+OUTER APPLY oa.c.nodes('//blocked-process-report/blocked-process') AS bd(bd)
 OUTER APPLY oa.c.nodes('//blocked-process-report/blocking-process') AS bg(bg)
 OPTION(RECOMPILE);
 
@@ -624,60 +640,61 @@ ADD query_text AS
    NCHAR(11),N'?'),NCHAR(8),N'?'),NCHAR(7),N'?'),NCHAR(6),N'?'),NCHAR(5),N'?'),NCHAR(4),N'?'),NCHAR(3),N'?'),NCHAR(2),N'?'),NCHAR(1),N'?'),NCHAR(0),N'?')
 PERSISTED;
 
+ALTER TABLE #blocking
+ADD blocking_desc AS 
+    '(' + CAST(blocking_spid AS VARCHAR(max)) + ':' + CAST(blocking_ecid AS VARCHAR(max)) + ')' PERSISTED,
+    blocked_desc AS
+    '(' + CAST(blocked_spid AS VARCHAR(max)) + ':' + CAST(blocked_ecid AS VARCHAR(max)) + ')' PERSISTED;
+    
+
 IF @debug = 1 BEGIN SELECT '#blocking' AS table_name, * FROM #blocking AS wa OPTION(RECOMPILE); END;
 
-SELECT DISTINCT
-    monitor_loop = c.value('(//@monitorLoop)[1]', 'int'), 
-    blocking_spid = blocking.value('(process/@spid)[1]', 'int'),
-    blocking_ecid = blocking.value('(process/@ecid)[1]', 'int'),
-    blocked_spid = blocked.value('(process/@spid)[1]', 'int'),
-    blocked_ecid = blocked.value('(process/@ecid)[1]', 'int'),
-    level = 0
-INTO #blocking_hierarchy
-FROM #blocking_xml AS bx
-OUTER APPLY bx.human_events_xml.nodes('/event') AS oa(c)
-OUTER APPLY oa.c.nodes('//blocked-process-report/blocking-process') AS blocking(blocking) /* cardinality should be 0,1 */
-OUTER APPLY oa.c.nodes('//blocked-process-report/blocked-process') AS blocked(blocked); /* cardinality should be 0-many */
-
-WITH blockheads AS 
-(
-    SELECT monitor_loop, blocking_spid, blocking_ecid
-    FROM #blocking_hierarchy
-    EXCEPT 
-    SELECT monitor_loop, blocked_spid, blocked_ecid
-    FROM #blocking_hierarchy
-),
-hierarchy AS 
+WITH hierarchy AS 
 (
     SELECT 
         monitor_loop, 
-        spid = blocking_spid, 
-        ecid = blocking_ecid, 
-        level = 1
-    FROM blockheads
+        blocking_desc,
+        blocked_desc,
+        level = 0,
+        sort_order = blocking_desc + ' <-- ' + blocked_desc
+    FROM #blocking b
+    WHERE NOT EXISTS (
+        SELECT *
+        FROM #blocking b2
+        WHERE b2.monitor_loop = b.monitor_loop
+        AND b2.blocked_desc = b.blocking_desc
+    )
 
     UNION ALL
 
     SELECT 
-        bh.monitor_loop, 
-        bh.blocked_spid, 
-        bh.blocked_ecid, 
-        h.level + 1
+        bg.monitor_loop,
+        bg.blocking_desc,
+        bg.blocked_desc,
+        h.level + 1,
+        h.sort_order + ' ' + bg.blocking_desc + ' <-- ' + bg.blocked_desc
     FROM hierarchy h
-    JOIN #blocking_hierarchy bh 
-        ON bh.monitor_loop = h.monitor_loop
-        AND bh.blocking_spid = h.spid
-        AND bh.blocking_ecid = h.ecid
+    JOIN #blocking bg
+        ON bg.monitor_loop = h.monitor_loop
+        AND bg.blocking_desc = h.blocked_desc
 )
-UPDATE #blocking_hierarchy
-SET level = h.level
-FROM #blocking_hierarchy bs
+UPDATE #blocked
+SET blocking_level = h.level,
+    sort_order = h.sort_order
+FROM #blocked b
 JOIN hierarchy h
-    ON h.monitor_loop = bs.monitor_loop
-    AND h.spid = bs.blocking_spid
-    AND h.ecid = bs.blocking_ecid;
+    ON h.monitor_loop = b.monitor_loop
+    AND h.blocking_desc = b.blocking_desc
+    AND h.blocked_desc = b.blocked_desc;
 
-IF @debug = 1 BEGIN SELECT '#blocking_hierarchy' AS table_name, * FROM #blocking_hierarchy OPTION(RECOMPILE); END;
+UPDATE #blocking
+SET blocking_level = bd.blocking_level,
+    sort_order = bd.sort_order
+FROM #blocking bg
+JOIN #blocked bd
+    ON bd.monitor_loop = bg.monitor_loop
+    AND bd.blocking_desc = bg.blocking_desc
+    AND bd.blocked_desc = bg.blocked_desc;
 
 SELECT
     kheb.event_time,
@@ -694,17 +711,24 @@ SELECT
         ),
     kheb.activity,
     blocking_tree = 
-        CASE
-            WHEN bh.level is null 
-            THEN  '(' + CAST(kheb.spid as varchar(max)) + ':' + CAST((kheb.ecid) as varchar(max)) + ') Lead Blocker'
-            ELSE 
-                REPLICATE(' > ', bh.[level]) + 
-                '(' + CAST(kheb.spid as varchar(max)) + ':' + CAST((kheb.ecid) as varchar(max)) 
-                + ') blocked by (' 
-                + CAST(bh.blocking_spid as varchar(max)) + ':' + CAST((bh.blocking_ecid) as varchar(max)) + ')' 
+        REPLICATE (' > ', kheb.blocking_level) + 
+        CASE kheb.activity
+            WHEN 'blocking' 
+            THEN '(' + kheb.blocking_desc + ') is blocking (' + kheb.blocked_desc + ')'
+            ELSE ' > (' + kheb.blocked_desc + ') is blocked by (' + kheb.blocking_desc + ')'
         END,
-    kheb.spid,
-    kheb.ecid,
+    spid = 
+        CASE kheb.activity
+            WHEN 'blocking' 
+            THEN kheb.blocking_spid
+            ELSE kheb.blocked_spid
+        END,
+    ecid =
+        CASE kheb.activity
+            WHEN 'blocking' 
+            THEN kheb.blocking_ecid
+            ELSE kheb.blocked_ecid
+        END,    
     query_text =
         CASE
             WHEN kheb.query_text
@@ -822,7 +846,8 @@ SELECT
     kheb.transaction_id,
     kheb.database_id,
     kheb.currentdbname,
-    kheb.blocked_process_report
+    kheb.blocked_process_report,
+    kheb.sort_order
 INTO #blocks
 FROM
 (               
@@ -852,11 +877,6 @@ FROM
     WHERE (bd.database_name = @database_name
            OR @database_name IS NULL)
 ) AS kheb
-LEFT JOIN #blocking_hierarchy bh
-    ON bh.monitor_loop = kheb.monitor_loop
-    AND bh.blocked_spid = kheb.spid
-    AND bh.blocked_ecid = kheb.ecid
-
 OPTION(RECOMPILE);
 
 SELECT
@@ -910,7 +930,7 @@ WHERE b.n = 1
 AND   (b.contentious_object = @object_name
        OR @object_name IS NULL)
 ORDER BY
-    b.event_time DESC,
+    b.sort_order,
     CASE
         WHEN b.activity = 'blocking'
         THEN 1


### PR DESCRIPTION
When processes are blocked by other processes, it sets up a kind of hierarchy which can be represented by a graph. 
The processes are nodes and the blocking relationship are the edges. 

When working with blocked process reports, it's important to always keep in mind whether you're dealing with the nodes or the edges. Blocked process reports typically represent the edges, the relationship between one blocking process and one blocked process. 

Also notice that the processes (blocked or blocking) are uniquely identified by `(monitorloop, spid, ecid)`.

So I've added blocking_spid info _and_ blocked spid info to both temp tables `#blocked` and `#blocking`. This added context helps order and organize the blocking tree. The tree looks a little like this:

![image](https://github.com/erikdarlingdata/DarlingData/assets/10028415/00ee3eb7-c6f2-420c-b26c-1e93dd9055c8)


