### PR TITLE
Logs and Parsers

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -689,7 +689,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             CROSS APPLY xml.xml_deadlock_report.nodes(''/event'') AS e(x)
             CROSS APPLY (SELECT x.value( ''(@timestamp)[1]'', ''datetimeoffset'' )) ca ([utc_timestamp])
             WHERE ca.utc_timestamp >= @start_date AND ca.utc_timestamp < @end_date
-            OPTION(RECOMPILE, USE HINT(''ENABLE_PARALLEL_PLAN_PREFERENCE''));';
+            OPTION(RECOMPILE);';
             
             IF @debug = 1
             BEGIN

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -641,9 +641,8 @@ BEGIN
     OR    el.text LIKE N'Starting up database%'
     OR    el.text LIKE N'Buffer pool extension is already disabled%'
     OR    el.text LIKE N'Buffer Pool: Allocating % bytes for % hashPages.'
-    OR    el.text LIKE N'Error: 18456%'
+    OR    el.text LIKE N'%Severity: 1[0-8]%'
     OR    el.text LIKE N'SSPI%'
-    OR    el.text LIKE N'Error: 18452%'
     OR    el.text IN
           (
               N'The Database Mirroring endpoint is in disabled or stopped state.',


### PR DESCRIPTION
Remove the final USE HINT from health parser to make it compatible with older versions of SQL Server

Fix the delete query in log hunter to get rid of all low-severity errors