### PR TITLE
DarlingData#360 - ADD ESCAPE to Query Text Search

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -3449,7 +3449,7 @@ BEGIN
                     @query_text_search,
                 N'[', @escape_character + N'['), 
                 N']', @escape_character + N']')
-    END
+    END;
 
     SELECT
         @current_table = 'inserting #query_text_search',
@@ -3489,8 +3489,14 @@ WHERE EXISTS
     /* If we are escaping bracket character in our query text search, add the ESCAPE clause and character to the LIKE subquery*/
     IF @escape_query_text_brackets = 1
     BEGIN
-        SELECT @sql = REPLACE(@sql,N'@query_text_search','@query_text_search ESCAPE '''+@escape_character+'''')
-    END
+        SELECT 
+            @sql = 
+                REPLACE
+                (
+                    @sql,
+                    N'@query_text_search',
+                    N'@query_text_search ESCAPE ''' + @escape_character + N'''')
+    END;
 
 /*If we're searching by a procedure name, limit the text search to it */
 IF


### PR DESCRIPTION
Add two parameters to sp_QuickieStore and add associated code to the section building the query for @query_text_search

```
@escape_query_text_brackets BIT = 0, /*Set this bit to 1 to search for query text containing square brackets (common in .NET Entity Framework and other ORM queries)*/
@escape_character NCHAR(1) = '\', /*Sets the ESCAPE character for special character searches, defaults to the SQL standard backslash (\) character*/
```

```
/* If our query texts contains square brackets (common in Entity Framework queries), add a leading escape character to each bracket character */
IF @escape_query_text_brackets = 1
BEGIN
	SELECT @query_text_search = REPLACE(REPLACE(@query_text_search,'[',@escape_character+'['),']',@escape_character+']')
END
```

```
/* If we are escaping bracket character in our query text search, add the ESCAPE clause and character to the LIKE subquery*/
IF @escape_query_text_brackets = 1
BEGIN
	SELECT @sql = REPLACE(@sql,N'@query_text_search','@query_text_search ESCAPE '''+@escape_character+'''')
END
```