### PR TITLE
Make sp_QuickieStore early exit if the procedure searched for does not exist when using @get_all_databases.

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -2044,6 +2044,19 @@ OPTION(RECOMPILE);' + @nc10;
     IF
     (
         @procedure_exists = 0
+    AND @get_all_databases = 1
+    )
+    BEGIN
+        FETCH NEXT
+        FROM database_cursor
+        INTO @database_name;
+
+        CONTINUE;
+    END;
+
+    IF
+    (
+        @procedure_exists = 0
     AND @get_all_databases = 0
     )
         BEGIN

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -2047,6 +2047,10 @@ OPTION(RECOMPILE);' + @nc10;
     AND @get_all_databases = 1
     )
     BEGIN
+        RAISERROR('The stored procedure %s does not appear to have any entries in Query Store for database %s
+Check that you spelled everything correctly and you''re in the right database
+We will skip this database and continue',
+                       10, 1, @procedure_name, @database_name) WITH NOWAIT;
         FETCH NEXT
         FROM database_cursor
         INTO @database_name;


### PR DESCRIPTION
Closes #412, but not in a way I'm proud of. It will probably be best to write some reusable logic for early exiting. This PR is what I believe to be the smallest change to fix the bug. I'm fairly confident that this doesn't break anything, but I haven't looked very closely at this procedure.