### PR TITLE
sp_QuickieStore.sql: Moved capturing of _date_original variables outside of loop.

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -1174,6 +1174,50 @@ BEGIN
 END;
 
 /*
+We also need to capture original values here.
+Doing it inside a loop over multiple databases
+would break the UTC conversion.
+*/
+SELECT
+    @start_date_original =
+        ISNULL
+        (
+            @start_date,
+            DATEADD
+            (
+                DAY,
+                -7,
+                DATEDIFF
+                (
+                    DAY,
+                    '19000101',
+                    SYSUTCDATETIME()
+                )
+            )
+        ),
+    @end_date_original =
+        ISNULL
+        (
+            @end_date,
+            DATEADD
+            (
+                DAY,
+                1,
+                DATEADD
+                (
+                    MINUTE,
+                    0,
+                    DATEDIFF
+                    (
+                        DAY,
+                        '19000101',
+                        SYSUTCDATETIME()
+                    )
+                )
+            )
+        );
+
+/*
 This section is in a cursor whether we
 hit one database, or multiple
 
@@ -1508,43 +1552,6 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;',
     @rc = 0,
     @em = @expert_mode,
     @fo = @format_output,
-    @start_date_original =
-        ISNULL
-        (
-            @start_date,
-            DATEADD
-            (
-                DAY,
-                -7,
-                DATEDIFF
-                (
-                    DAY,
-                    '19000101',
-                    SYSUTCDATETIME()
-                )
-            )
-        ),
-    @end_date_original =
-        ISNULL
-        (
-            @end_date,
-            DATEADD
-            (
-                DAY,
-                1,
-                DATEADD
-                (
-                    MINUTE,
-                    0,
-                    DATEDIFF
-                    (
-                        DAY,
-                        '19000101',
-                        SYSUTCDATETIME()
-                    )
-                )
-            )
-        ),
     @utc_minutes_difference =
         DATEDIFF
         (
@@ -1647,7 +1654,7 @@ SELECT
                 (
                     MINUTE,
                     @utc_minutes_difference,
-                    @start_date
+                    @start_date_original
                 )
         END,
     @end_date =
@@ -1676,7 +1683,7 @@ SELECT
                 (
                     MINUTE,
                     @utc_minutes_difference,
-                    @end_date
+                    @end_date_original
                 )
         END;
 


### PR DESCRIPTION
Closes #429 . As with the last `@get_all_databases` bug, I just had to move some bits outside of the loop and make something inside of the loop point to the now-outside bits. I think I'm finding one `@get_all_databases`-bug per month, which is a bit worrying.

As always, I must warn that I have never taken a deep look at how this procedure works, so I may have totally messed it up. It's clear that the date/UTC handling in this procedure is battle-worn, so it really is quite likely that I'm oblivious to something important. I have tried my best to make small changes that are true to the design and formatting, but this time it was worryingly easy. I was shocked to see that the `@[...]_date_original` variables already existed. It's as if somebody already tried to patch this bug.