### PR TITLE
sp_QuickieStore: Correct UTC offsets

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -7852,7 +7852,7 @@ BEGIN
                             THEN
                                 SWITCHOFFSET
                                 (
-                                    qsq.create_time,
+                                    qspf.create_time,
                                     @utc_offset_string
                                 )
                             WHEN @timezone IS NOT NULL


### PR DESCRIPTION
Closes #449 by switching to use `SWITCHOFFSET` rather than our old arithmetic tricks with `@utc_offset_minutes`. I'll spin up some Docker containers on different time zones to provide more evidence that this is working. For now, I just have this screenshot from my British Summer Time instance.
![BST](https://github.com/erikdarlingdata/DarlingData/assets/67124261/924fef26-aadc-43a5-a33b-70f3cf893836)

Notice that the _UTC columns are unchanged. This is intentional and correct.