### PR TITLE
sp_Quickiestore: Truncate #query_text_search_not if @Get_All_Databases = 1

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -6083,6 +6083,8 @@ BEGIN
     TRUNCATE TABLE
         #query_text_search;
     TRUNCATE TABLE
+        #query_text_search_not;
+    TRUNCATE TABLE
         #dm_exec_query_stats;
     TRUNCATE TABLE
         #query_types;


### PR DESCRIPTION
This came up [here](https://github.com/erikdarlingdata/DarlingData/pull/459#issuecomment-2229401694). I admittedly haven't found proof that this causes any bugs, but to memory `#query_text_search_not` is used just like `#query_text_search`. It's therefore just plain obvious that we should be truncating it.