### PR TITLE
sp_QuickieStore: Add more examples to the examples file.

### DIFF
--- a/sp_QuickieStore/Examples.sql
+++ b/sp_QuickieStore/Examples.sql
@@ -24,13 +24,21 @@ https://github.com/erikdarlingdata/DarlingData
 EXEC dbo.sp_QuickieStore
     @help = 1;
 
+/*The default is finding the top 10 sorted by CPU in the last seven days.*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013';
 
 /*Find top 10 sorted by memory*/
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
     @sort_order = 'memory',
-    @top = 10;              
+    @top = 10;
 
+/*Find top 10 in each user database sorted by cpu*/
+EXEC dbo.sp_QuickieStore
+    @get_all_databases = 1,
+    @sort_order = 'cpu',
+    @top = 10;
 
 /*Search for specific query_ids*/
 EXEC dbo.sp_QuickieStore
@@ -72,6 +80,13 @@ EXEC dbo.sp_QuickieStore
     @start_date = '20210320',
     @end_date = '20210321';              
 
+/*Filter out weekends and anything outside of your choice of hours.*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @workdays = 1,
+    @work_start = '8am',
+    @work_end = '6pm'
+
 
 /*Search for queries with a minimum execution count*/
 EXEC dbo.sp_QuickieStore
@@ -85,6 +100,26 @@ EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
     @top = 10,
     @duration_ms = 10000;
+
+
+/*Use wait filter to search for queries responsible for high waits*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @wait_filter = 'memory',
+    @sort_order = 'memory';
+
+/*We also support using wait types as a sort order, see the documentation for the full list.
+The wait-related sort orders are special because we add an extra column for the duration of the wait type you are asking for.
+It's all the way over on the right.
+*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @sort_order = 'memory waits';
+
+/*You can also sort by total wait time across all waits. */
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @sort_order = 'total waits';
 
 
 /*Search for queries with a specific execution type
@@ -120,12 +155,100 @@ EXEC dbo.sp_QuickieStore
 /*Search for a specific stored procedure*/
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
-    @procedure_name = 'top_percent_sniffer';   
+    @procedure_name = 'top_percent_sniffer';
+
+/*Search for a specific stored procedure in a specific schema*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @procedure_schema = 'not_dbo'
+    @procedure_name = 'top_percent_sniffer';
 
 /*Search for specific query text*/
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
     @query_text_search = 'WITH Comment'
+
+/*Search for specific query text, with brackets automatically escaped.
+Commonly needed when dealing with ORM queries.
+*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @query_text_search = 'FROM [users] AS [t0]',
+    @escape_brackets = 1;
+
+/*By default, We use '\' to escape when @escape_brackets = 1 is set.
+Maybe you want something else.
+Provide it with @escape_character.
+*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @query_text_search = 'FROM foo\bar AS [t0]',
+    @escape_character = '~'
+    @escape_brackets = 1;
+
+
+/*Find every reference to a particular table in your Query Store data, sorted by their execution counts.
+Quite expensive!
+Handy when tuning or finding dependencies, but only as good as what your Query Store has captured.
+Makes use of @get_all_databases = 1, which lets you search all user databases.
+Note the abuse of @start_date. By setting it very far back in the past and leaving @end_date unspecified, we cover all of the data.
+We also abuse @top by setting it very high.
+*/
+EXEC dbo.sp_QuickieStore
+    @get_all_databases = 1,
+    @start_date = '20000101',
+    @sort_order = 'executions',
+    @query_text_search = 'MyTable',
+    @top = 100;
+
+/*Filter out certain query text with @query_text_search_not.
+Good for when @query_text_search gets false positives.
+After all, it's only doing string searching.
+*/
+EXEC dbo.sp_QuickieStore
+    @get_all_databases = 1,
+    @start_date = '20000101',
+    @sort_order = 'executions',
+    @query_text_search = 'MyTable',
+    @query_text_search_not = 'MyTable_secret_backup'
+    @top = 100;
+
+
+/*What happened recently on a database?*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013'
+    @sort_order = 'recent';
+
+/*What happened recently that referenced my database?
+Good for finding cross-database queries, such as when checking if a database is dead code.
+Don't forget that queries in a database do not need to reference it explicitly!
+*/
+EXEC dbo.sp_QuickieStore
+    @get_all_databases = 1,
+    @start_date = '20000101',
+    @sort_order = 'recent',
+    @query_text_search = 'StackOverflow2013'
+    @top = 10;
+
+/*Only return queries with feedback (2022+)*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @only_query_with_feedback = 1;
+
+/*Only return queries with variants (2022+)*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @only_query_with_variants = 1;
+
+/*Only return queries with forced plans (2022+)*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @only_query_with_forced_plans = 1;
+
+/*Only return queries with forced plan failures (2022+)*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @only_query_with_forced_plan_failures = 1;
 
 /*Only return queries with query hints (2022+)*/
 EXEC dbo.sp_QuickieStore
@@ -140,19 +263,38 @@ EXEC dbo.sp_QuickieStore
     @expert_mode = 1;              
 
 
-/*Use format output to add commas to larger numbers*/
+/*Use format output to add commas to larger numbers
+This is enabled by default.
+*/
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
     @sort_order = 'memory',
     @top = 10,
     @format_output = 1;
 
-
-/*Use wait filter to search for queries responsible for high waits*/
+/*Disable format output to remove commas.*/
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
-    @wait_filter = 'memory',
-    @sort_order = 'memory';
+    @sort_order = 'memory',
+    @top = 10,
+    @format_output = 0;
+
+/*Change the timezone show in your outputs.
+This is only an output-formatting change.
+It does not change how dates are processed.
+*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @timezone = 'Egypt Standard Time';
+
+/*Debugging something complex?
+Hide the bottom table with @hide_help_table = 1 when you need more room.
+*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @hide_help_table = 1,
+    @sort_order = 'latch waits',
+    @top = 50;
 
 /*Search by query hashes*/
 EXEC dbo.sp_QuickieStore
@@ -169,6 +311,27 @@ This helps with scenarios where you have multiple production databases which hav
 EXEC dbo.sp_QuickieStore
     @include_sql_handles = 
         '0x0900F46AC89E66DF744C8A0AD4FD3D3306B90000000000000000000000000000000000000000000000000000,0x0200000AC89E66DF744C8A0AD4FD3D3306B90000000000000000000000000000000000000000000000000000';
+
+/*Search, but ignoring some query hashes*/
+EXEC dbo.sp_QuickieStore
+    @ignore_query_hashes = '0x1AB614B461F4D769,0x1CD777B461F4D769';
+
+/*Search, but ignoring some plan hashes*/
+EXEC dbo.sp_QuickieStore
+    @ignore_plan_hashes = '0x6B84B820B8B38564,0x6B84B999D7B38564';
+
+/*Search, but ignoring some SQL Handles*/
+EXEC dbo.sp_QuickieStore
+    @ignore_sql_handles = 
+        '0x0900F46AC89E66DF744C8A0AD4FD3D3306B90000000000000000000000000000000000000000000000000000,0x0200000AC89E66DF744C8A0AD4FD3D3306B90000000000000000000000000000000000000000000000000000';
+
+/*What query hashes have the most plans?
+This sort order is special because it needs to return multiple rows for each of the @top hashes it looks at.
+It is also special because it adds some new columns all the way over on the right of the output.
+*/
+EXEC dbo.sp_QuickieStore
+    @database_name = 'StackOverflow2013',
+    @sort_order = 'plan count by hashes';
 
 /*Check for regressions.
 Specifically, this checks for queries that did more logical reads last week than this week.
@@ -243,12 +406,22 @@ EXEC dbo.sp_QuickieStore
     @regression_direction = 'absolute',
     @regression_baseline_start_date = @TwoWeekAgo;
 
+/*Get version info.*/
+DECLARE @version_output varchar(30),
+        @version_date_output datetime;
+
+EXEC sp_QuickieStore 
+    @version = @version_output OUTPUT, 
+    @version_date = @version_date_output OUTPUT;
+
+SELECT
+    Version = @version_output,
+    VersionDate = @version_date_output;
 
 /*Troubleshoot performance*/
 EXEC dbo.sp_QuickieStore
     @database_name = 'StackOverflow2013',
     @troubleshoot_performance = 1;
-
 
 /*Debug dynamic SQL and temp table contents*/
 EXEC dbo.sp_QuickieStore


### PR DESCRIPTION
Closes #489 as best as I could.

The key improvements are:
* Most sort orders are now in the examples.
* Every parameter is now in the examples. We were previously missing some very important ones, like how to do version checks.
* Some lengthy examples added, to reflect how I've used `sp_QuickieStore`.

The faults in what I'm presenting here are as follows:
* I couldn't find an excuse to document `@sort_order = 'tempdb'`. The good news is that all other non-wait sort orders now appear in this example file. A fair few of the wait ones also appear now. 
* I feel that much more could be said about `@start_date` and `@end_date`'s defaults, but [it isn't clear that I understand them](https://github.com/erikdarlingdata/DarlingData/issues/484). Given how often I use these parameters explicitly, it's worrying that I couldn't find an excuse to write many more examples with them.
* I don't understand `@wait_filter` and therefore made no attempt to improve what already existed.
* I have no experience with the 2022-exclusive features, `@workdays`, or `@escape_character` , so what I added was a poor copy and paste job.
* I don't claim any understanding of why some of the examples in the original had two lines separating them. If it's to denote sections, then we don't we just give up and make this a Markdown file?

Anyway, I think it's still a big improvement!