### PR TITLE
Dev

### DIFF
--- a/sp_IndexCleanup/README.md
+++ b/sp_IndexCleanup/README.md
@@ -29,6 +29,7 @@ The procedure requires SQL Server 2012 (11.0) or later due to the use of FORMAT 
 | @min_writes | bigint | 0 | Minimum number of writes for an index to be considered used |
 | @min_size_gb | decimal(10,2) | 0 | Minimum size in GB for an index to be analyzed |
 | @min_rows | bigint | 0 | Minimum number of rows for a table to be analyzed |
+| @dedupe_only | bit | 0 | When set to 1, only performs index deduplication but does not mark unused indexes for removal |
 | @get_all_databases | bit | 0 | When set to 1, analyzes all eligible databases on the server |
 | @include_databases | nvarchar(max) | NULL | Comma-separated list of databases to include (used with @get_all_databases = 1) |
 | @exclude_databases | nvarchar(max) | NULL | Comma-separated list of databases to exclude (used with @get_all_databases = 1) |
@@ -49,6 +50,11 @@ EXECUTE dbo.sp_IndexCleanup
     @database_name = 'YourDatabase',
     @table_name = 'YourTable',
     @debug = 1;
+
+-- Only perform deduplication without marking unused indexes for removal
+EXECUTE dbo.sp_IndexCleanup
+    @database_name = 'YourDatabase',
+    @dedupe_only = 1;
 
 -- Filter indexes by minimum usage thresholds
 EXECUTE dbo.sp_IndexCleanup
@@ -79,6 +85,7 @@ EXECUTE dbo.sp_IndexCleanup
 ## Notes
 
 - The procedure issues a warning when server uptime is less than 14 days, as index usage stats may not be representative
+- When server uptime is less than 7 days, @dedupe_only mode is automatically enabled to prevent removing unused indexes with insufficient usage data
 - Certain features like online index operations and compression are only available in specific SQL Server editions (Enterprise, Azure SQL DB, Managed Instance)
 - It is recommended to have a recent backup before making any index changes
 - The multi-database processing feature (@get_all_databases) analyzes each database sequentially for better performance and resource management

--- a/sp_IndexCleanup/README.md
+++ b/sp_IndexCleanup/README.md
@@ -23,7 +23,7 @@ The procedure requires SQL Server 2012 (11.0) or later due to the use of FORMAT 
 | Parameter Name | Data Type | Default Value | Description |
 |----------------|-----------|---------------|-------------|
 | @database_name | sysname | NULL | The name of the database you wish to analyze |
-| @schema_name | sysname | NULL | The schema name to filter indexes by |
+| @schema_name | sysname | NULL | The schema name to filter indexes by - limits analysis to tables in the specified schema |
 | @table_name | sysname | NULL | The table name to filter indexes by |
 | @min_reads | bigint | 0 | Minimum number of reads for an index to be considered used |
 | @min_writes | bigint | 0 | Minimum number of writes for an index to be considered used |
@@ -55,6 +55,11 @@ EXECUTE dbo.sp_IndexCleanup
 EXECUTE dbo.sp_IndexCleanup
     @database_name = 'YourDatabase',
     @dedupe_only = 1;
+
+-- Analyze tables in a specific schema only
+EXECUTE dbo.sp_IndexCleanup
+    @database_name = 'YourDatabase',
+    @schema_name = 'YourSchema';
 
 -- Filter indexes by minimum usage thresholds
 EXECUTE dbo.sp_IndexCleanup

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -104,7 +104,7 @@ BEGIN TRY
                 CASE
                     ap.name
                     WHEN N'@database_name' THEN 'the name of the database you wish to analyze'
-                    WHEN N'@schema_name' THEN 'the schema name to filter indexes by'
+                    WHEN N'@schema_name' THEN 'the schema name to filter indexes by - limits analysis to tables in the specified schema'
                     WHEN N'@table_name' THEN 'the table name to filter indexes by'
                     WHEN N'@min_reads' THEN 'minimum number of reads for an index to be considered used'
                     WHEN N'@min_writes' THEN 'minimum number of writes for an index to be considered used'
@@ -1137,6 +1137,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         SELECT @sql += N'
         AND   t.object_id = @object_id';
     END;
+    
+    IF @schema_name IS NOT NULL AND @object_id IS NULL
+    BEGIN
+        IF @debug = 1
+        BEGIN
+            RAISERROR('adding schema_name filter', 0, 0) WITH NOWAIT;
+        END;
+
+        SELECT @sql += N'
+        AND   s.name = @schema_name';
+    END;
 
     SET @sql += N'
         AND EXISTS
@@ -1208,13 +1219,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         @min_writes bigint,
         @min_size_gb decimal(10,2),
         @min_rows bigint,
-        @object_id integer',
+        @object_id integer,
+        @schema_name sysname',
         @current_database_id,
         @min_reads,
         @min_writes,
         @min_size_gb,
         @min_rows,
-        @object_id;
+        @object_id,
+        @schema_name;
 
     SET @rc = ROWCOUNT_BIG();
 


### PR DESCRIPTION
Changes for sp_IndexCleanup:
* Add dedupe only mode for processing unused indexes like duplicates. This should be useful for people who are rightfully distrusting of read/write metrics, or people whose servers have been up a short amount of time. Speaking of which, it will automatically trigger if the server has been up <= 7 days
* Add schema-only filtering, for people who want to focus on a single schema in a database