### PR TITLE
Compression eligibility changes

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -1442,7 +1442,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             ce.can_compress = 0,
             ce.reason = ''Index contains incompatible data types''
         FROM #compression_eligibility AS ce
-        JOIN sys.indexes AS i 
+        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.indexes AS i 
 	      ON i.object_id = ce.object_id AND i.index_id = ce.index_id
 	    WHERE ce.can_compress = 1 
           AND i.type = 1 


### PR DESCRIPTION
When checking for compression eligibility, indexes on tables with sparse columns should be flagged as ineligible.
Additionally, clustered indexes which contain columns with ineligible data types should also be flagged as ineligible.
Otherwise, the compression eligibility of each index will be based on the server and compatibility checks.