### PR TITLE
Arithmetic overflow for total_size_mb

### DIFF
--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -2171,7 +2171,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         THEN 0
                         ELSE CONVERT(decimal(18, 2), SUM(fs.io_stall_write_ms) * 1.0 / SUM(fs.num_of_writes))
                     END,
-                total_size_mb = CONVERT(decimal(18, 2), SUM(mf.size) * 8 / 1024.0)
+                total_size_mb = CONVERT(decimal(18, 2), SUM(mf.size) * 8.0 / 1024.0)
             FROM sys.dm_io_virtual_file_stats(NULL, NULL) AS fs
             JOIN sys.master_files AS mf
               ON  fs.database_id = mf.database_id


### PR DESCRIPTION
Fixes an arithmetic overflow error at line 2174 converting sys.master_files size column to Megabytes