### PR TITLE
Update sp_PerfCheck.sql 

### DIFF
--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -2381,7 +2381,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     THEN 0
                     ELSE CONVERT(decimal(18, 2), SUM(fs.io_stall_write_ms) * 1.0 / SUM(fs.num_of_writes))
                 END,
-            total_size_mb = CONVERT(decimal(18, 2), SUM(mf.size) * 8.0 / 1024.0)
+            total_size_mb = CONVERT(decimal(18, 2), SUM(CAST(mf.size as BIGINT)) * 8.0 / 1024.0)
         FROM sys.dm_io_virtual_file_stats
         (' +
         CASE


### PR DESCRIPTION
fix the Conversion Error where the Database size is in  > 3TB 

Msg 8115, Level 16, State 2, Procedure dbo.sp_PerfCheck, Line 1980 [Batch Start Line 2] Arithmetic overflow error converting expression to data type int.

@erikdarlingdata  please review my changes, 
i test your Version 1.0.4 (04/04/25) with a Database  of 3800307.38 MB Size.