### PR TITLE
Expand wait_time_percent_of_uptime to accomodate >1,000% waits

### DIFF
--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -571,7 +571,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         avg_wait_ms AS (wait_time_ms / NULLIF(waiting_tasks_count, 0)),
         percentage decimal(5, 2) NOT NULL,
         signal_wait_time_ms bigint NOT NULL,
-        wait_time_percent_of_uptime decimal(5, 2) NULL,
+        wait_time_percent_of_uptime decimal(6, 2) NULL,
         category nvarchar(50) NOT NULL
     );
 


### PR DESCRIPTION
Hi Erik, love the new proc but I am getting some arithmetic errors in the block starting on line 1928 (the update on #wait_stats). This is ultimately due to having >1000% wait times as a percentage of server uptime:
![image](https://github.com/user-attachments/assets/1bbea451-dff7-4200-8c9d-b06f481f21ee)

I am not sure if this is a bug in the DMVs or accurate reporting, but this is from an Azure SQL Managed Instance being utilised as a data warehouse and this fix resolved the issue and now they appear as priority 20 results.

Can adjust how this is done if you would prefer, please let me know your thoughts