### PR TITLE
sp_QuickieStore: Made plan hash, query hash, or sql handle show when the parameter for filtering them out is passed in

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -8543,6 +8543,7 @@ FROM
         CASE
             WHEN @include_plan_hashes IS NOT NULL
             OR   @ignore_plan_hashes IS NOT NULL
+            OR   @sort_order = 'plan count by hashes'
             THEN N'
         qsp.query_plan_hash,'
             ELSE N''

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -8542,14 +8542,17 @@ FROM
         qsp.all_plan_ids,' +
         CASE
             WHEN @include_plan_hashes IS NOT NULL
+            OR   @ignore_plan_hashes IS NOT NULL
             THEN N'
         qsp.query_plan_hash,'
             WHEN @include_query_hashes IS NOT NULL
+            OR   @ignore_query_hashes IS NOT NULL
             OR   @sort_order = 'plan count by hashes'
             OR   @include_query_hash_totals = 1
             THEN N'
         qsq.query_hash,'
             WHEN @include_sql_handles IS NOT NULL
+            OR   @ignore_sql_handles IS NOT NULL
             THEN N'
         qsqt.statement_sql_handle,'
             ELSE N''

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -8545,12 +8545,18 @@ FROM
             OR   @ignore_plan_hashes IS NOT NULL
             THEN N'
         qsp.query_plan_hash,'
+            ELSE N''
+        END + 
+        CASE
             WHEN @include_query_hashes IS NOT NULL
             OR   @ignore_query_hashes IS NOT NULL
             OR   @sort_order = 'plan count by hashes'
             OR   @include_query_hash_totals = 1
             THEN N'
         qsq.query_hash,'
+            ELSE N''
+        END + 
+        CASE
             WHEN @include_sql_handles IS NOT NULL
             OR   @ignore_sql_handles IS NOT NULL
             THEN N'


### PR DESCRIPTION
Closes #607 . On top of that, it also makes it possible for more than one of the `qsp.query_plan_hash`, `qsq.query_hash`, or `qsqt.statement_sql_handle` columns to show in the same result set.