### PR TITLE
Fix 5 additional issues from round 2 code review

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -432,7 +432,7 @@ AND   ca.utc_timestamp < @end_date';
             SET @time_filter = N'
     AND   CONVERT(datetimeoffset(7), fx.timestamp_utc) BETWEEN @start_date AND @end_date';
         ELSE
-            SET @time_filter = '
+            SET @time_filter = N'
     AND   fx.timestamp_utc BETWEEN @start_date AND @end_date';
     END;
 

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -1356,7 +1356,7 @@ BEGIN
     IF @debug = 1
     BEGIN
         SELECT
-            table_name = '#blocking_sh',
+            table_name = '#blocking_xml_sh',
             bxs.*
         FROM #blocking_xml_sh AS bxs
         OPTION(RECOMPILE);

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -2058,11 +2058,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     END
                 ),
             @server_uptime_hours =
-                DATEDIFF(SECOND, osi.sqlserver_start_time, GETDATE()) / 3600.0
+                DATEDIFF(SECOND, osi.sqlserver_start_time, SYSDATETIME()) / 3600.0
         FROM sys.dm_os_wait_stats AS osw
         CROSS JOIN sys.dm_os_sys_info AS osi
         GROUP BY
-            DATEDIFF(SECOND, osi.sqlserver_start_time, GETDATE()) / 3600.0;
+            DATEDIFF(SECOND, osi.sqlserver_start_time, SYSDATETIME()) / 3600.0;
 
         SET @pagelatch_ratio_to_uptime =
             @pagelatch_wait_hours / NULLIF(@server_uptime_hours, 0) * 100;

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -3964,7 +3964,7 @@ OPTION(MAXDOP 1, RECOMPILE);',
 
             IF @debug = 1
             BEGIN
-                PRINT SUBSTRING(@cpu_sql, 0, 4000);
+                PRINT SUBSTRING(@cpu_sql, 1, 4000);
                 PRINT SUBSTRING(@cpu_sql, 4001, 8000);
             END;
 
@@ -4319,7 +4319,7 @@ OPTION(MAXDOP 1, RECOMPILE);',
             bi.wait_resource,            
             reads = ISNULL(der.reads, 0),
             writes = ISNULL(der.writes, 0),
-            physical_reads = ISNULL(der.logical_reads, bi.physical_io),
+            logical_reads = ISNULL(der.logical_reads, bi.physical_io),
             cpu_time = ISNULL(der.cpu_time, bi.cpu_time),
             used_memory = ISNULL(der.granted_query_memory, bi.memusage),
             bi.status,


### PR DESCRIPTION
## Summary

Follow-up to PR #662. Second review pass caught 5 more issues across 4 procedures:

- **sp_HealthParser**: Missing `N''` unicode prefix on dynamic SQL string literal
- **sp_HumanEventsBlockViewer**: Debug label showed `#blocking_sh` but queried `#blocking_xml_sh`
- **sp_PerfCheck**: `GETDATE()` → `SYSDATETIME()` for uptime calculation consistency
- **sp_PressureDetector**: Column named `physical_reads` was sourced from `der.logical_reads` — renamed to `logical_reads`
- **sp_PressureDetector**: `SUBSTRING(@cpu_sql, 0, 4000)` off-by-one — SQL Server SUBSTRING is 1-based, position 0 silently drops a character

## Test plan

- [x] All 10 procedures install cleanly on SQL Server 2022
- [x] All 10 procedures execute successfully on SQL Server 2022
- [x] Validated SUBSTRING(0) vs SUBSTRING(1) behavior difference via sqlcmd
- [x] Verified `logical_reads` column naming matches source DMV (`der.logical_reads`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)