### PR TITLE
Add @use_ring_buffer parameter to sp_HealthParser (v3.4)

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -50,6 +50,7 @@ ALTER PROCEDURE
     @wait_round_interval_minutes bigint = 60, /*Nearest interval to round wait stats to*/
     @skip_locks bit = 0, /*Skip the blocking and deadlocks*/
     @skip_waits bit = 0, /*Skip the wait stats*/
+    @use_ring_buffer bit = 0, /*Use ring_buffer target instead of file target for system_health session*/
     @pending_task_threshold integer = 10, /*Minimum number of pending tasks to care about*/
     @log_to_table bit = 0, /*enable logging to permanent tables*/
     @log_database_name sysname = NULL, /*database to store logging tables*/
@@ -71,8 +72,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.3',
-        @version_date = '20260216';
+        @version = '3.4',
+        @version_date = '20260217';
 
     IF @help = 1
     BEGIN
@@ -103,6 +104,7 @@ BEGIN
                     WHEN N'@wait_round_interval_minutes' THEN N'interval to round minutes to for wait stats'
                     WHEN N'@skip_locks' THEN N'skip the blocking and deadlocking section'
                     WHEN N'@skip_waits' THEN N'skip the wait stats section'
+                    WHEN N'@use_ring_buffer' THEN N'use ring_buffer target instead of file target for faster collection'
                     WHEN N'@pending_task_threshold' THEN N'minimum number of pending tasks to display'
                     WHEN N'@log_to_table' THEN N'enable logging to permanent tables instead of returning results'
                     WHEN N'@log_database_name' THEN N'database to store logging tables'
@@ -126,6 +128,7 @@ BEGIN
                     WHEN N'@wait_round_interval_minutes' THEN N'interval to round minutes to for top wait stats by count and duration'
                     WHEN N'@skip_locks' THEN N'0 or 1'
                     WHEN N'@skip_waits' THEN N'0 or 1'
+                    WHEN N'@use_ring_buffer' THEN N'0 or 1'
                     WHEN N'@pending_task_threshold' THEN N'a valid integer'
                     WHEN N'@log_to_table' THEN N'0 or 1'
                     WHEN N'@log_database_name' THEN N'any valid database name'
@@ -149,6 +152,7 @@ BEGIN
                     WHEN N'@wait_round_interval_minutes' THEN N'60'
                     WHEN N'@skip_locks' THEN N'0'
                     WHEN N'@skip_waits' THEN N'0'
+                    WHEN N'@use_ring_buffer' THEN N'0'
                     WHEN N'@pending_task_threshold' THEN N'10'
                     WHEN N'@log_to_table' THEN N'0'
                     WHEN N'@log_database_name' THEN N'NULL (current database)'
@@ -461,6 +465,7 @@ AND   ca.utc_timestamp < @end_date';
         @wait_round_interval_minutes = ISNULL(@wait_round_interval_minutes, 60),
         @skip_locks = ISNULL(@skip_locks, 0),
         @skip_waits = ISNULL(@skip_waits, 0),
+        @use_ring_buffer = ISNULL(@use_ring_buffer, 0),
         @pending_task_threshold = ISNULL(@pending_task_threshold, 10);
 
     /*Validate what to check*/
@@ -1540,67 +1545,14 @@ AND   ca.utc_timestamp < @end_date';
     ORDER BY
         ca.id;
 
-    OPEN @collection_cursor;
-
-    FETCH NEXT
-    FROM @collection_cursor
-    INTO
-        @area_name,
-        @object_name,
-        @temp_table,
-        @insert_list;
-
-    WHILE @@FETCH_STATUS = 0
+    /*
+    File target collection: read from system_health .xel files on disk
+    Skip this path when using ring_buffer target or on Managed Instance
+    */
+    IF  @mi = 0
+    AND @use_ring_buffer = 0
     BEGIN
-        /* Build the SQL statement for this collection area */
-        SET
-            @collection_sql =
-                REPLACE
-                (
-                    REPLACE
-                    (
-                        REPLACE
-                        (
-                            @sql_template,
-                            '{object_name}',
-                            @object_name
-                        ),
-                        '{temp_table}',
-                        @temp_table
-                    ),
-                    '{insert_list}',
-                    @insert_list
-                );
-
-        IF @debug = 1
-        BEGIN
-            RAISERROR('Collecting data for area: %s, object: %s, target table: %s', 0, 1, @area_name, @object_name, @temp_table) WITH NOWAIT;
-            PRINT @collection_sql;
-        END;
-
-        IF @debug = 1
-        BEGIN
-            RAISERROR('Executing collection SQL for dates between %s and %s', 0, 0, @start_date_debug, @end_date_debug) WITH NOWAIT;
-            SET STATISTICS XML ON;
-        END;
-
-        EXECUTE sys.sp_executesql
-            @collection_sql,
-            @params,
-            @start_date,
-            @end_date;
-
-        IF @debug = 1
-        BEGIN
-            SET STATISTICS XML OFF;
-        END;
-
-        UPDATE
-            @collection_areas
-        SET
-            is_processed = 1
-        WHERE temp_table = @temp_table
-        AND   should_collect = 1;
+        OPEN @collection_cursor;
 
         FETCH NEXT
         FROM @collection_cursor
@@ -1609,18 +1561,85 @@ AND   ca.utc_timestamp < @end_date';
             @object_name,
             @temp_table,
             @insert_list;
-    END;
 
-    IF @debug = 1
-    BEGIN
-        RAISERROR('Data collection complete', 0, 0) WITH NOWAIT;
-    END;
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            /* Build the SQL statement for this collection area */
+            SET
+                @collection_sql =
+                    REPLACE
+                    (
+                        REPLACE
+                        (
+                            REPLACE
+                            (
+                                @sql_template,
+                                '{object_name}',
+                                @object_name
+                            ),
+                            '{temp_table}',
+                            @temp_table
+                        ),
+                        '{insert_list}',
+                        @insert_list
+                    );
 
+            IF @debug = 1
+            BEGIN
+                RAISERROR('Collecting data for area: %s, object: %s, target table: %s', 0, 1, @area_name, @object_name, @temp_table) WITH NOWAIT;
+                PRINT @collection_sql;
+            END;
+
+            IF @debug = 1
+            BEGIN
+                RAISERROR('Executing collection SQL for dates between %s and %s', 0, 0, @start_date_debug, @end_date_debug) WITH NOWAIT;
+                SET STATISTICS XML ON;
+            END;
+
+            EXECUTE sys.sp_executesql
+                @collection_sql,
+                @params,
+                @start_date,
+                @end_date;
+
+            IF @debug = 1
+            BEGIN
+                SET STATISTICS XML OFF;
+            END;
+
+            UPDATE
+                @collection_areas
+            SET
+                is_processed = 1
+            WHERE temp_table = @temp_table
+            AND   should_collect = 1;
+
+            FETCH NEXT
+            FROM @collection_cursor
+            INTO
+                @area_name,
+                @object_name,
+                @temp_table,
+                @insert_list;
+        END;
+
+        IF @debug = 1
+        BEGIN
+            RAISERROR('Data collection complete', 0, 0) WITH NOWAIT;
+        END;
+    END; /*End file target collection*/
+
+    /*
+    Ring buffer collection: read from system_health ring_buffer target
+    Used for Managed Instance (always) and on-prem when @use_ring_buffer = 1
+    Faster than file target because it avoids disk I/O
+    */
     IF @mi = 1
+    OR @use_ring_buffer = 1
     BEGIN
         IF @debug = 1
         BEGIN
-            RAISERROR('Starting Managed Instance analysis', 0, 0) WITH NOWAIT;
+            RAISERROR('Starting ring_buffer analysis', 0, 0) WITH NOWAIT;
             RAISERROR('Inserting #x', 0, 0) WITH NOWAIT;
         END;
 
@@ -1688,7 +1707,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance waits', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer waits', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #wait_info', 0, 0) WITH NOWAIT;
             END;
 
@@ -1710,7 +1729,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance sp_server_diagnostics_component_result', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer sp_server_diagnostics_component_result', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #sp_server_diagnostics_component_result', 0, 0) WITH NOWAIT;
             END;
 
@@ -1737,7 +1756,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance deadlocks', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer deadlocks', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #xml_deadlock_report', 0, 0) WITH NOWAIT;
             END;
 
@@ -1761,7 +1780,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance scheduler monitor', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer scheduler monitor', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #scheduler_monitor', 0, 0) WITH NOWAIT;
             END;
 
@@ -1785,7 +1804,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance error reported events', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer error reported events', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #error_reported', 0, 0) WITH NOWAIT;
             END;
 
@@ -1809,7 +1828,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance memory broker events', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer memory broker events', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #memory_broker', 0, 0) WITH NOWAIT;
             END;
 
@@ -1833,7 +1852,7 @@ AND   ca.utc_timestamp < @end_date';
         BEGIN
             IF @debug = 1
             BEGIN
-                RAISERROR('Checking Managed Instance memory node OOM events', 0, 0) WITH NOWAIT;
+                RAISERROR('Checking ring_buffer memory node OOM events', 0, 0) WITH NOWAIT;
                 RAISERROR('Inserting #memory_node_oom', 0, 0) WITH NOWAIT;
             END;
 


### PR DESCRIPTION
## Summary
- Adds `@use_ring_buffer bit = 0` parameter so on-prem SQL Server can use the ring_buffer XE target instead of file target for system_health session data
- Ring buffer avoids disk I/O and benchmarks ~35% faster (1.6s vs 2.5s on a 10-min window)
- Guards file target cursor with `IF @mi = 0 AND @use_ring_buffer = 0`, extends MI block to `IF @mi = 1 OR @use_ring_buffer = 1`
- Version bumped to 3.4 (20260217)

## Test plan
- [x] Tested on sql2022 under HammerDB TPC-C load
- [x] Benchmarked file target vs ring buffer at 1hr and 10min windows
- [x] Verified PerformanceMonitor wrapper passes @use_ring_buffer through correctly
- [x] Execution plans captured and analyzed — all queries under 1.2s at 10-min window

🤖 Generated with [Claude Code](https://claude.com/claude-code)