### PR TITLE
Merge dev: build automation fix + ring buffer target

### DIFF
--- a/.github/workflows/build-sqlfile.yml
+++ b/.github/workflows/build-sqlfile.yml
@@ -9,9 +9,10 @@ jobs:
   build-sql-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
       - name: Checkout Code
         run: |
           git config --global user.name 'Darling Data'


### PR DESCRIPTION
## Summary
- Fix `build-sqlfile` workflow to use PAT token for pushing to `main` (bypasses branch protection that blocks the default `GITHUB_TOKEN`)
- Bump `actions/checkout` from v3 to v4
- sp_HealthParser v3.4: `@use_ring_buffer` parameter

## Test plan
- [ ] Merge triggers `build-sqlfile` workflow
- [ ] Workflow completes successfully (no more `GH013` push rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)