### PR TITLE
Switch build automation to PR-based workflow

### DIFF
--- a/.github/workflows/build-sqlfile.yml
+++ b/.github/workflows/build-sqlfile.yml
@@ -5,6 +5,7 @@ on:
       - main
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   build-sql-file:
     runs-on: ubuntu-latest
@@ -13,11 +14,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN }}
-      - name: Checkout Code
-        run: |
-          git config --global user.name 'Darling Data'
-          git config --global user.email 'erik@erikdarling.com'
-          git checkout
       - name: Trim trailing whitespace and replace Tabs
         shell: pwsh
         run: |
@@ -35,23 +31,27 @@ jobs:
                   if ($CharArray[$charIdx] -eq "`t") {
                       $currentTab = $tabSize - (($charIdx + $slidingOffset) % $tabSize)
                       $slidingOffset += $currentTab - 1
-                      $lineOutput += (" " * $currentTab) 
+                      $lineOutput += (" " * $currentTab)
                   }
                   else {
-                      $lineOutput += $CharArray[$charIdx] 
+                      $lineOutput += $CharArray[$charIdx]
                   }
               }
               $outputString += $lineOutput.TrimEnd() + "`n"   # Add line output with trailing spaces removed to the output string, and add newline
             }
             Set-Content -Path $fullPath -Value ($outputString.TrimEnd())
-          }  
+          }
       - name: Compile SQL File
         shell: pwsh
-        run: | 
+        run: |
           cd Install-All
           ./Merge-All.ps1
-      - name: Commit Updated File
-        run: |
-          git add .
-          git commit -am "Automation: Format and Build SQL File"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          commit-message: "Automation: Format and Build SQL File"
+          branch: automation/format-and-build
+          title: "Automation: Format and Build SQL File"
+          body: "Auto-generated formatting and rebuild of Install-All/DarlingData.sql"
+          delete-branch: true

--- a/.github/workflows/main-dev.yml
+++ b/.github/workflows/main-dev.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check branches
         run: |
-          if [ ${{ github.head_ref }} != "dev" ] && [ ${{ github.base_ref }} == "main" ]; then
-            echo "Merge requests to main branch are only allowed from dev branch."
+          if [ ${{ github.head_ref }} != "dev" ] && [ ${{ github.head_ref }} != "automation/format-and-build" ] && [ ${{ github.base_ref }} == "main" ]; then
+            echo "Merge requests to main branch are only allowed from dev or automation branches."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Replace direct `git push` to `main` with `peter-evans/create-pull-request` so automation respects branch protection
- Allow `automation/format-and-build` branch in the PR source check
- PAT token still used so the automation PR triggers status checks

## Test plan
- [ ] Merge this PR — triggers `build-sqlfile` workflow
- [ ] Workflow creates an `automation/format-and-build` PR instead of pushing directly
- [ ] That PR passes branch check and SQL tests
- [ ] Merge the automation PR to confirm end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)