### PR TITLE
sp_QuickieStore: never hide plan hashes in Expert Mode.

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -8583,6 +8583,7 @@ FROM
             WHEN @include_plan_hashes IS NOT NULL
             OR   @ignore_plan_hashes IS NOT NULL
             OR   @sort_order = 'plan count by hashes'
+            OR   @expert_mode = 1
             THEN N'
         qsp.query_plan_hash,'
             ELSE N''


### PR DESCRIPTION
One-line change. Closes #679.