### PR TITLE
Add 14 perfmon counters to sp_PressureDetector

### DIFF
--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -2085,7 +2085,10 @@ OPTION(MAXDOP 1, RECOMPILE);',
             N'Batch Requests/sec', N'SQL Compilations/sec', N'SQL Re-Compilations/sec', N'Longest Transaction Running Time', N'Log Bytes Flushed/sec',
             N'Lock waits', N'Log buffer waits', N'Log write waits', N'Memory grant queue waits', N'Network IO waits', N'Log Flush Write Time (ms)',
             N'Non-Page latch waits', N'Page IO latch waits', N'Page latch waits', N'Thread-safe memory objects waits', N'Wait for the worker',
-            N'Active parallel threads', N'Active requests', N'Blocked tasks', N'Query optimizations/sec', N'Queued requests', N'Reduced memory grants/sec'
+            N'Active parallel threads', N'Active requests', N'Blocked tasks', N'Query optimizations/sec', N'Queued requests', N'Reduced memory grants/sec',
+            N'Version Store Size (KB)', N'Free Space in tempdb (KB)', N'Active Temp Tables', N'Processes blocked', N'Full Scans/sec', N'Index Searches/sec',
+            N'Page Splits/sec', N'Free list stalls/sec', N'Workfiles Created/sec', N'Worktables Created/sec', N'Temp Tables Creation Rate', N'Version Generation rate (KB/s)',
+            N'Version Cleanup rate (KB/s)', N'Lock Timeouts/sec'
         );
 
 


### PR DESCRIPTION
## Summary
- Adds 14 perfmon counters to the `dm_os_performance_counters` IN clause
- Covers TempDB (version store, free space, temp tables), index access (full scans, index searches, page splits), and lock timeouts
- No logic changes — existing code handles both gauge (65792) and cumulative (272696576) counter types correctly

Closes #682

## Test plan
- [x] Deployed and tested on sql2016, sql2017, sql2019, sql2022
- [x] Snapshot mode (`@sample_seconds = 0`) — new counters appear in output
- [x] Delta mode (`@sample_seconds = 5`) — rate counters show proper differences
- [x] Zero-value gauge counters correctly suppressed by `cntr_value > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)