### PR TITLE
sp_QuickieStore: added expert mode T-SQL for plan forcing and hinting

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -1560,6 +1560,7 @@ VALUES
     /* SQL 2022 specific columns */
     (40, 'sql_2022', 'feedback', 'has_query_feedback', 'CASE WHEN EXISTS (SELECT 1/0 FROM #query_store_plan_feedback AS qspf WHERE qspf.plan_id = qsp.plan_id) THEN ''Yes'' ELSE ''No'' END', 1, 'sql_2022_views', 1, 0, NULL),
     (50, 'sql_2022', 'hints', 'has_query_store_hints', 'CASE WHEN EXISTS (SELECT 1/0 FROM #query_store_query_hints AS qsqh WHERE qsqh.query_id = qsp.query_id) THEN ''Yes'' ELSE ''No'' END', 1, 'sql_2022_views', 1, 0, NULL),
+    (55, 'sql_2022', 'hints', 'set_query_store_hints', '''EXECUTE ''+ QUOTENAME(DB_NAME(qsp.database_id)) + ''.sys.sp_query_store_set_hints @query_id = '' + CONVERT(nvarchar(20), qsq.query_id) + '', @query_hints = N''''OPTION(older_hints_go_here, USE HINT(''''''''newer_hints_go_here''''''''))'''';''', 1, 'sql_2022_views', 1, 1, NULL),
     (60, 'sql_2022', 'variants', 'has_plan_variants', 'CASE WHEN EXISTS (SELECT 1/0 FROM #query_store_query_variant AS qsqv WHERE qsqv.query_variant_query_id = qsp.query_id) THEN ''Yes'' ELSE ''No'' END', 1, 'sql_2022_views', 1, 0, NULL),
     (70, 'sql_2022', 'replay', 'has_compile_replay_script', 'qsp.has_compile_replay_script', 1, 'sql_2022_views', 1, 0, NULL),
     (80, 'sql_2022', 'opt_forcing', 'is_optimized_plan_forcing_disabled', 'qsp.is_optimized_plan_forcing_disabled', 1, 'sql_2022_views', 1, 0, NULL),


### PR DESCRIPTION
Closes #678. In Expert Mode, this gives the main `sp_QuickieStore` output two new columns. One is for adding hints and the other is for either forcing or unforcing that row's plan. Unconditionally, the special output table that shows existing hints now also has a column for removing that row's hint. That output table is already gated off by Expert Mode or `@Only_Queries_With_Hints = 1`.

This was all a bit too easy. Maybe Erik's hard work has paid off? I worry that I've missed something big and obvious. It passes the tests that I've tried, but this all worked so well that I never needed to build any nasty cases.

I was unsure if the template that I've added for `sp_query_store_set_hints` should have had an actual hint rather than a placeholder. I know how much Erik likes `FORCE_LEGACY_CARDINALITY_ESTIMATION`, so I would understand having that rather than my `newer_hints_go_here`.

Whether you see the code for forcing a plan or unforcing is conditional on if that row's plan is forced. This makes more sense if you know that calling `sp_query_store_force_plan` unforces whatever plan is currently forced.

A `@disable_optimized_plan_forcing = ?` placeholder is deliberately left in place. I always start with `= 0` and then switch to `= 1` only if that fails. If there is a best practice for this that we should put in the template, then I do not know it.

Note that I have made no attempt to touch the `@replica_group_id` stuff. Even on SQL Server 2025, I believe that's pretty obscure? Maybe somebody should come back to it when the feature becomes more used.

I have not tested with exotic database names. Erik may know some good ones.