### PR TITLE
March 1 2026 release

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -72,8 +72,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.4',
-        @version_date = '20260217';
+        @version = '3.3',
+        @version_date = '20260301';
 
     IF @help = 1
     BEGIN

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,8 +88,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.2.5',
-    @version_date = '20260206';
+    @version = '7.3',
+    @version_date = '20260301';
 
 IF @help = 1
 BEGIN

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -93,8 +93,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.2.5',
-    @version_date = '20260206';
+    @version = '5.3',
+    @version_date = '20260301';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -72,8 +72,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.2.5',
-        @version_date = '20260206';
+        @version = '2.3',
+        @version_date = '20260301';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,8 +73,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.2.5',
-        @version_date = '20260206';
+        @version = '3.3',
+        @version_date = '20260301';
 
     IF @help = 1
     BEGIN

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -65,7 +65,7 @@ BEGIN
         */
     SELECT
         @version = N'2.3',
-        @version_date = N'20260217';
+        @version_date = N'20260301';
 
     /*
     Help section, for help.

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,8 +78,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.2.5',
-    @version_date = '20260206';
+    @version = '6.3',
+    @version_date = '20260301';
 
 
 IF @help = 1

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -83,8 +83,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.2.5',
-    @version_date = '20260206';
+    @version = '1.3',
+    @version_date = '20260301';
 
 /*Help*/
 IF @help = 1

--- a/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
+++ b/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
@@ -53,8 +53,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.0',
-        @version_date = '20260212';
+        @version = '1.3',
+        @version_date = '20260301';
 
     /*
     Help section

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -120,8 +120,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.2.5',
-    @version_date = '20260206';
+    @version = '6.3',
+    @version_date = '20260301';
 
 /*
 Helpful section! For help.


### PR DESCRIPTION
## Summary
- Unified version bumps: all procs to x.3 / 20260301
- sp_HealthParser 3.3: `@skip_waits` and `@use_ring_buffer` parameters
- sp_PerfCheck 2.3: rework and README accuracy fixes
- sp_PressureDetector 6.3: 14 new perfmon counters, zero-rate filter
- sp_QuickieStore 6.3: expert mode plan hashes always visible, T-SQL for plan forcing/hinting (PR #684)

🤖 Generated with [Claude Code](https://claude.com/claude-code)