### PR TITLE
sp_QuickieStore: add sys.database_automatic_tuning_configurations support

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -8585,7 +8585,7 @@ WHERE EXISTS
           SELECT
               1/0
           FROM #query_store_plan AS qsp
-          WHERE datc.type_value = qsp.query_id
+          WHERE TRY_CAST(datc.type_value AS bigint) = qsp.query_id
       )
 OPTION(RECOMPILE);' + @nc10;
 

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -8580,6 +8580,13 @@ SELECT
     datc.details,
     datc.[state]
 FROM ' + @database_name_quoted + N'.sys.database_automatic_tuning_configurations AS datc
+WHERE EXISTS
+      (
+          SELECT
+              1/0
+          FROM #query_store_plan AS qsp
+          WHERE datc.type_value = qsp.query_id
+      )
 OPTION(RECOMPILE);' + @nc10;
 
     IF @debug = 1


### PR DESCRIPTION
## Summary
- Expert mode output for `sys.database_automatic_tuning_configurations` (issue #661)
- Respects existing filters when querying the view
- TRY_CAST fix for type_value comparison

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)