### PR TITLE
Bump all SP versions for April 2026 release

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -72,8 +72,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.3',
-        @version_date = '20260301';
+        @version = '3.4',
+        @version_date = '20260401';
 
     IF @help = 1
     BEGIN

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,8 +88,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.3',
-    @version_date = '20260301';
+    @version = '7.4',
+    @version_date = '20260401';
 
 IF @help = 1
 BEGIN

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -93,8 +93,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.3',
-    @version_date = '20260301';
+    @version = '5.4',
+    @version_date = '20260401';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -72,8 +72,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.3',
-        @version_date = '20260301';
+        @version = '2.4',
+        @version_date = '20260401';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,8 +73,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.3',
-        @version_date = '20260301';
+        @version = '3.4',
+        @version_date = '20260401';
 
     IF @help = 1
     BEGIN

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -64,8 +64,8 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.3',
-        @version_date = N'20260301';
+        @version = N'2.4',
+        @version_date = N'20260401';
 
     /*
     Help section, for help.

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,8 +78,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.3',
-    @version_date = '20260301';
+    @version = '6.4',
+    @version_date = '20260401';
 
 
 IF @help = 1

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -83,8 +83,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.3',
-    @version_date = '20260301';
+    @version = '1.4',
+    @version_date = '20260401';
 
 /*Help*/
 IF @help = 1

--- a/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
+++ b/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
@@ -53,8 +53,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.3',
-        @version_date = '20260301';
+        @version = '1.4',
+        @version_date = '20260401';
 
     /*
     Help section

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -121,8 +121,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.3',
-    @version_date = '20260301';
+    @version = '6.4',
+    @version_date = '20260401';
 
 /*
 Helpful section! For help.


### PR DESCRIPTION
## Summary
- Bumps all 10 stored procedure versions from x.3 → x.4
- Sets version_date to 20260401 across the board
- Install-All is intentionally not touched (auto-generated on merge to main)

## Stored Procedures
| SP | Old | New |
|----|-----|-----|
| sp_HealthParser | 3.3 | 3.4 |
| sp_HumanEvents | 7.3 | 7.4 |
| sp_HumanEventsBlockViewer | 5.3 | 5.4 |
| sp_IndexCleanup | 2.3 | 2.4 |
| sp_LogHunter | 3.3 | 3.4 |
| sp_PerfCheck | 2.3 | 2.4 |
| sp_PressureDetector | 6.3 | 6.4 |
| sp_QueryReproBuilder | 1.3 | 1.4 |
| sp_QueryStoreCleanup | 1.3 | 1.4 |
| sp_QuickieStore | 6.3 | 6.4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)