### PR TITLE
sp_QuickieStore: rewrite representative text query to avoid grouping on nvarchar(max)

### DIFF
--- a/Install-All/DarlingData.sql
+++ b/Install-All/DarlingData.sql
@@ -1,4 +1,4 @@
--- Compile Date: 03/23/2026 17:38:09 UTC
+-- Compile Date: 03/23/2026 19:02:42 UTC
 SET ANSI_NULLS ON;
 SET ANSI_PADDING ON;
 SET ANSI_WARNINGS ON;
@@ -36737,7 +36737,7 @@ BEGIN
     SELECT 'object_name: the stored procedure, function, or trigger this query belongs to, or "Adhoc" for ad hoc SQL' UNION ALL
     SELECT 'query_sql_text: representative query text (the most-executed variant for this query_hash)' UNION ALL
     SELECT 'query_plan: the most recent execution plan (XML) for this query_hash' UNION ALL
-    SELECT 'top_waits: top 3 Query Store wait categories with total wait time in ms (SQL 2017+ only, NULL on 2016)' UNION ALL
+    SELECT 'top_waits: top 3 Query Store wait categories with total wait time in ms (SQL 2017+ with wait stats enabled, omitted otherwise)' UNION ALL
     SELECT 'query_hash: the query_hash that groups all parameterized variants of the same query' UNION ALL
     SELECT 'query_count: how many distinct query_ids share this hash (parameterized variants)' UNION ALL
     SELECT 'plan_count: how many distinct plans exist across all variants. >1 may indicate plan instability.' UNION ALL
@@ -41494,11 +41494,31 @@ SELECT
         END + N',
     pw.primary_window,
     qi.object_name,
-    rt.query_sql_text,
+    query_sql_text =
+        (
+             SELECT
+                 [processing-instruction(query)] =
+                     REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                     REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                     REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                         rt.query_sql_text COLLATE Latin1_General_BIN2,
+                     NCHAR(31),N''?''),NCHAR(30),N''?''),NCHAR(29),N''?''),NCHAR(28),N''?''),NCHAR(27),N''?''),NCHAR(26),N''?''),NCHAR(25),N''?''),NCHAR(24),N''?''),NCHAR(23),N''?''),NCHAR(22),N''?''),
+                     NCHAR(21),N''?''),NCHAR(20),N''?''),NCHAR(19),N''?''),NCHAR(18),N''?''),NCHAR(17),N''?''),NCHAR(16),N''?''),NCHAR(15),N''?''),NCHAR(14),N''?''),NCHAR(12),N''?''),
+                     NCHAR(11),N''?''),NCHAR(8),N''?''),NCHAR(7),N''?''),NCHAR(6),N''?''),NCHAR(5),N''?''),NCHAR(4),N''?''),NCHAR(3),N''?''),NCHAR(2),N''?''),NCHAR(1),N''?''),NCHAR(0),N'''')
+             FOR XML
+                 PATH(N''''),
+                 TYPE
+        ),
     query_plan =
         TRY_CONVERT(xml, qp.query_plan),
-    qw.top_waits,
-    s.query_hash,
+    ' +
+    CASE
+        WHEN @new = 1
+         AND @query_store_waits_enabled = 1
+        THEN N'qw.top_waits,
+    '
+        ELSE N''
+    END + N's.query_hash,
     s.query_count,
     s.plan_count,
     qi.query_id_list,
@@ -41832,9 +41852,15 @@ LEFT JOIN #hi_query_identifiers AS qi
     ON s.query_hash = qi.query_hash
 LEFT JOIN #hi_primary_window AS pw
     ON s.query_hash = pw.query_hash
-LEFT JOIN #hi_query_waits AS qw
+' +
+    CASE
+        WHEN @new = 1
+         AND @query_store_waits_enabled = 1
+        THEN N'LEFT JOIN #hi_query_waits AS qw
     ON s.query_hash = qw.query_hash
-OUTER APPLY
+'
+        ELSE N''
+    END + N'OUTER APPLY
 (
     SELECT TOP (1)
         qsp.query_plan

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -4241,55 +4241,63 @@ OPTION(RECOMPILE);' + @nc10;
     SELECT
         @sql += N'
 SELECT
-    qsq.query_hash,
+    ranked.query_hash,
     qsqt.query_sql_text,
-    rn =
-        ROW_NUMBER() OVER
-        (
-            PARTITION BY qsq.query_hash
-            ORDER BY SUM(qsrs.count_executions) DESC
-        )
-FROM ' + @database_name_quoted + N'.sys.query_store_query AS qsq
-JOIN ' + @database_name_quoted + N'.sys.query_store_plan AS qsp
-    ON qsq.query_id = qsp.query_id
-JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
-    ON qsp.plan_id = qsrs.plan_id
-JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats_interval AS qsrsi
-    ON qsrs.runtime_stats_interval_id = qsrsi.runtime_stats_interval_id
-JOIN ' + @database_name_quoted + N'.sys.query_store_query_text AS qsqt
-    ON qsq.query_text_id = qsqt.query_text_id
-WHERE qsrsi.start_time >= @start_date
-AND   qsrsi.start_time <  @end_date' + @nc10;
+    ranked.rn
+FROM
+(
+    SELECT
+        qsq.query_hash,
+        qsq.query_text_id,
+        rn =
+            ROW_NUMBER() OVER
+            (
+                PARTITION BY qsq.query_hash
+                ORDER BY SUM(qsrs.count_executions) DESC
+            )
+    FROM ' + @database_name_quoted + N'.sys.query_store_query AS qsq
+    JOIN ' + @database_name_quoted + N'.sys.query_store_plan AS qsp
+        ON qsq.query_id = qsp.query_id
+    JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
+        ON qsp.plan_id = qsrs.plan_id
+    JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats_interval AS qsrsi
+        ON qsrs.runtime_stats_interval_id = qsrsi.runtime_stats_interval_id
+    WHERE qsrsi.start_time >= @start_date
+    AND   qsrsi.start_time <  @end_date' + @nc10;
 
     /*Same maintenance filter for representative text*/
     IF @include_maintenance = 0
     BEGIN
         SELECT
-            @sql += N'AND   NOT EXISTS
-      (
-          SELECT
-              1/0
-          FROM ' + @database_name_quoted + N'.sys.query_store_query_text AS qsqt2
-          WHERE qsqt2.query_text_id = qsq.query_text_id
-          AND
+            @sql += N'    AND   NOT EXISTS
           (
-              qsqt2.query_sql_text LIKE N''ALTER INDEX%''
-           OR qsqt2.query_sql_text LIKE N''ALTER TABLE%''
-           OR qsqt2.query_sql_text LIKE N''CREATE%INDEX%''
-           OR qsqt2.query_sql_text LIKE N''CREATE STATISTICS%''
-           OR qsqt2.query_sql_text LIKE N''UPDATE STATISTICS%''
-           OR qsqt2.query_sql_text LIKE N''%SELECT StatMan%''
-           OR qsqt2.query_sql_text LIKE N''DBCC%''
-           OR qsqt2.query_sql_text LIKE N''(@[_]msparam%''
-           OR qsqt2.query_sql_text LIKE N''WAITFOR%''
-          )
-      )' + @nc10;
+              SELECT
+                  1/0
+              FROM ' + @database_name_quoted + N'.sys.query_store_query_text AS qsqt2
+              WHERE qsqt2.query_text_id = qsq.query_text_id
+              AND
+              (
+                  qsqt2.query_sql_text LIKE N''ALTER INDEX%''
+               OR qsqt2.query_sql_text LIKE N''ALTER TABLE%''
+               OR qsqt2.query_sql_text LIKE N''CREATE%INDEX%''
+               OR qsqt2.query_sql_text LIKE N''CREATE STATISTICS%''
+               OR qsqt2.query_sql_text LIKE N''UPDATE STATISTICS%''
+               OR qsqt2.query_sql_text LIKE N''%SELECT StatMan%''
+               OR qsqt2.query_sql_text LIKE N''DBCC%''
+               OR qsqt2.query_sql_text LIKE N''(@[_]msparam%''
+               OR qsqt2.query_sql_text LIKE N''WAITFOR%''
+              )
+          )' + @nc10;
     END;
 
     SELECT
-        @sql += N'GROUP BY
-    qsq.query_hash,
-    qsqt.query_sql_text
+        @sql += N'    GROUP BY
+        qsq.query_hash,
+        qsq.query_text_id
+) AS ranked
+JOIN ' + @database_name_quoted + N'.sys.query_store_query_text AS qsqt
+    ON qsqt.query_text_id = ranked.query_text_id
+WHERE ranked.rn = 1
 OPTION(RECOMPILE);' + @nc10;
 
     IF @debug = 1


### PR DESCRIPTION
## Summary
The `#hi_representative_text` query in `@find_high_impact` grouped by `query_hash + query_sql_text`, forcing the Hash Aggregate to hash `nvarchar(max)` values — slow and memory-hungry.

Rewritten to:
1. Group by `query_hash + query_text_id` (both fixed-width) in a subquery
2. Pick the `rn = 1` winner
3. Join back to `query_store_query_text` only for that single row per hash

## Test plan
- [x] SQL2022 — same results, clean execution
- [x] SQL2016 — same results, clean execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)