### PR TITLE
sp_QuickieStore: use staged query_ids in final plan OUTER APPLY

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -5606,10 +5606,10 @@ OUTER APPLY
                         qsp.last_execution_time DESC
                 ),
             qsp.query_plan
-        FROM ' + @database_name_quoted + N'.sys.query_store_query AS qsq
+        FROM #hi_id_staging_queries AS sq
         JOIN ' + @database_name_quoted + N'.sys.query_store_plan AS qsp
-            ON qsq.query_id = qsp.query_id
-        WHERE qsq.query_hash = o.query_hash
+            ON qsp.query_id = sq.query_id
+        WHERE sq.query_hash = o.query_hash
     ) AS qp0
     WHERE qp0.n = 1
 ) AS qp


### PR DESCRIPTION
## Summary
Final plan OUTER APPLY now uses `#hi_id_staging_queries` instead of correlating through `query_store_query` per row. Drops from 2 DMVs to 1 in the correlated subquery.

## Test plan
- [x] SQL2022 — clean output, plans present

🤖 Generated with [Claude Code](https://claude.com/claude-code)