### PR TITLE
sp_QuickieStore: use EXISTS in final plan OUTER APPLY

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -5606,10 +5606,15 @@ OUTER APPLY
                         qsp.last_execution_time DESC
                 ),
             qsp.query_plan
-        FROM #hi_id_staging_plans AS sp
-        JOIN ' + @database_name_quoted + N'.sys.query_store_plan AS qsp
-            ON qsp.plan_id = sp.plan_id
-        WHERE sp.query_hash = o.query_hash
+        FROM ' + @database_name_quoted + N'.sys.query_store_plan AS qsp
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_id_staging_plans AS sp
+            WHERE qsp.plan_id = sp.plan_id
+            AND   sp.query_hash = o.query_hash
+        )
     ) AS qp0
     WHERE qp0.n = 1
 ) AS qp


### PR DESCRIPTION
## Summary
Replaced JOIN to `#hi_id_staging_plans` with EXISTS semi-join in the final OUTER APPLY. The optimizer picks a better plan with the EXISTS pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)