### PR TITLE
sp_QuickieStore: split Step 1 aggregate to avoid 4-way DMV join

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -3946,6 +3946,29 @@ IF @find_high_impact = 1
 BEGIN
     /*Create temp tables for high impact analysis*/
     CREATE TABLE
+        #hi_plan_stats
+    (
+        plan_id bigint NOT NULL,
+        total_executions bigint NOT NULL,
+        total_cpu_ms decimal(38, 6) NOT NULL,
+        min_cpu_ms decimal(38, 6) NULL,
+        max_cpu_ms decimal(38, 6) NULL,
+        total_duration_ms decimal(38, 6) NOT NULL,
+        min_duration_ms decimal(38, 6) NULL,
+        max_duration_ms decimal(38, 6) NULL,
+        total_physical_reads_mb decimal(38, 6) NOT NULL,
+        min_physical_reads_mb decimal(38, 6) NULL,
+        max_physical_reads_mb decimal(38, 6) NULL,
+        total_writes_mb decimal(38, 6) NOT NULL,
+        min_writes_mb decimal(38, 6) NULL,
+        max_writes_mb decimal(38, 6) NULL,
+        total_memory_mb decimal(38, 6) NOT NULL,
+        min_memory_mb decimal(38, 6) NULL,
+        max_memory_mb decimal(38, 6) NULL,
+        max_dop bigint NULL
+    );
+
+    CREATE TABLE
         #hi_query_stats
     (
         query_hash binary(8) NOT NULL,
@@ -4075,7 +4098,123 @@ BEGIN
         volatile_metrics nvarchar(4000) NULL
     );
 
-    /*Step 1: Aggregate runtime stats to query_hash level*/
+    /*Step 1a: Aggregate runtime stats to plan_id level (qsrs + qsrsi only)*/
+    SELECT
+        @current_table = 'inserting #hi_plan_stats',
+        @sql = @isolation_level;
+
+    IF @troubleshoot_performance = 1
+    BEGIN
+        EXECUTE sys.sp_executesql
+            @troubleshoot_insert,
+          N'@current_table nvarchar(100)',
+            @current_table;
+
+        SET STATISTICS XML ON;
+    END;
+
+    SELECT
+        @sql += N'
+SELECT
+    qsrs.plan_id,
+    total_executions =
+        SUM(qsrs.count_executions),
+    total_cpu_ms =
+        SUM(qsrs.avg_cpu_time / 1000.0 * qsrs.count_executions),
+    min_cpu_ms =
+        MIN(qsrs.min_cpu_time / 1000.0),
+    max_cpu_ms =
+        MAX(qsrs.max_cpu_time / 1000.0),
+    total_duration_ms =
+        SUM(qsrs.avg_duration / 1000.0 * qsrs.count_executions),
+    min_duration_ms =
+        MIN(qsrs.min_duration / 1000.0),
+    max_duration_ms =
+        MAX(qsrs.max_duration / 1000.0),
+    total_physical_reads_mb =
+        SUM(qsrs.avg_physical_io_reads * 8.0 / 1024.0 * qsrs.count_executions),
+    min_physical_reads_mb =
+        MIN(qsrs.min_physical_io_reads * 8.0 / 1024.0),
+    max_physical_reads_mb =
+        MAX(qsrs.max_physical_io_reads * 8.0 / 1024.0),
+    total_writes_mb =
+        SUM(qsrs.avg_logical_io_writes * 8.0 / 1024.0 * qsrs.count_executions),
+    min_writes_mb =
+        MIN(qsrs.min_logical_io_writes * 8.0 / 1024.0),
+    max_writes_mb =
+        MAX(qsrs.max_logical_io_writes * 8.0 / 1024.0),
+    total_memory_mb =
+        SUM(qsrs.avg_query_max_used_memory * 8.0 / 1024.0 * qsrs.count_executions),
+    min_memory_mb =
+        MIN(qsrs.min_query_max_used_memory * 8.0 / 1024.0),
+    max_memory_mb =
+        MAX(qsrs.max_query_max_used_memory * 8.0 / 1024.0),
+    max_dop =
+        MAX(qsrs.max_dop)
+FROM ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
+JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats_interval AS qsrsi
+    ON qsrsi.runtime_stats_interval_id = qsrs.runtime_stats_interval_id
+WHERE qsrsi.start_time >= @start_date
+AND   qsrsi.start_time <  @end_date
+GROUP BY
+    qsrs.plan_id
+HAVING
+    SUM(qsrs.count_executions) > 0
+OPTION(RECOMPILE);' + @nc10;
+
+    IF @debug = 1
+    BEGIN
+        PRINT LEN(@sql);
+        PRINT @sql;
+    END;
+
+    INSERT
+        #hi_plan_stats WITH (TABLOCK)
+    (
+        plan_id,
+        total_executions,
+        total_cpu_ms,
+        min_cpu_ms,
+        max_cpu_ms,
+        total_duration_ms,
+        min_duration_ms,
+        max_duration_ms,
+        total_physical_reads_mb,
+        min_physical_reads_mb,
+        max_physical_reads_mb,
+        total_writes_mb,
+        min_writes_mb,
+        max_writes_mb,
+        total_memory_mb,
+        min_memory_mb,
+        max_memory_mb,
+        max_dop
+    )
+    EXECUTE sys.sp_executesql
+        @sql,
+      N'@start_date datetimeoffset(7),
+        @end_date datetimeoffset(7)',
+        @start_date,
+        @end_date;
+
+    IF @troubleshoot_performance = 1
+    BEGIN
+        SET STATISTICS XML OFF;
+
+        EXECUTE sys.sp_executesql
+            @troubleshoot_update,
+          N'@current_table nvarchar(100)',
+            @current_table;
+
+        EXECUTE sys.sp_executesql
+            @troubleshoot_info,
+          N'@sql nvarchar(max),
+            @current_table nvarchar(100)',
+            @sql,
+            @current_table;
+    END;
+
+    /*Step 1b: Roll up to query_hash level (qsp + qsq against pre-aggregated temp table)*/
     SELECT
         @current_table = 'inserting #hi_query_stats',
         @sql = @isolation_level;
@@ -4095,73 +4234,65 @@ BEGIN
 SELECT
     qsq.query_hash,
     query_count =
-        COUNT(DISTINCT qsq.query_id),
+        COUNT(DISTINCT qsp.query_id),
     plan_count =
-        COUNT(DISTINCT qsp.plan_id),
+        COUNT(DISTINCT ps.plan_id),
     total_executions =
-        SUM(qsrs.count_executions),
+        SUM(ps.total_executions),
     total_cpu_ms =
-        SUM(qsrs.avg_cpu_time / 1000.0 * qsrs.count_executions),
+        SUM(ps.total_cpu_ms),
     avg_cpu_ms =
-        SUM(qsrs.avg_cpu_time / 1000.0 * qsrs.count_executions) /
-        NULLIF(SUM(qsrs.count_executions), 0),
+        SUM(ps.total_cpu_ms) /
+        NULLIF(SUM(ps.total_executions), 0),
     min_cpu_ms =
-        MIN(qsrs.min_cpu_time / 1000.0),
+        MIN(ps.min_cpu_ms),
     max_cpu_ms =
-        MAX(qsrs.max_cpu_time / 1000.0),
+        MAX(ps.max_cpu_ms),
     total_duration_ms =
-        SUM(qsrs.avg_duration / 1000.0 * qsrs.count_executions),
+        SUM(ps.total_duration_ms),
     avg_duration_ms =
-        SUM(qsrs.avg_duration / 1000.0 * qsrs.count_executions) /
-        NULLIF(SUM(qsrs.count_executions), 0),
+        SUM(ps.total_duration_ms) /
+        NULLIF(SUM(ps.total_executions), 0),
     min_duration_ms =
-        MIN(qsrs.min_duration / 1000.0),
+        MIN(ps.min_duration_ms),
     max_duration_ms =
-        MAX(qsrs.max_duration / 1000.0),
+        MAX(ps.max_duration_ms),
     total_physical_reads_mb =
-        SUM(qsrs.avg_physical_io_reads * 8.0 / 1024.0 * qsrs.count_executions),
+        SUM(ps.total_physical_reads_mb),
     avg_physical_reads_mb =
-        SUM(qsrs.avg_physical_io_reads * 8.0 / 1024.0 * qsrs.count_executions) /
-        NULLIF(SUM(qsrs.count_executions), 0),
+        SUM(ps.total_physical_reads_mb) /
+        NULLIF(SUM(ps.total_executions), 0),
     min_physical_reads_mb =
-        MIN(qsrs.min_physical_io_reads * 8.0 / 1024.0),
+        MIN(ps.min_physical_reads_mb),
     max_physical_reads_mb =
-        MAX(qsrs.max_physical_io_reads * 8.0 / 1024.0),
+        MAX(ps.max_physical_reads_mb),
     total_writes_mb =
-        SUM(qsrs.avg_logical_io_writes * 8.0 / 1024.0 * qsrs.count_executions),
+        SUM(ps.total_writes_mb),
     avg_writes_mb =
-        SUM(qsrs.avg_logical_io_writes * 8.0 / 1024.0 * qsrs.count_executions) /
-        NULLIF(SUM(qsrs.count_executions), 0),
+        SUM(ps.total_writes_mb) /
+        NULLIF(SUM(ps.total_executions), 0),
     min_writes_mb =
-        MIN(qsrs.min_logical_io_writes * 8.0 / 1024.0),
+        MIN(ps.min_writes_mb),
     max_writes_mb =
-        MAX(qsrs.max_logical_io_writes * 8.0 / 1024.0),
+        MAX(ps.max_writes_mb),
     total_memory_mb =
-        SUM(qsrs.avg_query_max_used_memory * 8.0 / 1024.0 * qsrs.count_executions),
+        SUM(ps.total_memory_mb),
     avg_memory_mb =
-        SUM(qsrs.avg_query_max_used_memory * 8.0 / 1024.0 * qsrs.count_executions) /
-        NULLIF(SUM(qsrs.count_executions), 0),
+        SUM(ps.total_memory_mb) /
+        NULLIF(SUM(ps.total_executions), 0),
     min_memory_mb =
-        MIN(qsrs.min_query_max_used_memory * 8.0 / 1024.0),
+        MIN(ps.min_memory_mb),
     max_memory_mb =
-        MAX(qsrs.max_query_max_used_memory * 8.0 / 1024.0),
+        MAX(ps.max_memory_mb),
     max_dop =
-        MAX(qsrs.max_dop)
-FROM ' + @database_name_quoted + N'.sys.query_store_query AS qsq
+        MAX(ps.max_dop)
+FROM #hi_plan_stats AS ps
 JOIN ' + @database_name_quoted + N'.sys.query_store_plan AS qsp
+    ON qsp.plan_id = ps.plan_id
+JOIN ' + @database_name_quoted + N'.sys.query_store_query AS qsq
     ON qsq.query_id = qsp.query_id
-JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
-    ON qsp.plan_id = qsrs.plan_id
-JOIN ' + @database_name_quoted + N'.sys.query_store_runtime_stats_interval AS qsrsi
-    ON qsrs.runtime_stats_interval_id = qsrsi.runtime_stats_interval_id
-WHERE qsrsi.start_time >= @start_date
-AND   qsrsi.start_time <  @end_date' + @nc10;
-
-    SELECT
-        @sql += N'GROUP BY
+GROUP BY
     qsq.query_hash
-HAVING
-    SUM(qsrs.count_executions) > 0
 OPTION(RECOMPILE);' + @nc10;
 
     IF @debug = 1
@@ -4200,11 +4331,7 @@ OPTION(RECOMPILE);' + @nc10;
         max_dop
     )
     EXECUTE sys.sp_executesql
-        @sql,
-      N'@start_date datetimeoffset(7),
-        @end_date datetimeoffset(7)',
-        @start_date,
-        @end_date;
+        @sql;
 
     IF @troubleshoot_performance = 1
     BEGIN
@@ -5613,7 +5740,7 @@ OUTER APPLY
                 1/0
             FROM #hi_id_staging_plans AS sp
             WHERE qsp.plan_id = sp.plan_id
-            AND   sp.query_hash = o.query_hash
+            AND   o.query_hash = sp.query_hash
         )
     ) AS qp0
     WHERE qp0.n = 1


### PR DESCRIPTION
## Summary
Split the initial 4-way DMV join (qsq → qsp → qsrs → qsrsi) into two stages:
- **Step 1a**: Aggregate runtime_stats by plan_id (2 DMVs: qsrs + qsrsi)
- **Step 1b**: Roll up to query_hash from pre-aggregated temp table (2 DMVs: qsp + qsq)

Follows the pattern used elsewhere in sp_QuickieStore where Query Store views are touched individually or in small groups.

## Test plan
- [x] SQL2022 — same results (96 hashes, 32 surfaced)
- [x] SQL2016 — same results

🤖 Generated with [Claude Code](https://claude.com/claude-code)