### PR TITLE
sp_QuickieStore: @find_high_impact performance overhaul (60s → 10s)

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -3948,7 +3948,8 @@ BEGIN
     CREATE TABLE
         #hi_plan_stats
     (
-        plan_id bigint NOT NULL,
+        plan_id bigint NOT NULL
+            PRIMARY KEY CLUSTERED,
         total_executions bigint NOT NULL,
         total_cpu_ms decimal(38, 6) NOT NULL,
         min_cpu_ms decimal(38, 6) NULL,
@@ -3971,7 +3972,8 @@ BEGIN
     CREATE TABLE
         #hi_query_stats
     (
-        query_hash binary(8) NOT NULL,
+        query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED,
         query_count bigint NOT NULL,
         plan_count bigint NOT NULL,
         total_executions bigint NOT NULL,
@@ -4002,6 +4004,7 @@ BEGIN
         #hi_interesting
     (
         query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED
     );
 
     CREATE TABLE
@@ -4023,14 +4026,16 @@ BEGIN
     CREATE TABLE
         #hi_primary_window
     (
-        query_hash binary(8) NOT NULL,
+        query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED,
         primary_window nvarchar(60) NULL
     );
 
     CREATE TABLE
         #hi_query_waits
     (
-        query_hash binary(8) NOT NULL,
+        query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED,
         top_waits nvarchar(max) NULL
     );
 
@@ -4046,7 +4051,8 @@ BEGIN
     CREATE TABLE
         #hi_query_identifiers
     (
-        query_hash binary(8) NOT NULL,
+        query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED,
         query_id_list nvarchar(max) NULL,
         plan_id_list nvarchar(max) NULL,
         object_name nvarchar(500) NULL
@@ -4080,7 +4086,8 @@ BEGIN
         object_name nvarchar(500) NULL,
         query_sql_text nvarchar(max) NULL,
         top_waits nvarchar(max) NULL,
-        query_hash binary(8) NOT NULL,
+        query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED,
         query_count bigint NOT NULL,
         plan_count bigint NOT NULL,
         query_id_list nvarchar(max) NULL,
@@ -4103,6 +4110,7 @@ BEGIN
         #hi_intervals
     (
         runtime_stats_interval_id bigint NOT NULL
+        PRIMARY KEY CLUSTERED
     );
 
     SELECT
@@ -4228,7 +4236,7 @@ GROUP BY
     qsrs.plan_id
 HAVING
     SUM(qsrs.count_executions) > 0
-OPTION(RECOMPILE);' + @nc10;
+OPTION(RECOMPILE, HASH JOIN);' + @nc10;
 
     IF @debug = 1
     BEGIN


### PR DESCRIPTION
## Summary
Comprehensive performance overhaul of `@find_high_impact`, reducing total execution time from ~60s to ~10s on large Query Stores.

### Query decomposition
- **Split 4-way DMV join** into staged steps: interval IDs → runtime stats (EXISTS) → plan rollup → query hash rollup
- **Staged query_ids** reused by representative text, time bucketing, and identifiers — each touches minimal DMVs
- **Static SQL INSERT** for scoring/diagnostics, separate OUTER APPLY for plans

### Join/filter improvements
- EXISTS semi-join pattern for interval filtering and plan fetch
- Plan OUTER APPLY uses `#hi_id_staging_plans` with PK seek on `query_store_plan`
- Removed redundant maintenance NOT EXISTS subqueries (~12s)
- Removed `query_plan IS NOT NULL` filter (~5s)
- ROW_NUMBER pattern replaces TOP(1) in correlated plan subquery

### Optimizer hints
- Clustered PKs on 7 temp tables (`plan_id`, `query_hash`, interval IDs)
- Hash join hint on interval EXISTS

### Output fixes
- Step ordering fix (staging after #hi_interesting, not before)
- `@sort_order` tiebreaker for impact_score ties

## PRs included
#709, #710, #711, #712, #713, #714, #715, #716, #717

## Test plan
- [x] SQL2022 — StackOverflow2013, hammerdb_tpch, hammerdb_tpcc
- [x] SQL2016 — StackOverflow2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)