### PR TITLE
sp_IndexCleanup: preserve UNIQUE in merge script (#724)

### DIFF
--- a/Install-All/DarlingData.sql
+++ b/Install-All/DarlingData.sql
@@ -1,4 +1,4 @@
--- Compile Date: 03/24/2026 19:28:29 UTC
+-- Compile Date: 03/25/2026 13:41:18 UTC
 SET ANSI_NULLS ON;
 SET ANSI_PADDING ON;
 SET ANSI_WARNINGS ON;
@@ -16393,9 +16393,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             schema_id = s.schema_id,
             schema_name = s.name,
             object_id = i.object_id,
-            table_name = ISNULL(t.name, v.name),
+            table_name = o.name,
             index_id = i.index_id,
-            index_name = ISNULL(i.name, ISNULL(t.name, v.name) + N''.Heap''),
+            index_name = ISNULL(i.name, o.name + N''.Heap''),
             can_compress =
                 CASE
                     WHEN p.index_id > 0
@@ -16404,20 +16404,18 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     ELSE 0
                 END
         FROM ' + QUOTENAME(@current_database_name) + N'.sys.indexes AS i
-        LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.tables AS t
-          ON i.object_id = t.object_id
-        LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.views AS v
-          ON i.object_id = v.object_id
+        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
+          ON i.object_id = o.object_id
         JOIN ' + QUOTENAME(@current_database_name) + N'.sys.schemas AS s
-          ON ISNULL(t.schema_id, v.schema_id) = s.schema_id
+          ON o.schema_id = s.schema_id
         JOIN ' + QUOTENAME(@current_database_name) + N'.sys.partitions AS p
           ON  i.object_id = p.object_id
           AND i.index_id = p.index_id
         /* LEFT JOIN to dm_db_index_usage_stats removed 2026-01-15 - was dead code with no columns selected */
-        WHERE (t.object_id IS NULL OR t.is_ms_shipped = 0)
-        AND   (t.object_id IS NULL OR t.type <> N''TF'')
-        AND    i.is_disabled = 0
-        AND    i.is_hypothetical = 0';
+        WHERE o.is_ms_shipped = 0
+        AND   o.type IN (N''U'', N''V'')
+        AND   i.is_disabled = 0
+        AND   i.is_hypothetical = 0';
 
     IF @supports_temporal_tables = 1
     BEGIN
@@ -16917,9 +16915,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         schema_id = s.schema_id,
         schema_name = s.name,
         os.object_id,
-        table_name = ISNULL(t.name, v.name),
+        table_name = o.name,
         os.index_id,
-        index_name = ISNULL(i.name, ISNULL(t.name, v.name) + N''.Heap''),
+        index_name = ISNULL(i.name, o.name + N''.Heap''),
         range_scan_count = SUM(os.range_scan_count),
         singleton_lookup_count = SUM(os.singleton_lookup_count),
         forwarded_fetch_count = SUM(os.forwarded_fetch_count),
@@ -16957,12 +16955,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         NULL,
         NULL
     ) AS os
-    LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.tables AS t
-      ON os.object_id = t.object_id
-    LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.views AS v
-      ON os.object_id = v.object_id
+    JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
+      ON os.object_id = o.object_id
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.schemas AS s
-      ON ISNULL(t.schema_id, v.schema_id) = s.schema_id
+      ON o.schema_id = s.schema_id
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.indexes AS i
       ON  os.object_id = i.object_id
       AND os.index_id = i.index_id
@@ -16980,7 +16976,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         s.schema_id,
         s.name,
         os.object_id,
-        ISNULL(t.name, v.name),
+        o.name,
         os.index_id,
         i.name
     OPTION(RECOMPILE);
@@ -17063,6 +17059,66 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         RAISERROR('Generating #index_details insert', 0, 0) WITH NOWAIT;
     END;
 
+    /*Stage dm_db_index_usage_stats for this database to avoid repeated DMV scans*/
+    IF OBJECT_ID(N'tempdb..#usage_stats') IS NOT NULL
+    BEGIN
+        TRUNCATE TABLE #usage_stats;
+    END;
+    ELSE
+    BEGIN
+        CREATE TABLE
+            #usage_stats
+        (
+            object_id int NOT NULL,
+            index_id int NOT NULL,
+            user_seeks bigint NOT NULL,
+            user_scans bigint NOT NULL,
+            user_lookups bigint NOT NULL,
+            user_updates bigint NOT NULL,
+            last_user_seek datetime NULL,
+            last_user_scan datetime NULL,
+            last_user_lookup datetime NULL,
+            last_user_update datetime NULL,
+            PRIMARY KEY CLUSTERED (object_id, index_id)
+        );
+    END;
+
+    INSERT
+        #usage_stats WITH (TABLOCK)
+    (
+        object_id,
+        index_id,
+        user_seeks,
+        user_scans,
+        user_lookups,
+        user_updates,
+        last_user_seek,
+        last_user_scan,
+        last_user_lookup,
+        last_user_update
+    )
+    SELECT
+        us.object_id,
+        us.index_id,
+        us.user_seeks,
+        us.user_scans,
+        us.user_lookups,
+        us.user_updates,
+        us.last_user_seek,
+        us.last_user_scan,
+        us.last_user_lookup,
+        us.last_user_update
+    FROM sys.dm_db_index_usage_stats AS us
+    WHERE us.database_id = @current_database_id
+    AND   EXISTS
+    (
+        SELECT
+            1/0
+        FROM #filtered_objects AS fo
+        WHERE fo.database_id = @current_database_id
+        AND   fo.object_id = us.object_id
+    );
+
     SELECT
         @sql = N'
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -17074,8 +17130,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         i.index_id,
         s.schema_id,
         schema_name = s.name,
-        table_name = ISNULL(t.name, v.name),
-        index_name = ISNULL(i.name, ISNULL(t.name, v.name) + N''.Heap''),
+        table_name = o.name,
+        index_name = ISNULL(i.name, o.name + N''.Heap''),
         column_name = c.name,
         column_id = c.column_id,
         i.is_primary_key,
@@ -17083,15 +17139,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         i.is_unique_constraint,
         is_indexed_view =
             CASE
-                WHEN EXISTS
-                (
-                    SELECT
-                        1/0
-                    FROM ' + QUOTENAME(@current_database_name) + N'.sys.objects AS so
-                    WHERE i.object_id = so.object_id
-                    AND   so.is_ms_shipped = 0
-                    AND   so.type = ''V''
-                )
+                WHEN o.type = ''V''
                 THEN 1
                 ELSE 0
             END,
@@ -17168,12 +17216,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 THEN 0
             END
     FROM ' + QUOTENAME(@current_database_name) + N'.sys.indexes AS i
-    LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.tables AS t
-      ON i.object_id = t.object_id
-    LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.views AS v
-      ON i.object_id = v.object_id
+    JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
+      ON i.object_id = o.object_id
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.schemas AS s
-      ON ISNULL(t.schema_id, v.schema_id) = s.schema_id
+      ON o.schema_id = s.schema_id
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.index_columns AS ic
       ON  i.object_id = ic.object_id
       AND i.index_id = ic.index_id
@@ -17184,11 +17230,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         N'.sys.columns AS c
       ON  ic.object_id = c.object_id
       AND ic.column_id = c.column_id
-    LEFT JOIN sys.dm_db_index_usage_stats AS us
+    LEFT JOIN #usage_stats AS us
       ON  i.object_id = us.object_id
       AND i.index_id = us.index_id
-      AND us.database_id = @database_id
-    WHERE (t.object_id IS NULL OR t.is_ms_shipped = 0)
+    WHERE o.is_ms_shipped = 0
+    AND   o.type IN (N''U'', N''V'')
     AND   i.type IN (1, 2)
     AND   i.is_disabled = 0
     AND   i.is_hypothetical = 0
@@ -17353,8 +17399,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             ps.index_id,
             s.schema_id,
             schema_name = s.name,
-            table_name = ISNULL(t.name, v.name),
-            index_name = ISNULL(i.name, ISNULL(t.name, v.name) + N''.Heap''),
+            table_name = o.name,
+            index_name = ISNULL(i.name, o.name + N''.Heap''),
             ps.partition_id,
             p.partition_number,
             total_rows = ps.row_count,
@@ -17364,12 +17410,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             p.data_compression_desc,
             i.data_space_id
         FROM ' + QUOTENAME(@current_database_name) + N'.sys.indexes AS i
-        LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.tables AS t
-          ON i.object_id = t.object_id
-        LEFT JOIN ' + QUOTENAME(@current_database_name) + N'.sys.views AS v
-          ON i.object_id = v.object_id
+        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
+          ON i.object_id = o.object_id
         JOIN ' + QUOTENAME(@current_database_name) + N'.sys.schemas AS s
-          ON ISNULL(t.schema_id, v.schema_id) = s.schema_id
+          ON o.schema_id = s.schema_id
         JOIN ' + QUOTENAME(@current_database_name) + N'.sys.partitions AS p
           ON  i.object_id = p.object_id
           AND i.index_id = p.index_id
@@ -17377,7 +17421,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           ON p.partition_id = a.container_id
         LEFT HASH JOIN ' + QUOTENAME(@current_database_name) + N'.sys.dm_db_partition_stats AS ps
           ON p.partition_id = ps.partition_id
-        WHERE (t.object_id IS NULL OR t.type <> N''TF'')
+        WHERE o.type IN (N''U'', N''V'')
         AND   i.type IN (1, 2)
         AND   EXISTS
         (
@@ -17406,7 +17450,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             ps.index_id,
             s.schema_id,
             s.name,
-            ISNULL(t.name, v.name),
+            o.name,
             i.name,
             ps.partition_id,
             p.partition_number,
@@ -18120,7 +18164,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       AND NOT (ia1.is_unique = 1 AND ia2.is_unique = 0)
     WHERE ia1.consolidation_rule IS NULL  /* Not already processed */
     AND   ia2.consolidation_rule IS NULL  /* Not already processed */
-    /* Exclude unique constraints - we'll handle those separately in Rule 7 */
+    /* Don't disable unique constraints — but allow them as the wider (target) index */
     AND NOT EXISTS
     (
         SELECT
@@ -18128,14 +18172,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         FROM #index_details AS id1_uc
         WHERE id1_uc.index_hash = ia1.index_hash
         AND   id1_uc.is_unique_constraint = 1
-    )
-    AND NOT EXISTS
-    (
-        SELECT
-            1/0
-        FROM #index_details AS id2_uc
-        WHERE id2_uc.index_hash = ia2.index_hash
-        AND   id2_uc.is_unique_constraint = 1
     )
     AND EXISTS
     (

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -4524,8 +4524,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             CASE
                 WHEN ia.action = N'MAKE UNIQUE'
                 THEN N'CREATE UNIQUE '
-                WHEN ia.action = N'MERGE INCLUDES'
-                THEN N'CREATE '
+                WHEN ia.is_unique = 1
+                THEN N'CREATE UNIQUE '
                 ELSE N'CREATE '
             END +
             N'INDEX ' +


### PR DESCRIPTION
## Summary
Merge scripts for Key Superset indexes now preserve the UNIQUE keyword when the index is unique. Previously only checked for the `MAKE UNIQUE` action, missing the case where a unique constraint/index was the superset target with `MERGE INCLUDES` action.

Closes #724

## Test plan
- [x] Unique constraint as superset → `CREATE UNIQUE INDEX`
- [x] Unique index as superset → `CREATE UNIQUE INDEX`
- [x] Regular NC as superset → `CREATE INDEX` (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)