### PR TITLE
sp_IndexCleanup: preserve UNIQUE in merge scripts + adversarial tests

### DIFF
--- a/sp_IndexCleanup/tests/adversarial_test.sql
+++ b/sp_IndexCleanup/tests/adversarial_test.sql
@@ -1,0 +1,253 @@
+/*
+sp_IndexCleanup Adversarial Test Suite — Setup & Execute
+========================================================
+This script:
+  1. Creates test tables with data and edge-case index configurations
+  2. Generates usage stats
+  3. Runs sp_IndexCleanup @dedupe_only = 1
+
+Output is captured by the test runner (run_tests.py) for validation.
+Run with: python run_tests.py
+
+Direct execution (visual inspection only):
+  sqlcmd -S SQL2022 -U sa -P "password" -d StackOverflow2013 -i adversarial_test.sql
+*/
+SET NOCOUNT ON;
+
+USE StackOverflow2013;
+GO
+
+/* ============================================= */
+/* Cleanup previous test artifacts               */
+/* ============================================= */
+IF OBJECT_ID('dbo.test_ic_view') IS NOT NULL
+BEGIN
+    IF EXISTS (SELECT 1/0 FROM sys.indexes WHERE object_id = OBJECT_ID('dbo.test_ic_view') AND name = N'cx_test_ic_view')
+        DROP INDEX cx_test_ic_view ON dbo.test_ic_view;
+END;
+GO
+IF OBJECT_ID('dbo.test_ic_view') IS NOT NULL DROP VIEW dbo.test_ic_view;
+GO
+DROP TABLE IF EXISTS dbo.test_ic_basic;
+DROP TABLE IF EXISTS dbo.test_ic_uc;
+DROP TABLE IF EXISTS dbo.test_ic_filtered;
+DROP TABLE IF EXISTS dbo.test_ic_heap;
+DROP TABLE IF EXISTS dbo.test_ic_multi;
+DROP TABLE IF EXISTS dbo.test_ic_view_base;
+GO
+
+/* ============================================= */
+/* Create test tables with data                  */
+/* ============================================= */
+
+CREATE TABLE dbo.test_ic_basic
+(
+    id bigint IDENTITY(1,1) NOT NULL PRIMARY KEY CLUSTERED,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL,
+    col_d integer NOT NULL,
+    col_e nvarchar(100) NULL,
+    col_f datetime NOT NULL DEFAULT GETDATE()
+);
+
+CREATE TABLE dbo.test_ic_uc
+(
+    id bigint IDENTITY(1,1) NOT NULL PRIMARY KEY CLUSTERED,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL,
+    col_d integer NOT NULL,
+    col_e nvarchar(100) NULL
+);
+
+CREATE TABLE dbo.test_ic_filtered
+(
+    id bigint IDENTITY(1,1) NOT NULL PRIMARY KEY CLUSTERED,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    status_code integer NOT NULL
+);
+
+CREATE TABLE dbo.test_ic_heap
+(
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL
+);
+
+CREATE TABLE dbo.test_ic_multi
+(
+    id bigint IDENTITY(1,1) NOT NULL PRIMARY KEY CLUSTERED,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL
+);
+
+CREATE TABLE dbo.test_ic_view_base
+(
+    id bigint IDENTITY(1,1) NOT NULL PRIMARY KEY CLUSTERED,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL
+);
+GO
+
+CREATE VIEW dbo.test_ic_view WITH SCHEMABINDING
+AS
+SELECT
+    col_a = tvb.col_a,
+    col_b = tvb.col_b,
+    row_count = COUNT_BIG(*)
+FROM dbo.test_ic_view_base AS tvb
+GROUP BY tvb.col_a, tvb.col_b;
+GO
+
+/* Populate with 10K+ rows */
+INSERT INTO dbo.test_ic_basic (col_a, col_b, col_c, col_d, col_e)
+SELECT TOP (10000) ABS(CHECKSUM(NEWID())) % 1000, ABS(CHECKSUM(NEWID())) % 500,
+    ABS(CHECKSUM(NEWID())) % 200, ABS(CHECKSUM(NEWID())) % 100, LEFT(NEWID(), 20)
+FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
+
+INSERT INTO dbo.test_ic_uc (col_a, col_b, col_c, col_d, col_e)
+SELECT TOP (10000) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    ABS(CHECKSUM(NEWID())) % 500, ABS(CHECKSUM(NEWID())) % 200,
+    ABS(CHECKSUM(NEWID())) % 100, LEFT(NEWID(), 20)
+FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
+
+INSERT INTO dbo.test_ic_filtered (col_a, col_b, status_code)
+SELECT TOP (10000) ABS(CHECKSUM(NEWID())) % 1000, ABS(CHECKSUM(NEWID())) % 500,
+    ABS(CHECKSUM(NEWID())) % 5
+FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
+
+INSERT INTO dbo.test_ic_heap (col_a, col_b, col_c)
+SELECT TOP (10000) ABS(CHECKSUM(NEWID())) % 1000, ABS(CHECKSUM(NEWID())) % 500,
+    ABS(CHECKSUM(NEWID())) % 200
+FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
+
+INSERT INTO dbo.test_ic_multi (col_a, col_b)
+SELECT TOP (10000) ABS(CHECKSUM(NEWID())) % 1000, ABS(CHECKSUM(NEWID())) % 500
+FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
+
+INSERT INTO dbo.test_ic_view_base (col_a, col_b, col_c)
+SELECT TOP (10000) ABS(CHECKSUM(NEWID())) % 100, ABS(CHECKSUM(NEWID())) % 50,
+    ABS(CHECKSUM(NEWID())) % 200
+FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
+GO
+
+/* ============================================= */
+/* Create test indexes                           */
+/* ============================================= */
+
+/* Group 1: UC as superset (#721, #724) */
+ALTER TABLE dbo.test_ic_uc ADD CONSTRAINT uq_uc_abc UNIQUE (col_a, col_b, col_c);
+CREATE NONCLUSTERED INDEX ix_uc_ab ON dbo.test_ic_uc (col_a, col_b);
+CREATE NONCLUSTERED INDEX ix_uc_ab_inc ON dbo.test_ic_uc (col_a, col_b) INCLUDE (col_e);
+CREATE NONCLUSTERED INDEX ix_uc_bc ON dbo.test_ic_uc (col_b, col_c);
+CREATE UNIQUE NONCLUSTERED INDEX uix_uc_acd ON dbo.test_ic_uc (col_a, col_c, col_d);
+CREATE NONCLUSTERED INDEX ix_uc_ac ON dbo.test_ic_uc (col_a, col_c);
+ALTER TABLE dbo.test_ic_uc ADD CONSTRAINT uq_uc_ad UNIQUE (col_a, col_d);
+
+/* Group 2: Sort direction */
+CREATE INDEX ix_sort_a_desc ON dbo.test_ic_basic (col_a DESC);
+CREATE INDEX ix_sort_a_desc2 ON dbo.test_ic_basic (col_a DESC);
+CREATE INDEX ix_sort_a_asc ON dbo.test_ic_basic (col_a ASC);
+CREATE INDEX ix_sort_ab_asc ON dbo.test_ic_basic (col_a ASC, col_b ASC);
+CREATE INDEX ix_sort_ab_mixed ON dbo.test_ic_basic (col_a DESC, col_b ASC);
+
+/* Group 3: Filtered indexes */
+CREATE INDEX ix_filt_a_s1 ON dbo.test_ic_filtered (col_a) WHERE status_code = 1;
+CREATE INDEX ix_filt_a_s1_dup ON dbo.test_ic_filtered (col_a) WHERE status_code = 1;
+CREATE INDEX ix_filt_a_s2 ON dbo.test_ic_filtered (col_a) WHERE status_code = 2;
+CREATE INDEX ix_filt_ab_s3 ON dbo.test_ic_filtered (col_a, col_b) WHERE status_code = 3;
+CREATE INDEX ix_filt_a_s3 ON dbo.test_ic_filtered (col_a) WHERE status_code = 3;
+CREATE INDEX ix_filt_ab_s4 ON dbo.test_ic_filtered (col_a, col_b) WHERE status_code = 4;
+CREATE INDEX ix_filt_a_s0 ON dbo.test_ic_filtered (col_a) WHERE status_code = 0;
+
+/* Group 4a: Key Duplicate — same keys, different includes, no wider index */
+CREATE INDEX ix_inc_f_inc_b ON dbo.test_ic_basic (col_f) INCLUDE (col_b);
+CREATE INDEX ix_inc_f_inc_c ON dbo.test_ic_basic (col_f) INCLUDE (col_c);
+
+/* Group 4b: Key Subset — narrower key with includes absorbed by wider key */
+CREATE INDEX ix_inc_cd_inc_e ON dbo.test_ic_basic (col_c, col_d) INCLUDE (col_e);
+CREATE INDEX ix_inc_c_inc_b ON dbo.test_ic_basic (col_c) INCLUDE (col_b);
+
+/* Group 5: Indexed view */
+CREATE UNIQUE CLUSTERED INDEX cx_test_ic_view ON dbo.test_ic_view (col_a, col_b);
+CREATE NONCLUSTERED INDEX ix_view_a ON dbo.test_ic_view (col_a);
+CREATE NONCLUSTERED INDEX ix_view_a_dup ON dbo.test_ic_view (col_a);
+
+/* Group 6: Heap */
+CREATE NONCLUSTERED INDEX ix_heap_a ON dbo.test_ic_heap (col_a);
+CREATE NONCLUSTERED INDEX ix_heap_a_dup ON dbo.test_ic_heap (col_a);
+
+/* Group 7: Multi-table isolation */
+CREATE INDEX ix_multi_a ON dbo.test_ic_multi (col_a);
+CREATE INDEX ix_basic_col_d ON dbo.test_ic_basic (col_d);
+GO
+
+/* ============================================= */
+/* Generate usage stats                          */
+/* ============================================= */
+DECLARE @c bigint, @i integer = 0;
+WHILE @i < 10
+BEGIN
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = uq_uc_abc) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = ix_uc_ab) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = ix_uc_ab_inc) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = ix_uc_bc) WHERE col_b = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = uix_uc_acd) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = ix_uc_ac) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_uc WITH (INDEX = uq_uc_ad) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_sort_a_desc) WHERE col_a > 500;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_sort_a_desc2) WHERE col_a > 600;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_sort_a_asc) WHERE col_a < 100;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_sort_ab_asc) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_sort_ab_mixed) WHERE col_a = 2;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_a_s1) WHERE col_a > 500 AND status_code = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_a_s1_dup) WHERE col_a > 600 AND status_code = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_a_s2) WHERE col_a > 500 AND status_code = 2;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_ab_s3) WHERE col_a = 1 AND status_code = 3;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_a_s3) WHERE col_a = 2 AND status_code = 3;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_ab_s4) WHERE col_a = 1 AND status_code = 4;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_filtered WITH (INDEX = ix_filt_a_s0) WHERE col_a = 1 AND status_code = 0;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_inc_f_inc_b) WHERE col_f > '2020-01-01';
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_inc_f_inc_c) WHERE col_f > '2021-01-01';
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_inc_cd_inc_e) WHERE col_c = 1 AND col_d = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_inc_c_inc_b) WHERE col_c = 2;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_view WITH (INDEX = ix_view_a, NOEXPAND) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_view WITH (INDEX = ix_view_a_dup, NOEXPAND) WHERE col_a = 2;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_heap WITH (INDEX = ix_heap_a) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_heap WITH (INDEX = ix_heap_a_dup) WHERE col_a = 2;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_multi WITH (INDEX = ix_multi_a) WHERE col_a = 1;
+    SELECT @c = COUNT_BIG(*) FROM dbo.test_ic_basic WITH (INDEX = ix_basic_col_d) WHERE col_d = 1;
+    SELECT @i += 1;
+END;
+GO
+
+/* ============================================= */
+/* Run sp_IndexCleanup                           */
+/* ============================================= */
+EXECUTE dbo.sp_IndexCleanup
+    @database_name = N'StackOverflow2013',
+    @dedupe_only = 1;
+GO
+
+/* ============================================= */
+/* Cleanup                                       */
+/* ============================================= */
+IF OBJECT_ID('dbo.test_ic_view') IS NOT NULL
+BEGIN
+    DROP INDEX ix_view_a ON dbo.test_ic_view;
+    DROP INDEX ix_view_a_dup ON dbo.test_ic_view;
+    DROP INDEX cx_test_ic_view ON dbo.test_ic_view;
+END;
+GO
+IF OBJECT_ID('dbo.test_ic_view') IS NOT NULL DROP VIEW dbo.test_ic_view;
+GO
+DROP TABLE IF EXISTS dbo.test_ic_basic;
+DROP TABLE IF EXISTS dbo.test_ic_uc;
+DROP TABLE IF EXISTS dbo.test_ic_filtered;
+DROP TABLE IF EXISTS dbo.test_ic_heap;
+DROP TABLE IF EXISTS dbo.test_ic_multi;
+DROP TABLE IF EXISTS dbo.test_ic_view_base;
+GO

--- a/sp_IndexCleanup/tests/run_tests.py
+++ b/sp_IndexCleanup/tests/run_tests.py
@@ -1,0 +1,277 @@
+"""
+sp_IndexCleanup Adversarial Test Runner
+=======================================
+Runs adversarial_test.sql, captures output, and validates expected results.
+
+Usage:
+    python run_tests.py [--server SQL2022] [--password "L!nt0044"]
+"""
+
+import subprocess
+import sys
+import re
+
+
+def run_sqlcmd(server, password):
+    """Run the test SQL and capture output."""
+    cmd = [
+        "sqlcmd", "-S", server, "-U", "sa", "-P", password,
+        "-d", "StackOverflow2013",
+        "-i", "adversarial_test.sql",
+        "-W",  # trim trailing spaces
+        "-s", "\t",  # tab delimiter
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    return result.stdout, result.stderr
+
+
+def parse_output(stdout):
+    """Parse sp_IndexCleanup tab-delimited output into rows."""
+    rows = []
+    lines = stdout.split("\n")
+    headers = None
+
+    for line in lines:
+        if not line.strip():
+            continue
+        if "script_type" in line and "index_name" in line:
+            headers = [h.strip() for h in line.split("\t")]
+            continue
+        if headers and line.startswith("---"):
+            continue
+        if headers and len(line.split("\t")) >= 6:
+            cols = [c.strip() for c in line.split("\t")]
+            if len(cols) >= len(headers):
+                row = dict(zip(headers, cols))
+                rows.append(row)
+
+    return rows
+
+
+def find_rows(rows, **filters):
+    """Find rows matching all filter criteria."""
+    matches = []
+    for row in rows:
+        match = True
+        for key, value in filters.items():
+            if key.endswith("__like"):
+                col = key[:-6]
+                if col not in row or value.lower() not in row[col].lower():
+                    match = False
+                    break
+            elif key.endswith("__in"):
+                col = key[:-4]
+                if col not in row or row[col] not in value:
+                    match = False
+                    break
+            else:
+                if key not in row or row[key] != value:
+                    match = False
+                    break
+        if match:
+            matches.append(row)
+    return matches
+
+
+def run_tests(rows):
+    """Run all assertions and return results."""
+    results = []
+
+    def assert_test(group, name, condition, detail=""):
+        results.append({
+            "group": group,
+            "name": name,
+            "passed": condition,
+            "detail": detail,
+        })
+
+    # ---- Group 1: UC as superset (#721, #724) ----
+
+    # 1a: NC subset of UC → DISABLE
+    matches = find_rows(rows, table_name="test_ic_uc", index_name="ix_uc_ab",
+                        script_type="DISABLE SCRIPT")
+    assert_test("1-UC", "1a: NC subset of UC flagged DISABLE",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # 1a: UC merge script → CREATE UNIQUE
+    matches = find_rows(rows, table_name="test_ic_uc", index_name="uq_uc_abc",
+                        script_type="MERGE SCRIPT")
+    has_unique = any("CREATE UNIQUE" in m.get("script", "") for m in matches)
+    assert_test("1-UC", "1a: UC merge script has CREATE UNIQUE",
+                has_unique, f"found {len(matches)} merge rows, unique={has_unique}")
+
+    # 1b: NC subset of UC with includes → DISABLE
+    matches = find_rows(rows, table_name="test_ic_uc", index_name="ix_uc_ab_inc",
+                        script_type="DISABLE SCRIPT")
+    assert_test("1-UC", "1b: NC subset of UC (with includes) flagged DISABLE",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # 1c: NC with non-prefix UC keys → NOT subset
+    matches = find_rows(rows, table_name="test_ic_uc", index_name="ix_uc_bc",
+                        script_type="DISABLE SCRIPT", additional_info__like="Key Subset")
+    assert_test("1-UC", "1c: NC non-prefix keys NOT flagged as subset",
+                len(matches) == 0, f"found {len(matches)} (expected 0)")
+
+    # 1d: Unique index as superset → NC subset DISABLE
+    matches = find_rows(rows, table_name="test_ic_uc", index_name="ix_uc_ac",
+                        script_type="DISABLE SCRIPT")
+    assert_test("1-UC", "1d: NC subset of unique index flagged DISABLE",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # 1d: Unique index merge → CREATE UNIQUE
+    matches = find_rows(rows, table_name="test_ic_uc", index_name="uix_uc_acd",
+                        script_type="MERGE SCRIPT")
+    has_unique = any("CREATE UNIQUE" in m.get("script", "") for m in matches)
+    assert_test("1-UC", "1d: Unique index merge has CREATE UNIQUE",
+                has_unique, f"found {len(matches)} merge rows, unique={has_unique}")
+
+    # ---- Group 2: Sort direction ----
+
+    # 2a: Same DESC duplicates → one DISABLE
+    matches = find_rows(rows, table_name="test_ic_basic",
+                        index_name__in={"ix_sort_a_desc", "ix_sort_a_desc2"},
+                        script_type="DISABLE SCRIPT")
+    assert_test("2-Sort", "2a: DESC duplicate flagged DISABLE",
+                len(matches) >= 1, f"found {len(matches)}")
+
+    # 2c: Subset with different sort → NOT subset
+    matches = find_rows(rows, table_name="test_ic_basic", index_name="ix_sort_ab_mixed",
+                        script_type="DISABLE SCRIPT", additional_info__like="Key Subset")
+    assert_test("2-Sort", "2c: Different sort NOT flagged as subset",
+                len(matches) == 0, f"found {len(matches)} (expected 0)")
+
+    # ---- Group 3: Filtered indexes ----
+
+    # 3a: Same filter duplicate → DISABLE
+    matches = find_rows(rows, table_name="test_ic_filtered",
+                        index_name__in={"ix_filt_a_s1", "ix_filt_a_s1_dup"},
+                        script_type="DISABLE SCRIPT")
+    assert_test("3-Filter", "3a: Filtered duplicate flagged DISABLE",
+                len(matches) >= 1, f"found {len(matches)}")
+
+    # 3b: Different filter → NOT duplicate
+    matches = find_rows(rows, table_name="test_ic_filtered", index_name="ix_filt_a_s2",
+                        script_type="DISABLE SCRIPT", additional_info__like="Duplicate")
+    assert_test("3-Filter", "3b: Different filter NOT flagged duplicate",
+                len(matches) == 0, f"found {len(matches)} (expected 0)")
+
+    # 3c: Subset with same filter → DISABLE
+    matches = find_rows(rows, table_name="test_ic_filtered", index_name="ix_filt_a_s3",
+                        script_type="DISABLE SCRIPT")
+    assert_test("3-Filter", "3c: Filtered subset flagged DISABLE",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # 3d: Subset with different filter → NOT subset
+    matches = find_rows(rows, table_name="test_ic_filtered", index_name="ix_filt_a_s0",
+                        script_type="DISABLE SCRIPT", additional_info__like="Key Subset")
+    assert_test("3-Filter", "3d: Different filter NOT flagged as subset",
+                len(matches) == 0, f"found {len(matches)} (expected 0)")
+
+    # ---- Group 4: Include merges ----
+
+    # 4a: Same keys, different includes → one gets MERGE SCRIPT
+    matches = find_rows(rows, table_name="test_ic_basic",
+                        index_name__in={"ix_inc_f_inc_b", "ix_inc_f_inc_c"},
+                        script_type="MERGE SCRIPT")
+    assert_test("4-Includes", "4a: Key dup with different includes gets MERGE",
+                len(matches) >= 1, f"found {len(matches)}")
+
+    # 4a: The other gets DISABLE
+    matches = find_rows(rows, table_name="test_ic_basic",
+                        index_name__in={"ix_inc_f_inc_b", "ix_inc_f_inc_c"},
+                        script_type="DISABLE SCRIPT")
+    assert_test("4-Includes", "4a: Key dup loser gets DISABLE",
+                len(matches) >= 1, f"found {len(matches)}")
+
+    # 4b: Key subset with includes → DISABLE
+    matches = find_rows(rows, table_name="test_ic_basic", index_name="ix_inc_c_inc_b",
+                        script_type="DISABLE SCRIPT")
+    assert_test("4-Includes", "4b: Key subset (with includes) flagged DISABLE",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # ---- Group 5: Indexed view ----
+
+    # 5a: Duplicate NC on indexed view → DISABLE
+    matches = find_rows(rows, table_name="test_ic_view",
+                        index_name__in={"ix_view_a", "ix_view_a_dup"},
+                        script_type="DISABLE SCRIPT")
+    assert_test("5-View", "5a: Duplicate NC on view flagged DISABLE",
+                len(matches) >= 1, f"found {len(matches)}")
+
+    # ---- Group 6: Heap ----
+
+    # 6a: Duplicate on heap → DISABLE
+    matches = find_rows(rows, table_name="test_ic_heap",
+                        index_name__in={"ix_heap_a", "ix_heap_a_dup"},
+                        script_type="DISABLE SCRIPT")
+    assert_test("6-Heap", "6a: Duplicate on heap flagged DISABLE",
+                len(matches) >= 1, f"found {len(matches)}")
+
+    # ---- Group 7: Cross-table isolation ----
+
+    # 7a: Different tables should NOT interact
+    matches = find_rows(rows, table_name="test_ic_multi", index_name="ix_multi_a",
+                        script_type="DISABLE SCRIPT", additional_info__like="Duplicate")
+    assert_test("7-Isolation", "7a: Cross-table NOT flagged as duplicate",
+                len(matches) == 0, f"found {len(matches)} (expected 0)")
+
+    return results
+
+
+def main():
+    server = "SQL2022"
+    password = "L!nt0044"
+
+    # Parse args
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--server" and i + 1 < len(args):
+            server = args[i + 1]
+        elif arg == "--password" and i + 1 < len(args):
+            password = args[i + 1]
+
+    print(f"Running adversarial tests against {server}...")
+    print()
+
+    stdout, stderr = run_sqlcmd(server, password)
+
+    if "Msg " in stderr and "Level 16" in stderr:
+        print("ERROR: SQL errors detected:")
+        print(stderr)
+        sys.exit(1)
+
+    rows = parse_output(stdout)
+    print(f"Captured {len(rows)} output rows from sp_IndexCleanup")
+    print()
+
+    if len(rows) == 0:
+        print("ERROR: No output rows captured. Check SQL setup.")
+        print("stderr:", stderr[:500] if stderr else "(empty)")
+        sys.exit(1)
+
+    results = run_tests(rows)
+
+    # Report
+    passed = sum(1 for r in results if r["passed"])
+    failed = sum(1 for r in results if not r["passed"])
+
+    for r in results:
+        status = "PASS" if r["passed"] else "FAIL"
+        print(f"  [{status}] {r['group']}: {r['name']}  ({r['detail']})")
+
+    print()
+    print(f"Results: {passed} passed, {failed} failed, {len(results)} total")
+
+    if failed > 0:
+        print()
+        print("FAILED TESTS:")
+        for r in results:
+            if not r["passed"]:
+                print(f"  {r['group']}: {r['name']}  ({r['detail']})")
+        sys.exit(1)
+    else:
+        print("All tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **#724 fix**: Merge scripts check `is_unique` directly, preserving UNIQUE keyword for unique constraints and unique indexes
- **Test suite**: New `sp_IndexCleanup/tests/` with adversarial test SQL + Python runner covering 7 groups (18 assertions)
- **#726**: Closed as test design issue, not a proc bug

Closes #724, closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)