### PR TITLE
sp_IndexCleanup: fix heap table index detection (#727)

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -2311,7 +2311,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             nvarchar(MAX),
             N'.sys.dm_db_partition_stats ps
         WHERE ps.object_id = i.object_id
-        AND   ps.index_id = 1
+        AND   ps.index_id IN (0, 1)
         AND   ps.row_count >= @min_rows
     )'
         );


### PR DESCRIPTION
## Summary
Changed `ps.index_id = 1` to `ps.index_id IN (0, 1)` in the partition stats row count filter so heap tables (index_id = 0) are included in deduplication analysis.

Adversarial test suite: 18/18 passing.

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)