### PR TITLE
README: add shields.io badge flair (repo + social)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 # Darling Data: SQL Server Troubleshooting Scripts
 <a name="header1"></a>
-![licence badge]
+<p align="center">
+  <a href="https://github.com/erikdarlingdata/DarlingData/stargazers"><img src="https://img.shields.io/github/stars/erikdarlingdata/DarlingData?style=for-the-badge&logo=github&color=gold&logoColor=black" alt="GitHub Stars"></a>
+  <a href="https://github.com/erikdarlingdata/DarlingData/network/members"><img src="https://img.shields.io/github/forks/erikdarlingdata/DarlingData?style=for-the-badge&logo=github" alt="GitHub Forks"></a>
+  <a href="https://github.com/erikdarlingdata/DarlingData/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/erikdarlingdata/DarlingData?style=for-the-badge" alt="License: MIT"></a>
+  <a href="https://github.com/erikdarlingdata/DarlingData/releases/latest"><img src="https://img.shields.io/github/v/release/erikdarlingdata/DarlingData?style=for-the-badge" alt="Latest Release"></a>
+  <a href="https://github.com/erikdarlingdata/DarlingData/issues"><img src="https://img.shields.io/github/issues/erikdarlingdata/DarlingData?style=for-the-badge" alt="Open Issues"></a>
+  <a href="https://github.com/erikdarlingdata/DarlingData/commits/main"><img src="https://img.shields.io/github/last-commit/erikdarlingdata/DarlingData?style=for-the-badge" alt="Last Commit"></a>
+  <a href="https://github.com/erikdarlingdata/DarlingData/actions/workflows/sql-tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/erikdarlingdata/DarlingData/sql-tests.yml?style=for-the-badge&label=SQL%20Tests" alt="SQL Tests CI"></a>
+</p>
+<p align="center">
+  <a href="https://x.com/erikdarling"><img src="https://img.shields.io/badge/Follow_%40ErikDarling-black?style=for-the-badge&logo=x&logoColor=white" alt="Follow @ErikDarling on X"></a>
+  <a href="https://www.youtube.com/@erikaboringdata"><img src="https://img.shields.io/badge/YouTube-Subscribe-red?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube Subscribe"></a>
+  <a href="https://www.linkedin.com/in/erik-darling-83545913/"><img src="https://img.shields.io/badge/LinkedIn-Connect-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn Connect"></a>
+  <a href="https://www.erikdarlingdata.com"><img src="https://img.shields.io/badge/Blog-erikdarlingdata.com-FF6B35?style=for-the-badge&logo=wordpress&logoColor=white" alt="Blog"></a>
+</p>
 
 # Navigatory 
  - Scripts:


### PR DESCRIPTION
## Summary
- Replaces the old `![licence badge]` placeholder with proper shields.io badges using `style=for-the-badge` for a chunky, colorful look
- Two centered rows: repo stats on the first line, social links on the second

## Changes
- `README.md` — replaced placeholder with 11 badges in two `<p align="center">` blocks

**Row 1 — Repo badges:**
- ⭐ GitHub Stars (gold + GitHub logo)
- 🍴 GitHub Forks
- 📄 License (auto-detects MIT)
- 🚀 Latest Release
- 🐛 Open Issues
- 🕐 Last Commit
- ✅ SQL Tests CI (`sql-tests.yml` workflow)

**Row 2 — Social badges:**
- 𝕏 Follow @ErikDarling on X (black + X logo)
- ▶️ YouTube Subscribe (red)
- 💼 LinkedIn Connect (LinkedIn blue)
- 📝 Blog → erikdarlingdata.com (orange)

## Test Plan
- [ ] Preview README on the branch to confirm badges render correctly
- [ ] Verify all badge links resolve to the correct destinations
- [ ] Confirm CI status badge points to `sql-tests.yml`

Generated with [Claude Code](https://claude.com/claude-code)