### PR TITLE
Add sp_QuickieCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     - [sp_HumanEvents](#human-events): Use Extended Events to track down various query performance issues
     - [sp_HumanEventsBlockViewer](#human-events-block-viewer): Analyze the blocked process report
     - [sp_QuickieStore](#quickie-store): The fastest and most configurable way to navigate Query Store data
+    - [sp_QuickieCache](#quickie-cache): High-impact query detection from the plan cache using Pareto analysis
     - [sp_QueryReproBuilder](#query-repro-builder): Generate executable reproduction scripts from Query Store data
     - [sp_HealthParser](#health-parser): Pull all the performance-related data from the system health Extended Event
     - [sp_LogHunter](#log-hunter): Get all of the worst stuff out of your error log
@@ -328,6 +329,53 @@ Current valid parameter details:
 | @version                                | varchar        | OUTPUT; for support                                                                                                                               | none; OUTPUT                                                                                                                                                                                                                                                                                                                                                      | none; OUTPUT                                                              |
 | @version_date                           | datetime       | OUTPUT; for support                                                                                                                               | none; OUTPUT                                                                                                                                                                                                                                                                                                                                                      | none; OUTPUT                                                              |
 
+
+[*Back to top*](#navigatory)
+
+## Quickie Cache
+
+The plan cache companion to sp_QuickieStore. While QuickieStore digs into Query Store data, QuickieCache uses the same Pareto (80/20) analysis approach against the plan cache DMVs.
+
+It aggregates data from `sys.dm_exec_query_stats`, `sys.dm_exec_procedure_stats`, `sys.dm_exec_function_stats`, and `sys.dm_exec_trigger_stats`, then scores queries across 7 resource dimensions (CPU, duration, reads, writes, memory grants, spills, executions) using `PERCENT_RANK`. Only the vital few queries with disproportionate resource consumption are surfaced.
+
+Results come in three result sets:
+ * **Plan cache health findings**: plan age distribution, single-use plan bloat, duplicate plan detection, USERSTORE_TOKENPERM pressure
+ * **High-impact queries**: Pareto-scored queries with impact scores, resource shares, and diagnostic signals (parameter sniffing, plan instability, wasteful grants, wait-bound queries, etc.)
+ * **Workload profile summary**: overall concentration analysis with tuning recommendations
+
+Requires SQL Server 2016 SP1+ for full memory grant and spill analysis.
+
+Current valid parameter details:
+
+|       parameter_name        |  data_type   |                                             description                                              |               valid_inputs               |  defaults  |
+|-----------------------------|--------------|------------------------------------------------------------------------------------------------------|------------------------------------------|------------|
+| @top                        | integer      | candidates per metric dimension before dedup                                                         | a positive integer                       | 10         |
+| @database_name              | sysname      | filter to a specific database                                                                        | a valid database name                    | NULL       |
+| @start_date                 | datetime     | only include plans created after this date                                                           | a valid datetime                         | NULL       |
+| @end_date                   | datetime     | only include plans created before this date                                                          | a valid datetime                         | NULL       |
+| @minimum_execution_count    | bigint       | minimum execution count to include a query                                                           | a positive integer                       | 2          |
+| @ignore_system_databases    | bit          | exclude system databases (master, model, msdb, tempdb)                                               | 0 or 1                                   | 1          |
+| @impact_threshold           | decimal(3,2) | minimum impact_score (0.00-1.00) to surface in results                                               | 0.00 to 1.00                             | 0.50       |
+| @debug                      | bit          | print diagnostic information                                                                         | 0 or 1                                   | 0          |
+| @help                       | bit          | display parameter help                                                                               | 0 or 1                                   | 0          |
+
+```sql
+-- Basic execution
+EXECUTE dbo.sp_QuickieCache;
+
+-- Focus on a specific database
+EXECUTE dbo.sp_QuickieCache
+    @database_name = N'YourDatabase';
+
+-- Only plans created today
+EXECUTE dbo.sp_QuickieCache
+    @start_date = '20260403';
+
+-- Lower the threshold to surface more queries
+EXECUTE dbo.sp_QuickieCache
+    @impact_threshold = 0.25,
+    @top = 20;
+```
 
 [*Back to top*](#navigatory)
 

--- a/sp_QuickieCache/README.md
+++ b/sp_QuickieCache/README.md
@@ -1,0 +1,79 @@
+<img src="https://erikdarling.com/wp-content/uploads/2025/08/darling-data-logo_RGB.jpg" width="300px" />
+
+# sp_QuickieCache
+
+The plan cache companion to sp_QuickieStore.
+
+While QuickieStore digs into Query Store data, QuickieCache uses the same Pareto (80/20) analysis approach against the plan cache DMVs to find the vital few queries consuming disproportionate resources.
+
+## How It Works
+
+1. **Collects** data from all four plan cache stat DMVs (`dm_exec_query_stats`, `dm_exec_procedure_stats`, `dm_exec_function_stats`, `dm_exec_trigger_stats`)
+2. **Selects candidates** by taking the top N queries per metric dimension (CPU, duration, reads, writes, memory grants, spills, executions) and deduplicating
+3. **Scores** each candidate with `PERCENT_RANK` across all 7 dimensions, only counting dimensions where the query consumes >= 0.1% of the total
+4. **Surfaces** queries with an `impact_score` above the threshold, along with diagnostic signals
+
+## Result Sets
+
+1. **Plan cache health findings**: plan age distribution, single-use plan bloat per database, duplicate plan detection per database, USERSTORE_TOKENPERM memory pressure
+2. **High-impact queries**: Pareto-scored queries with resource shares and diagnostics
+3. **Workload profile summary**: concentration analysis (Concentrated / Moderate / Flat) with recommendations
+
+## Diagnostics Detected
+
+* Parameter sniffing (CPU and reads variance > 30% from average)
+* Plan instability (multiple cached plans for the same query)
+* Wait-bound queries (duration >> CPU)
+* Wasteful memory grants (< 10% utilization)
+* TempDB spills
+* Row count variance
+* Rare but expensive queries (few executions, high resource share)
+* High frequency queries (> 100 executions/minute)
+
+## Parameters
+
+| parameter_name | data_type | description | default |
+|---|---|---|---|
+| @top | integer | candidates per metric dimension before dedup | 10 |
+| @database_name | sysname | filter to a specific database | NULL |
+| @start_date | datetime | only include plans created after this date | NULL |
+| @end_date | datetime | only include plans created before this date | NULL |
+| @minimum_execution_count | bigint | minimum execution count to include a query | 2 |
+| @ignore_system_databases | bit | exclude system databases | 1 |
+| @impact_threshold | decimal(3,2) | minimum impact_score to surface | 0.50 |
+| @debug | bit | print diagnostic information | 0 |
+| @help | bit | display parameter help | 0 |
+
+## Examples
+
+```sql
+-- Basic execution
+EXECUTE dbo.sp_QuickieCache;
+
+-- Focus on a specific database
+EXECUTE dbo.sp_QuickieCache
+    @database_name = N'YourDatabase';
+
+-- Only plans created today
+EXECUTE dbo.sp_QuickieCache
+    @start_date = '20260403';
+
+-- Lower the threshold to surface more queries
+EXECUTE dbo.sp_QuickieCache
+    @impact_threshold = 0.25,
+    @top = 20;
+
+-- Filter to a specific time window
+EXECUTE dbo.sp_QuickieCache
+    @start_date = '20260401',
+    @end_date = '20260402';
+```
+
+## Requirements
+
+* SQL Server 2016 SP1+ for full memory grant and spill analysis
+* Older versions will work but with reduced metric coverage
+
+## Resources
+* [sp_QuickieStore](https://github.com/erikdarlingdata/DarlingData/tree/main/sp_QuickieStore) - the Query Store companion
+* [Blog](https://www.erikdarling.com)

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -1,0 +1,1946 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+IF OBJECT_ID(N'dbo.sp_QuickieCache', N'P') IS NULL
+BEGIN
+    EXECUTE(N'CREATE PROCEDURE dbo.sp_QuickieCache AS RETURN 138;');
+END;
+GO
+
+ALTER PROCEDURE
+    dbo.sp_QuickieCache
+(
+    @top integer = 10, /*candidates per metric dimension before dedup*/
+    @database_name sysname = NULL, /*filter to a specific database*/
+    @start_date datetime = NULL, /*only include plans created after this date*/
+    @end_date datetime = NULL, /*only include plans created before this date*/
+    @minimum_execution_count bigint = 2, /*noise floor for single-exec queries*/
+    @ignore_system_databases bit = 1, /*exclude master, model, msdb, tempdb*/
+    @impact_threshold decimal(3, 2) = 0.50, /*minimum impact_score to surface (0.00-1.00)*/
+    @debug bit = 0, /*print diagnostics*/
+    @help bit = 0 /*display parameter help*/
+)
+WITH RECOMPILE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+    /*
+    ██████╗ ██╗      █████╗ ███╗   ██╗     ██████╗ █████╗  ██████╗██╗  ██╗███████╗
+    ██╔══██╗██║     ██╔══██╗████╗  ██║    ██╔════╝██╔══██╗██╔════╝██║  ██║██╔════╝
+    ██████╔╝██║     ███████║██╔██╗ ██║    ██║     ███████║██║     ███████║█████╗
+    ██╔═══╝ ██║     ██╔══██║██║╚██╗██║    ██║     ██╔══██║██║     ██╔══██║██╔══╝
+    ██║     ███████╗██║  ██║██║ ╚████║    ╚██████╗██║  ██║╚██████╗██║  ██║███████╗
+    ╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝     ╚═════╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝╚══════╝
+
+    sp_QuickieCache: The plan cache companion to sp_QuickieStore.
+
+    Copyright 2026 Erik Darling Data, LLC
+
+    Uses the Pareto principle to find the vital few queries consuming
+    disproportionate resources across statements, procedures, functions,
+    and triggers. Scores across 7 dimensions using PERCENT_RANK and
+    surfaces queries with impact_score >= @impact_threshold.
+
+    Data sources:
+        sys.dm_exec_query_stats      (statements)
+        sys.dm_exec_procedure_stats  (stored procedures)
+        sys.dm_exec_function_stats   (scalar/table-valued functions)
+        sys.dm_exec_trigger_stats    (triggers)
+
+    Requires SQL Server 2016 SP1+ for memory grant and spill columns.
+    */
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Help section                                    ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    IF @help = 1
+    BEGIN
+        SELECT
+            parameter_name =
+                ap.name,
+            data_type =
+                t.name,
+            description =
+                CASE ap.name
+                    WHEN N'@top'
+                    THEN N'Number of candidate queries per metric dimension (cpu, reads, etc.) before dedup. Default: 10.'
+                    WHEN N'@database_name'
+                    THEN N'Filter to a specific database. Default: NULL (all user databases).'
+                    WHEN N'@start_date'
+                    THEN N'Only include plans created after this date. Default: NULL (no filter).'
+                    WHEN N'@end_date'
+                    THEN N'Only include plans created before this date. Default: NULL (no filter).'
+                    WHEN N'@minimum_execution_count'
+                    THEN N'Minimum execution count to include a query. Filters single-execution noise. Default: 2.'
+                    WHEN N'@ignore_system_databases'
+                    THEN N'Exclude system databases (master, model, msdb, tempdb). Default: 1.'
+                    WHEN N'@impact_threshold'
+                    THEN N'Minimum impact_score (0.00-1.00) to surface in results. Default: 0.50.'
+                    WHEN N'@debug'
+                    THEN N'Print diagnostic information. Default: 0.'
+                    WHEN N'@help'
+                    THEN N'You are here. Default: 0.'
+                    ELSE N''
+                END
+        FROM sys.all_parameters AS ap
+        JOIN sys.types AS t
+          ON t.user_type_id = ap.user_type_id
+        WHERE ap.object_id = @@PROCID
+        ORDER BY
+            ap.parameter_id;
+
+        SELECT
+            methodology = N'Pareto (80/20) analysis across 7 resource dimensions',
+            dimensions = N'CPU, Duration, Logical Reads, Logical Writes, Memory Grants, Spills, Executions',
+            scoring = N'PERCENT_RANK per dimension, averaged across active dimensions (>= 0.1% of total)',
+            high_signal = N'Dimensions where query ranks >= 80th percentile',
+            output = N'Queries with impact_score >= @impact_threshold, plus workload profile summary';
+
+        RETURN;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Version detection                               ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    DECLARE
+        @has_spills bit = 0,
+        @has_memory_grants bit = 0,
+        @database_id integer = NULL;
+
+    IF EXISTS
+    (
+        SELECT
+            1/0
+        FROM sys.all_columns AS ac
+        WHERE ac.object_id = OBJECT_ID(N'sys.dm_exec_query_stats')
+        AND   ac.name = N'total_spills'
+    )
+    BEGIN
+        SELECT
+            @has_spills = 1;
+    END;
+
+    IF EXISTS
+    (
+        SELECT
+            1/0
+        FROM sys.all_columns AS ac
+        WHERE ac.object_id = OBJECT_ID(N'sys.dm_exec_query_stats')
+        AND   ac.name = N'min_grant_kb'
+    )
+    BEGIN
+        SELECT
+            @has_memory_grants = 1;
+    END;
+
+    IF @debug = 1
+    BEGIN
+        DECLARE
+            @debug_msg nvarchar(4000) = N'';
+
+        SELECT
+            @debug_msg =
+                N'Has spill columns: ' + CONVERT(nvarchar(1), @has_spills) +
+                N', Has memory grant columns: ' + CONVERT(nvarchar(1), @has_memory_grants);
+
+        RAISERROR(N'%s', 0, 1, @debug_msg) WITH NOWAIT;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Parameter validation                            ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    IF @database_name IS NOT NULL
+    BEGIN
+        SELECT
+            @database_id = DB_ID(@database_name);
+
+        IF @database_id IS NULL
+        BEGIN
+            RAISERROR(N'Database [%s] does not exist on this server.', 16, 1, @database_name) WITH NOWAIT;
+            RETURN;
+        END;
+    END;
+
+    IF @impact_threshold < 0.0
+    OR @impact_threshold > 1.0
+    BEGIN
+        RAISERROR(N'@impact_threshold must be between 0.00 and 1.00.', 16, 1) WITH NOWAIT;
+        RETURN;
+    END;
+
+    IF @top < 1
+    BEGIN
+        RAISERROR(N'@top must be at least 1.', 16, 1) WITH NOWAIT;
+        RETURN;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Plan cache health analysis                      ║
+    ╚══════════════════════════════════════════════════╝
+
+    Context-level checks about the overall plan cache state,
+    independent of individual query analysis.
+    */
+    CREATE TABLE
+        #plan_cache_health
+    (
+        id integer NOT NULL IDENTITY(1, 1),
+        finding_group nvarchar(100) NOT NULL,
+        finding nvarchar(200) NOT NULL,
+        database_name sysname NULL,
+        priority integer NOT NULL,
+        details nvarchar(max) NULL
+    );
+
+    /*
+    Plan creation time distribution:
+    What % of plans were created in the last 24h / 4h / 1h?
+    High percentages suggest plan cache instability or memory pressure.
+    */
+    DECLARE
+        @total_plans bigint = 0,
+        @plans_24h bigint = 0,
+        @plans_4h bigint = 0,
+        @plans_1h bigint = 0,
+        @pct_24h decimal(5, 2) = 0,
+        @pct_4h decimal(5, 2) = 0,
+        @pct_1h decimal(5, 2) = 0,
+        @oldest_plan_date datetime = NULL;
+
+    SELECT
+        @total_plans = COUNT_BIG(*),
+        @plans_24h =
+            SUM
+            (
+                CASE
+                    WHEN DATEDIFF(HOUR, qs.creation_time, GETDATE()) <= 24
+                    THEN 1
+                    ELSE 0
+                END
+            ),
+        @plans_4h =
+            SUM
+            (
+                CASE
+                    WHEN DATEDIFF(HOUR, qs.creation_time, GETDATE()) <= 4
+                    THEN 1
+                    ELSE 0
+                END
+            ),
+        @plans_1h =
+            SUM
+            (
+                CASE
+                    WHEN DATEDIFF(HOUR, qs.creation_time, GETDATE()) <= 1
+                    THEN 1
+                    ELSE 0
+                END
+            ),
+        @oldest_plan_date = MIN(qs.creation_time)
+    FROM sys.dm_exec_query_stats AS qs
+    OPTION(RECOMPILE);
+
+    IF @total_plans > 0
+    BEGIN
+        SELECT
+            @pct_24h = @plans_24h * 100.0 / @total_plans,
+            @pct_4h = @plans_4h * 100.0 / @total_plans,
+            @pct_1h = @plans_1h * 100.0 / @total_plans;
+    END;
+
+    IF @pct_24h > 75
+    BEGIN
+        INSERT
+            #plan_cache_health
+        (
+            finding_group,
+            finding,
+            priority,
+            details
+        )
+        VALUES
+        (
+            N'Plan Cache Instability',
+            N'Most plans are recent',
+            1,
+            N'Of ' + FORMAT(@total_plans, N'N0') +
+            N' cached plans, ' +
+            CONVERT(nvarchar(10), @pct_24h) + N'% created in the last 24 hours, ' +
+            CONVERT(nvarchar(10), @pct_4h) + N'% in the last 4 hours, ' +
+            CONVERT(nvarchar(10), @pct_1h) + N'% in the last 1 hour. ' +
+            N'This may indicate memory pressure, frequent recompiles, or plan cache flushes. ' +
+            N'Oldest cached plan: ' + CONVERT(nvarchar(30), @oldest_plan_date, 120) + N'.'
+        );
+    END;
+    ELSE
+    BEGIN
+        INSERT
+            #plan_cache_health
+        (
+            finding_group,
+            finding,
+            priority,
+            details
+        )
+        VALUES
+        (
+            N'Plan Cache Stability',
+            N'Plan age distribution looks healthy',
+            254,
+            N'Of ' + FORMAT(@total_plans, N'N0') +
+            N' cached plans, ' +
+            CONVERT(nvarchar(10), @pct_24h) + N'% created in the last 24 hours, ' +
+            CONVERT(nvarchar(10), @pct_4h) + N'% in the last 4 hours, ' +
+            CONVERT(nvarchar(10), @pct_1h) + N'% in the last 1 hour. ' +
+            N'Oldest cached plan: ' + CONVERT(nvarchar(30), @oldest_plan_date, 120) + N'.'
+        );
+    END;
+
+    /*
+    Single-use plan bloat per database:
+    High % of execution_count = 1 plans suggests ad hoc workload
+    that may benefit from Forced Parameterization.
+    Only surfaces databases where single-use plans exceed 10%.
+    */
+    INSERT
+        #plan_cache_health
+    (
+        finding_group,
+        finding,
+        database_name,
+        priority,
+        details
+    )
+    SELECT TOP (5)
+        finding_group =
+            CASE
+                WHEN single_use_pct > 75
+                THEN N'Single-Use Plan Bloat'
+                ELSE N'Single-Use Plans'
+            END,
+        finding =
+            CASE
+                WHEN single_use_pct > 75
+                THEN N'Excessive single-use plans in cache'
+                ELSE N'Notable single-use plan percentage'
+            END,
+        x.database_name,
+        priority =
+            CASE
+                WHEN single_use_pct > 75
+                THEN 1
+                ELSE 254
+            END,
+        details =
+            FORMAT(x.single_use_count, N'N0') +
+            N' of ' + FORMAT(x.total_count, N'N0') +
+            N' plans (' +
+            CONVERT(nvarchar(10), x.single_use_pct) +
+            N'%) executed only once. Consider Forced Parameterization if these are unparameterized ad hoc queries.'
+    FROM
+    (
+        SELECT
+            database_name =
+                DB_NAME(CONVERT(integer, pa.value)),
+            total_count =
+                COUNT_BIG(*),
+            single_use_count =
+                SUM
+                (
+                    CASE
+                        WHEN qs.execution_count = 1
+                        THEN 1
+                        ELSE 0
+                    END
+                ),
+            single_use_pct =
+                CONVERT
+                (
+                    decimal(5, 2),
+                    SUM
+                    (
+                        CASE
+                            WHEN qs.execution_count = 1
+                            THEN 1
+                            ELSE 0
+                        END
+                    ) * 100.0 / COUNT_BIG(*)
+                )
+        FROM sys.dm_exec_query_stats AS qs
+        CROSS APPLY
+        (
+            SELECT TOP (1)
+                value = pa.value
+            FROM sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
+            WHERE pa.attribute = N'dbid'
+        ) AS pa
+        WHERE pa.value IS NOT NULL
+        AND   CONVERT(integer, pa.value) NOT IN (1, 2, 3, 4)
+        AND   CONVERT(integer, pa.value) < 32761
+        GROUP BY
+            pa.value
+    ) AS x
+    WHERE x.single_use_pct > 10
+    ORDER BY
+        x.single_use_count DESC
+    OPTION(RECOMPILE);
+
+    /*
+    Duplicate plan hashes:
+    Same query_hash compiled into multiple plans suggests
+    SET option differences or parameterization issues.
+    */
+    DECLARE
+        @duplicate_hashes bigint = 0,
+        @duplicate_plans bigint = 0,
+        @pct_duplicate decimal(5, 2) = 0;
+
+    SELECT
+        @duplicate_hashes = COUNT_BIG(*),
+        @duplicate_plans = SUM(x.plan_count)
+    FROM
+    (
+        SELECT
+            plan_count = COUNT_BIG(*)
+        FROM sys.dm_exec_query_stats AS qs
+        WHERE qs.query_hash <> 0x0000000000000000
+        GROUP BY
+            qs.query_hash
+        HAVING
+            COUNT_BIG(*) > 5
+    ) AS x
+    OPTION(RECOMPILE);
+
+    IF @total_plans > 0
+    AND @duplicate_plans > 0
+    BEGIN
+        SELECT
+            @pct_duplicate = @duplicate_plans * 100.0 / @total_plans;
+    END;
+
+    IF @pct_duplicate > 5
+    BEGIN
+        INSERT
+            #plan_cache_health
+        (
+            finding_group,
+            finding,
+            database_name,
+            priority,
+            details
+        )
+        SELECT TOP (5)
+            finding_group =
+                CASE
+                    WHEN @pct_duplicate > 75
+                    THEN N'Severe Plan Duplication'
+                    ELSE N'Plan Duplication'
+                END,
+            finding =
+                CASE
+                    WHEN @pct_duplicate > 75
+                    THEN N'Massive duplicate plan compilation'
+                    ELSE N'Notable duplicate plan compilation'
+                END,
+            database_name = DB_NAME(CONVERT(integer, pa.value)),
+            priority =
+                CASE
+                    WHEN @pct_duplicate > 75
+                    THEN 1
+                    ELSE 254
+                END,
+            details =
+                FORMAT(COUNT_BIG(DISTINCT qs2.query_hash), N'N0') +
+                N' query hashes with 5+ plans, totaling ' +
+                FORMAT(COUNT_BIG(*), N'N0') + N' plans. ' +
+                N'Most likely unparameterized queries. SET option differences between sessions can also cause this. Consider Forced Parameterization.'
+        FROM
+        (
+            SELECT
+                qs.query_hash
+            FROM sys.dm_exec_query_stats AS qs
+            WHERE qs.query_hash <> 0x0000000000000000
+            GROUP BY
+                qs.query_hash
+            HAVING
+                COUNT_BIG(*) > 5
+        ) AS x
+        JOIN sys.dm_exec_query_stats AS qs2
+          ON qs2.query_hash = x.query_hash
+        CROSS APPLY
+        (
+            SELECT TOP (1)
+                value = pa.value
+            FROM sys.dm_exec_plan_attributes(qs2.plan_handle) AS pa
+            WHERE pa.attribute = N'dbid'
+        ) AS pa
+        WHERE pa.value IS NOT NULL
+        AND   CONVERT(integer, pa.value) NOT IN (1, 2, 3, 4)
+        AND   CONVERT(integer, pa.value) < 32761
+        GROUP BY
+            pa.value
+        ORDER BY
+            COUNT_BIG(*) DESC
+        OPTION(RECOMPILE);
+    END;
+
+    /*
+    USERSTORE_TOKENPERM memory pressure:
+    When the token/permission cache consumes >= 10% of buffer pool,
+    it can starve the plan cache and cause churn.
+    */
+    DECLARE
+        @buffer_pool_mb decimal(18, 2) = 0,
+        @tokenperm_mb decimal(18, 2) = 0;
+
+    SELECT
+        @buffer_pool_mb =
+            SUM
+            (
+                CASE
+                    WHEN mc.type = N'MEMORYCLERK_SQLBUFFERPOOL'
+                    THEN mc.pages_kb / 1024.0
+                    ELSE 0
+                END
+            ),
+        @tokenperm_mb =
+            SUM
+            (
+                CASE
+                    WHEN mc.type = N'USERSTORE_TOKENPERM'
+                    THEN mc.pages_kb / 1024.0
+                    ELSE 0
+                END
+            )
+    FROM sys.dm_os_memory_clerks AS mc
+    WHERE mc.type IN (N'MEMORYCLERK_SQLBUFFERPOOL', N'USERSTORE_TOKENPERM')
+    OPTION(RECOMPILE);
+
+    IF @buffer_pool_mb > 0
+    AND @tokenperm_mb > 2048
+    AND (@tokenperm_mb / @buffer_pool_mb) * 100.0 >= 10.0
+    BEGIN
+        INSERT
+            #plan_cache_health
+        (
+            finding_group,
+            finding,
+            priority,
+            details
+        )
+        VALUES
+        (
+            N'Memory Pressure',
+            N'Large USERSTORE_TOKENPERM cache',
+            10,
+            N'USERSTORE_TOKENPERM is ' +
+            FORMAT(CONVERT(bigint, @tokenperm_mb), N'N0') +
+            N' MB (' +
+            CONVERT
+            (
+                nvarchar(10),
+                CONVERT(decimal(5, 1), (@tokenperm_mb / @buffer_pool_mb) * 100.0)
+            ) +
+            N'% of the ' +
+            FORMAT(CONVERT(bigint, @buffer_pool_mb), N'N0') +
+            N' MB buffer pool). ' +
+            N'This can starve the plan cache and cause plan churn. ' +
+            N'See KB4053569 or consider trace flag 4618/4610.'
+        );
+    END;
+
+    IF @debug = 1
+    BEGIN
+        SELECT
+            @debug_msg =
+                N'Plan cache health: ' + CONVERT(nvarchar(20), @total_plans) +
+                N' total plans, ' + CONVERT(nvarchar(10), @pct_24h) +
+                N'% < 24h, ' + CONVERT(nvarchar(10), @pct_4h) +
+                N'% < 4h, ' + CONVERT(nvarchar(10), @pct_1h) + N'% < 1h';
+        RAISERROR(N'%s', 0, 1, @debug_msg) WITH NOWAIT;
+
+        SELECT
+            @debug_msg =
+                N'Duplicates: ' + CONVERT(nvarchar(10), @pct_duplicate) + N'%';
+        RAISERROR(N'%s', 0, 1, @debug_msg) WITH NOWAIT;
+
+        SELECT
+            @debug_msg =
+                N'TokenPerm: ' + CONVERT(nvarchar(20), @tokenperm_mb) +
+                N' MB, Buffer pool: ' + CONVERT(nvarchar(20), @buffer_pool_mb) + N' MB';
+        RAISERROR(N'%s', 0, 1, @debug_msg) WITH NOWAIT;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Create staging table                            ║
+    ╚══════════════════════════════════════════════════╝
+
+    All four stat DMVs feed into this single table.
+    Statements group by query_hash; procedures, functions,
+    and triggers group by database_id + object_id.
+    */
+    CREATE TABLE
+        #query_stats
+    (
+        id integer NOT NULL IDENTITY(1, 1),
+        query_type varchar(20) NOT NULL,
+        database_name sysname NULL,
+        object_name sysname NULL,
+        query_hash binary(8) NULL,
+        plan_count integer NOT NULL DEFAULT 0,
+        total_executions bigint NOT NULL DEFAULT 0,
+        total_cpu_ms decimal(38, 2) NOT NULL DEFAULT 0,
+        total_duration_ms decimal(38, 2) NOT NULL DEFAULT 0,
+        total_logical_reads bigint NOT NULL DEFAULT 0,
+        total_logical_writes bigint NOT NULL DEFAULT 0,
+        total_physical_reads bigint NOT NULL DEFAULT 0,
+        total_rows bigint NOT NULL DEFAULT 0,
+        total_grant_mb decimal(38, 2) NOT NULL DEFAULT 0,
+        total_used_grant_mb decimal(38, 2) NOT NULL DEFAULT 0,
+        total_spills bigint NOT NULL DEFAULT 0,
+        max_grant_mb decimal(38, 2) NULL,
+        max_used_grant_mb decimal(38, 2) NULL,
+        max_spills bigint NULL,
+        max_dop integer NULL,
+        min_rows bigint NULL,
+        max_rows bigint NULL,
+        min_cpu_ms decimal(38, 2) NULL,
+        max_cpu_ms decimal(38, 2) NULL,
+        min_logical_reads bigint NULL,
+        max_logical_reads bigint NULL,
+        min_duration_ms decimal(38, 2) NULL,
+        max_duration_ms decimal(38, 2) NULL,
+        oldest_plan_creation datetime NULL,
+        newest_plan_creation datetime NULL,
+        last_execution_time datetime NULL,
+        sample_sql_handle varbinary(64) NULL,
+        sample_plan_handle varbinary(64) NULL,
+        sample_statement_start integer NULL,
+        sample_statement_end integer NULL
+    );
+
+    DECLARE
+        @sql nvarchar(max) = N'';
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 1a: Collect statement-level stats          ║
+    ║  (sys.dm_exec_query_stats, grouped by hash)      ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    SELECT
+        @sql = N'
+INSERT
+    #query_stats
+WITH
+    (TABLOCK)
+(
+    query_type,
+    database_name,
+    query_hash,
+    plan_count,
+    total_executions,
+    total_cpu_ms,
+    total_duration_ms,
+    total_logical_reads,
+    total_logical_writes,
+    total_physical_reads,
+    total_rows,' +
+    CASE
+        WHEN @has_memory_grants = 1
+        THEN N'
+    total_grant_mb,
+    total_used_grant_mb,
+    max_grant_mb,
+    max_used_grant_mb,'
+        ELSE N''
+    END +
+    CASE
+        WHEN @has_spills = 1
+        THEN N'
+    total_spills,
+    max_spills,'
+        ELSE N''
+    END + N'
+    max_dop,
+    min_rows,
+    max_rows,
+    min_cpu_ms,
+    max_cpu_ms,
+    min_logical_reads,
+    max_logical_reads,
+    min_duration_ms,
+    max_duration_ms,
+    oldest_plan_creation,
+    newest_plan_creation,
+    last_execution_time
+)
+SELECT
+    query_type = ''Statement'',
+    database_name =
+        DB_NAME
+        (
+            CONVERT
+            (
+                integer,
+                MAX(pa.value)
+            )
+        ),
+    query_hash = qs.query_hash,
+    plan_count = COUNT_BIG(DISTINCT qs.plan_handle),
+    total_executions = SUM(qs.execution_count),
+    total_cpu_ms = SUM(qs.total_worker_time) / 1000.0,
+    total_duration_ms = SUM(qs.total_elapsed_time) / 1000.0,
+    total_logical_reads = SUM(qs.total_logical_reads),
+    total_logical_writes = SUM(qs.total_logical_writes),
+    total_physical_reads = SUM(qs.total_physical_reads),
+    total_rows = SUM(qs.total_rows),' +
+    CASE
+        WHEN @has_memory_grants = 1
+        THEN N'
+    total_grant_mb = SUM(ISNULL(qs.max_grant_kb, 0)) / 1024.0,
+    total_used_grant_mb = SUM(ISNULL(qs.max_used_grant_kb, 0)) / 1024.0,
+    max_grant_mb = MAX(ISNULL(qs.max_grant_kb, 0)) / 1024.0,
+    max_used_grant_mb = MAX(ISNULL(qs.max_used_grant_kb, 0)) / 1024.0,'
+        ELSE N''
+    END +
+    CASE
+        WHEN @has_spills = 1
+        THEN N'
+    total_spills = SUM(ISNULL(qs.total_spills, 0)),
+    max_spills = MAX(ISNULL(qs.max_spills, 0)),'
+        ELSE N''
+    END + N'
+    max_dop = MAX(qs.max_dop),
+    min_rows = MIN(qs.min_rows),
+    max_rows = MAX(qs.max_rows),
+    min_cpu_ms = MIN(qs.min_worker_time) / 1000.0,
+    max_cpu_ms = MAX(qs.max_worker_time) / 1000.0,
+    min_logical_reads = MIN(qs.min_logical_reads),
+    max_logical_reads = MAX(qs.max_logical_reads),
+    min_duration_ms = MIN(qs.min_elapsed_time) / 1000.0,
+    max_duration_ms = MAX(qs.max_elapsed_time) / 1000.0,
+    oldest_plan_creation = MIN(qs.creation_time),
+    newest_plan_creation = MAX(qs.creation_time),
+    last_execution_time = MAX(qs.last_execution_time)
+FROM sys.dm_exec_query_stats AS qs
+CROSS APPLY
+(
+    SELECT TOP (1)
+        value = pa.value
+    FROM sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
+    WHERE pa.attribute = N''dbid''
+) AS pa
+WHERE qs.query_hash <> 0x0000000000000000
+AND   qs.execution_count >= @minimum_execution_count' +
+    CASE
+        WHEN @ignore_system_databases = 1
+        THEN N'
+AND   ISNULL(pa.value, 0) NOT IN (1, 2, 3, 4)
+AND   ISNULL(pa.value, 0) < 32761'
+        ELSE N''
+    END +
+    CASE
+        WHEN @database_id IS NOT NULL
+        THEN N'
+AND   pa.value = @database_id'
+        ELSE N''
+    END +
+    CASE
+        WHEN @start_date IS NOT NULL
+        THEN N'
+AND   qs.creation_time >= @start_date'
+        ELSE N''
+    END +
+    CASE
+        WHEN @end_date IS NOT NULL
+        THEN N'
+AND   qs.creation_time < @end_date'
+        ELSE N''
+    END + N'
+GROUP BY
+    qs.query_hash
+HAVING
+    SUM(qs.execution_count) >= @minimum_execution_count
+OPTION(RECOMPILE, MAXDOP 1);';
+
+    IF @debug = 1
+    BEGIN
+        RAISERROR(N'Statement aggregation SQL:', 0, 1) WITH NOWAIT;
+        RAISERROR(N'%s', 0, 1, @sql) WITH NOWAIT;
+    END;
+
+    EXECUTE sys.sp_executesql
+        @sql,
+        N'@minimum_execution_count bigint, @database_id integer, @start_date datetime, @end_date datetime',
+        @minimum_execution_count,
+        @database_id,
+        @start_date,
+        @end_date;
+
+    IF @debug = 1
+    BEGIN
+        DECLARE
+            @stmt_count bigint;
+
+        SELECT
+            @stmt_count = COUNT_BIG(*)
+        FROM #query_stats AS qs
+        WHERE qs.query_type = 'Statement';
+
+        RAISERROR(N'Statement query_hash groups collected: %I64d', 0, 1, @stmt_count) WITH NOWAIT;
+    END;
+
+    /*
+    Fix up sample handles and offsets so they come from
+    the same plan row. MAX() in the GROUP BY can mismatch
+    a sql_handle from one plan with offsets from another,
+    producing clipped or blank query text.
+    */
+    UPDATE
+        qs
+    SET
+        qs.sample_sql_handle = x.sql_handle,
+        qs.sample_plan_handle = x.plan_handle,
+        qs.sample_statement_start = x.statement_start_offset,
+        qs.sample_statement_end = x.statement_end_offset
+    FROM #query_stats AS qs
+    CROSS APPLY
+    (
+        SELECT TOP (1)
+            dqs.sql_handle,
+            dqs.plan_handle,
+            dqs.statement_start_offset,
+            dqs.statement_end_offset
+        FROM sys.dm_exec_query_stats AS dqs
+        WHERE dqs.query_hash = qs.query_hash
+        ORDER BY
+            dqs.execution_count DESC
+    ) AS x
+    WHERE qs.query_type = 'Statement'
+    OPTION(RECOMPILE);
+
+    /*
+    Link statement-level rows to their parent procedure
+    via sql_handle in dm_exec_procedure_stats.
+    */
+    UPDATE
+        qs
+    SET
+        qs.object_name =
+            QUOTENAME(OBJECT_SCHEMA_NAME(ps.object_id, ps.database_id)) +
+            N'.' +
+            QUOTENAME(OBJECT_NAME(ps.object_id, ps.database_id))
+    FROM #query_stats AS qs
+    JOIN sys.dm_exec_procedure_stats AS ps
+      ON ps.sql_handle = qs.sample_sql_handle
+    WHERE qs.query_type = 'Statement'
+    AND   qs.object_name IS NULL
+    OPTION(RECOMPILE);
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 1b: Collect procedure-level stats          ║
+    ║  (sys.dm_exec_procedure_stats)                   ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    INSERT
+        #query_stats
+    WITH
+        (TABLOCK)
+    (
+        query_type,
+        database_name,
+        object_name,
+        plan_count,
+        total_executions,
+        total_cpu_ms,
+        total_duration_ms,
+        total_logical_reads,
+        total_logical_writes,
+        total_physical_reads,
+        oldest_plan_creation,
+        newest_plan_creation,
+        last_execution_time,
+        sample_sql_handle,
+        sample_plan_handle
+    )
+    SELECT
+        query_type = 'Procedure',
+        database_name = DB_NAME(ps.database_id),
+        object_name = OBJECT_SCHEMA_NAME(ps.object_id, ps.database_id) + N'.' + OBJECT_NAME(ps.object_id, ps.database_id),
+        plan_count = COUNT_BIG(DISTINCT ps.plan_handle),
+        total_executions = SUM(ps.execution_count),
+        total_cpu_ms = SUM(ps.total_worker_time) / 1000.0,
+        total_duration_ms = SUM(ps.total_elapsed_time) / 1000.0,
+        total_logical_reads = SUM(ps.total_logical_reads),
+        total_logical_writes = SUM(ps.total_logical_writes),
+        total_physical_reads = SUM(ps.total_physical_reads),
+        oldest_plan_creation = MIN(ps.cached_time),
+        newest_plan_creation = MAX(ps.cached_time),
+        last_execution_time = MAX(ps.last_execution_time),
+        sample_sql_handle = MAX(ps.sql_handle),
+        sample_plan_handle = MAX(ps.plan_handle)
+    FROM sys.dm_exec_procedure_stats AS ps
+    WHERE ps.execution_count >= @minimum_execution_count
+    AND   ps.database_id > CASE WHEN @ignore_system_databases = 1 THEN 4 ELSE 0 END
+    AND   ps.database_id < 32761
+    AND   ps.database_id = ISNULL(@database_id, ps.database_id)
+    AND   ps.cached_time >= ISNULL(@start_date, ps.cached_time)
+    AND   ps.cached_time < ISNULL(@end_date, DATEADD(DAY, 1, ps.cached_time))
+    GROUP BY
+        ps.database_id,
+        ps.object_id
+    HAVING
+        SUM(ps.execution_count) >= @minimum_execution_count
+    OPTION(RECOMPILE, MAXDOP 1);
+
+    IF @debug = 1
+    BEGIN
+        DECLARE
+            @proc_count bigint;
+
+        SELECT
+            @proc_count = COUNT_BIG(*)
+        FROM #query_stats AS qs
+        WHERE qs.query_type = 'Procedure';
+
+        RAISERROR(N'Procedure objects collected: %I64d', 0, 1, @proc_count) WITH NOWAIT;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 1c: Collect function-level stats           ║
+    ║  (sys.dm_exec_function_stats)                    ║
+    ╚══════════════════════════════════════════════════╝
+
+    dm_exec_function_stats is available starting SQL Server 2016.
+    */
+    IF EXISTS
+    (
+        SELECT
+            1/0
+        FROM sys.all_objects AS ao
+        WHERE ao.name = N'dm_exec_function_stats'
+        AND   ao.schema_id = SCHEMA_ID(N'sys')
+    )
+    BEGIN
+        SELECT
+            @sql = N'
+INSERT
+    #query_stats
+WITH
+    (TABLOCK)
+(
+    query_type,
+    database_name,
+    object_name,
+    plan_count,
+    total_executions,
+    total_cpu_ms,
+    total_duration_ms,
+    total_logical_reads,
+    total_logical_writes,
+    total_physical_reads,
+    oldest_plan_creation,
+    newest_plan_creation,
+    last_execution_time,
+    sample_sql_handle,
+    sample_plan_handle
+)
+SELECT
+    query_type = ''Function'',
+    database_name = DB_NAME(fs.database_id),
+    object_name = OBJECT_SCHEMA_NAME(fs.object_id, fs.database_id) + N''.'' + OBJECT_NAME(fs.object_id, fs.database_id),
+    plan_count = COUNT_BIG(DISTINCT fs.plan_handle),
+    total_executions = SUM(fs.execution_count),
+    total_cpu_ms = SUM(fs.total_worker_time) / 1000.0,
+    total_duration_ms = SUM(fs.total_elapsed_time) / 1000.0,
+    total_logical_reads = SUM(fs.total_logical_reads),
+    total_logical_writes = SUM(fs.total_logical_writes),
+    total_physical_reads = SUM(fs.total_physical_reads),
+    oldest_plan_creation = MIN(fs.cached_time),
+    newest_plan_creation = MAX(fs.cached_time),
+    last_execution_time = MAX(fs.last_execution_time),
+    sample_sql_handle = MAX(fs.sql_handle),
+    sample_plan_handle = MAX(fs.plan_handle)
+FROM sys.dm_exec_function_stats AS fs
+WHERE fs.execution_count >= @minimum_execution_count
+AND   fs.database_id > CASE WHEN @ignore_system_databases = 1 THEN 4 ELSE 0 END
+AND   fs.database_id < 32761
+AND   fs.database_id = ISNULL(@database_id, fs.database_id)
+AND   fs.cached_time >= ISNULL(@start_date, fs.cached_time)
+AND   fs.cached_time < ISNULL(@end_date, DATEADD(DAY, 1, fs.cached_time))
+GROUP BY
+    fs.database_id,
+    fs.object_id
+HAVING
+    SUM(fs.execution_count) >= @minimum_execution_count
+OPTION(RECOMPILE, MAXDOP 1);';
+
+        EXECUTE sys.sp_executesql
+            @sql,
+            N'@minimum_execution_count bigint, @database_id integer, @ignore_system_databases bit, @start_date datetime, @end_date datetime',
+            @minimum_execution_count,
+            @database_id,
+            @ignore_system_databases,
+            @start_date,
+            @end_date;
+
+        IF @debug = 1
+        BEGIN
+            DECLARE
+                @func_count bigint;
+
+            SELECT
+                @func_count = COUNT_BIG(*)
+            FROM #query_stats AS qs
+            WHERE qs.query_type = 'Function';
+
+            RAISERROR(N'Function objects collected: %I64d', 0, 1, @func_count) WITH NOWAIT;
+        END;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 1d: Collect trigger-level stats            ║
+    ║  (sys.dm_exec_trigger_stats)                     ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    INSERT
+        #query_stats
+    WITH
+        (TABLOCK)
+    (
+        query_type,
+        database_name,
+        object_name,
+        plan_count,
+        total_executions,
+        total_cpu_ms,
+        total_duration_ms,
+        total_logical_reads,
+        total_logical_writes,
+        total_physical_reads,
+        oldest_plan_creation,
+        newest_plan_creation,
+        last_execution_time,
+        sample_sql_handle,
+        sample_plan_handle
+    )
+    SELECT
+        query_type = 'Trigger',
+        database_name = DB_NAME(ts.database_id),
+        object_name = OBJECT_SCHEMA_NAME(ts.object_id, ts.database_id) + N'.' + OBJECT_NAME(ts.object_id, ts.database_id),
+        plan_count = COUNT_BIG(DISTINCT ts.plan_handle),
+        total_executions = SUM(ts.execution_count),
+        total_cpu_ms = SUM(ts.total_worker_time) / 1000.0,
+        total_duration_ms = SUM(ts.total_elapsed_time) / 1000.0,
+        total_logical_reads = SUM(ts.total_logical_reads),
+        total_logical_writes = SUM(ts.total_logical_writes),
+        total_physical_reads = SUM(ts.total_physical_reads),
+        oldest_plan_creation = MIN(ts.cached_time),
+        newest_plan_creation = MAX(ts.cached_time),
+        last_execution_time = MAX(ts.last_execution_time),
+        sample_sql_handle = MAX(ts.sql_handle),
+        sample_plan_handle = MAX(ts.plan_handle)
+    FROM sys.dm_exec_trigger_stats AS ts
+    WHERE ts.execution_count >= @minimum_execution_count
+    AND   ts.database_id > CASE WHEN @ignore_system_databases = 1 THEN 4 ELSE 0 END
+    AND   ts.database_id < 32761
+    AND   ts.database_id = ISNULL(@database_id, ts.database_id)
+    AND   ts.cached_time >= ISNULL(@start_date, ts.cached_time)
+    AND   ts.cached_time < ISNULL(@end_date, DATEADD(DAY, 1, ts.cached_time))
+    GROUP BY
+        ts.database_id,
+        ts.object_id
+    HAVING
+        SUM(ts.execution_count) >= @minimum_execution_count
+    OPTION(RECOMPILE, MAXDOP 1);
+
+    IF @debug = 1
+    BEGIN
+        DECLARE
+            @trig_count bigint;
+
+        SELECT
+            @trig_count = COUNT_BIG(*)
+        FROM #query_stats AS qs
+        WHERE qs.query_type = 'Trigger';
+
+        RAISERROR(N'Trigger objects collected: %I64d', 0, 1, @trig_count) WITH NOWAIT;
+    END;
+
+    /*
+    Bail out early if nothing to analyze
+    */
+    IF NOT EXISTS
+    (
+        SELECT
+            1/0
+        FROM #query_stats
+    )
+    BEGIN
+        RAISERROR(N'No queries found in the plan cache matching the filter criteria.', 10, 1) WITH NOWAIT;
+        RETURN;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Compute workload totals for share calculations  ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    DECLARE
+        @total_cpu_ms decimal(38, 2) = 0,
+        @total_duration_ms decimal(38, 2) = 0,
+        @total_logical_reads bigint = 0,
+        @total_logical_writes bigint = 0,
+        @total_grant_mb decimal(38, 2) = 0,
+        @total_spills bigint = 0,
+        @total_executions bigint = 0,
+        @total_entries bigint = 0;
+
+    SELECT
+        @total_cpu_ms = SUM(qs.total_cpu_ms),
+        @total_duration_ms = SUM(qs.total_duration_ms),
+        @total_logical_reads = SUM(qs.total_logical_reads),
+        @total_logical_writes = SUM(qs.total_logical_writes),
+        @total_grant_mb = SUM(qs.total_grant_mb),
+        @total_spills = SUM(qs.total_spills),
+        @total_executions = SUM(qs.total_executions),
+        @total_entries = COUNT_BIG(*)
+    FROM #query_stats AS qs
+    OPTION(RECOMPILE);
+
+    IF @debug = 1
+    BEGIN
+        SELECT
+            @debug_msg =
+                N'Workload totals — CPU: ' + CONVERT(nvarchar(20), @total_cpu_ms) +
+                N' ms, Reads: ' + CONVERT(nvarchar(20), @total_logical_reads) +
+                N', Executions: ' + CONVERT(nvarchar(20), @total_executions) +
+                N', Entries: ' + CONVERT(nvarchar(20), @total_entries);
+        RAISERROR(N'%s', 0, 1, @debug_msg) WITH NOWAIT;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 2: Select interesting candidates           ║
+    ║  (Top N per metric, then deduplicate)            ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    CREATE TABLE
+        #candidates
+    (
+        id integer NOT NULL
+    );
+
+    /*
+    Union of top N by each metric dimension
+    */
+    INSERT
+        #candidates
+    WITH
+        (TABLOCK)
+    (
+        id
+    )
+    SELECT DISTINCT
+        x.id
+    FROM
+    (
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        ORDER BY
+            qs.total_cpu_ms DESC
+
+        UNION
+
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        ORDER BY
+            qs.total_duration_ms DESC
+
+        UNION
+
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        ORDER BY
+            qs.total_logical_reads DESC
+
+        UNION
+
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        ORDER BY
+            qs.total_logical_writes DESC
+
+        UNION
+
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        WHERE qs.total_grant_mb > 0
+        ORDER BY
+            qs.total_grant_mb DESC
+
+        UNION
+
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        WHERE qs.total_spills > 0
+        ORDER BY
+            qs.total_spills DESC
+
+        UNION
+
+        SELECT TOP (@top)
+            qs.id
+        FROM #query_stats AS qs
+        ORDER BY
+            qs.total_executions DESC
+    ) AS x
+    OPTION(RECOMPILE);
+
+    IF @debug = 1
+    BEGIN
+        DECLARE
+            @candidate_count bigint;
+
+        SELECT
+            @candidate_count = COUNT_BIG(*)
+        FROM #candidates;
+
+        RAISERROR(N'Unique candidates: %I64d', 0, 1, @candidate_count) WITH NOWAIT;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 3: Score with PERCENT_RANK                 ║
+    ║  Only active if query >= 0.1% of total resource  ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    CREATE TABLE
+        #scored
+    (
+        id integer NOT NULL,
+        query_type varchar(20) NOT NULL,
+        database_name sysname NULL,
+        object_name sysname NULL,
+        query_hash binary(8) NULL,
+        plan_count integer NOT NULL,
+        total_executions bigint NOT NULL,
+        total_cpu_ms decimal(38, 2) NOT NULL,
+        total_duration_ms decimal(38, 2) NOT NULL,
+        total_logical_reads bigint NOT NULL,
+        total_logical_writes bigint NOT NULL,
+        total_physical_reads bigint NOT NULL,
+        total_rows bigint NOT NULL,
+        total_grant_mb decimal(38, 2) NOT NULL,
+        total_used_grant_mb decimal(38, 2) NOT NULL,
+        max_grant_mb decimal(38, 2) NULL,
+        max_used_grant_mb decimal(38, 2) NULL,
+        total_spills bigint NOT NULL,
+        max_spills bigint NULL,
+        max_dop integer NULL,
+        min_rows bigint NULL,
+        max_rows bigint NULL,
+        min_cpu_ms decimal(38, 2) NULL,
+        max_cpu_ms decimal(38, 2) NULL,
+        min_logical_reads bigint NULL,
+        max_logical_reads bigint NULL,
+        min_duration_ms decimal(38, 2) NULL,
+        max_duration_ms decimal(38, 2) NULL,
+
+        /* resource shares */
+        cpu_share decimal(5, 2) NULL,
+        duration_share decimal(5, 2) NULL,
+        reads_share decimal(5, 2) NULL,
+        writes_share decimal(5, 2) NULL,
+        grant_share decimal(5, 2) NULL,
+        spills_share decimal(5, 2) NULL,
+        executions_share decimal(5, 2) NULL,
+
+        /* percentile ranks */
+        cpu_pctl decimal(5, 4) NULL,
+        duration_pctl decimal(5, 4) NULL,
+        reads_pctl decimal(5, 4) NULL,
+        writes_pctl decimal(5, 4) NULL,
+        grant_pctl decimal(5, 4) NULL,
+        spills_pctl decimal(5, 4) NULL,
+        executions_pctl decimal(5, 4) NULL,
+
+        /* composite score */
+        impact_score decimal(5, 2) NULL,
+        high_signals nvarchar(500) NULL,
+        diagnostics nvarchar(max) NULL,
+
+        /* plan metadata */
+        oldest_plan_creation datetime NULL,
+        newest_plan_creation datetime NULL,
+        last_execution_time datetime NULL,
+        sample_sql_handle varbinary(64) NULL,
+        sample_plan_handle varbinary(64) NULL,
+        sample_statement_start integer NULL,
+        sample_statement_end integer NULL
+    );
+
+    INSERT
+        #scored
+    WITH
+        (TABLOCK)
+    (
+        id,
+        query_type,
+        database_name,
+        object_name,
+        query_hash,
+        plan_count,
+        total_executions,
+        total_cpu_ms,
+        total_duration_ms,
+        total_logical_reads,
+        total_logical_writes,
+        total_physical_reads,
+        total_rows,
+        total_grant_mb,
+        total_used_grant_mb,
+        max_grant_mb,
+        max_used_grant_mb,
+        total_spills,
+        max_spills,
+        max_dop,
+        min_rows,
+        max_rows,
+        min_cpu_ms,
+        max_cpu_ms,
+        min_logical_reads,
+        max_logical_reads,
+        min_duration_ms,
+        max_duration_ms,
+        cpu_share,
+        duration_share,
+        reads_share,
+        writes_share,
+        grant_share,
+        spills_share,
+        executions_share,
+        cpu_pctl,
+        duration_pctl,
+        reads_pctl,
+        writes_pctl,
+        grant_pctl,
+        spills_pctl,
+        executions_pctl,
+        oldest_plan_creation,
+        newest_plan_creation,
+        last_execution_time,
+        sample_sql_handle,
+        sample_plan_handle,
+        sample_statement_start,
+        sample_statement_end
+    )
+    SELECT
+        id = qs.id,
+        query_type = qs.query_type,
+        database_name = qs.database_name,
+        object_name = qs.object_name,
+        query_hash = qs.query_hash,
+        plan_count = qs.plan_count,
+        total_executions = qs.total_executions,
+        total_cpu_ms = qs.total_cpu_ms,
+        total_duration_ms = qs.total_duration_ms,
+        total_logical_reads = qs.total_logical_reads,
+        total_logical_writes = qs.total_logical_writes,
+        total_physical_reads = qs.total_physical_reads,
+        total_rows = qs.total_rows,
+        total_grant_mb = qs.total_grant_mb,
+        total_used_grant_mb = qs.total_used_grant_mb,
+        max_grant_mb = qs.max_grant_mb,
+        max_used_grant_mb = qs.max_used_grant_mb,
+        total_spills = qs.total_spills,
+        max_spills = qs.max_spills,
+        max_dop = qs.max_dop,
+        min_rows = qs.min_rows,
+        max_rows = qs.max_rows,
+        min_cpu_ms = qs.min_cpu_ms,
+        max_cpu_ms = qs.max_cpu_ms,
+        min_logical_reads = qs.min_logical_reads,
+        max_logical_reads = qs.max_logical_reads,
+        min_duration_ms = qs.min_duration_ms,
+        max_duration_ms = qs.max_duration_ms,
+
+        /* resource shares (% of total workload) */
+        cpu_share =
+            CASE
+                WHEN @total_cpu_ms > 0
+                THEN CONVERT(decimal(5, 2), qs.total_cpu_ms * 100.0 / @total_cpu_ms)
+                ELSE 0
+            END,
+        duration_share =
+            CASE
+                WHEN @total_duration_ms > 0
+                THEN CONVERT(decimal(5, 2), qs.total_duration_ms * 100.0 / @total_duration_ms)
+                ELSE 0
+            END,
+        reads_share =
+            CASE
+                WHEN @total_logical_reads > 0
+                THEN CONVERT(decimal(5, 2), qs.total_logical_reads * 100.0 / @total_logical_reads)
+                ELSE 0
+            END,
+        writes_share =
+            CASE
+                WHEN @total_logical_writes > 0
+                THEN CONVERT(decimal(5, 2), qs.total_logical_writes * 100.0 / @total_logical_writes)
+                ELSE 0
+            END,
+        grant_share =
+            CASE
+                WHEN @total_grant_mb > 0
+                THEN CONVERT(decimal(5, 2), qs.total_grant_mb * 100.0 / @total_grant_mb)
+                ELSE 0
+            END,
+        spills_share =
+            CASE
+                WHEN @total_spills > 0
+                THEN CONVERT(decimal(5, 2), qs.total_spills * 100.0 / @total_spills)
+                ELSE 0
+            END,
+        executions_share =
+            CASE
+                WHEN @total_executions > 0
+                THEN CONVERT(decimal(5, 2), qs.total_executions * 100.0 / @total_executions)
+                ELSE 0
+            END,
+
+        /*
+        PERCENT_RANK across all entries in the workload (not just candidates).
+        NULL if the query contributes < 0.1% of total for that metric.
+        */
+        cpu_pctl =
+            CASE
+                WHEN @total_cpu_ms > 0
+                AND  qs.total_cpu_ms * 1.0 / @total_cpu_ms >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_cpu_ms
+                     )
+                ELSE NULL
+            END,
+        duration_pctl =
+            CASE
+                WHEN @total_duration_ms > 0
+                AND  qs.total_duration_ms * 1.0 / @total_duration_ms >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_duration_ms
+                     )
+                ELSE NULL
+            END,
+        reads_pctl =
+            CASE
+                WHEN @total_logical_reads > 0
+                AND  qs.total_logical_reads * 1.0 / @total_logical_reads >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_logical_reads
+                     )
+                ELSE NULL
+            END,
+        writes_pctl =
+            CASE
+                WHEN @total_logical_writes > 0
+                AND  qs.total_logical_writes * 1.0 / @total_logical_writes >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_logical_writes
+                     )
+                ELSE NULL
+            END,
+        grant_pctl =
+            CASE
+                WHEN @total_grant_mb > 0
+                AND  qs.total_grant_mb * 1.0 / @total_grant_mb >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_grant_mb
+                     )
+                ELSE NULL
+            END,
+        spills_pctl =
+            CASE
+                WHEN @total_spills > 0
+                AND  qs.total_spills * 1.0 / @total_spills >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_spills
+                     )
+                ELSE NULL
+            END,
+        executions_pctl =
+            CASE
+                WHEN @total_executions > 0
+                AND  qs.total_executions * 1.0 / @total_executions >= 0.001
+                THEN PERCENT_RANK() OVER
+                     (
+                         ORDER BY
+                             qs.total_executions
+                     )
+                ELSE NULL
+            END,
+
+        oldest_plan_creation = qs.oldest_plan_creation,
+        newest_plan_creation = qs.newest_plan_creation,
+        last_execution_time = qs.last_execution_time,
+        sample_sql_handle = qs.sample_sql_handle,
+        sample_plan_handle = qs.sample_plan_handle,
+        sample_statement_start = qs.sample_statement_start,
+        sample_statement_end = qs.sample_statement_end
+    FROM #query_stats AS qs
+    WHERE EXISTS
+    (
+        SELECT
+            1/0
+        FROM #candidates AS c
+        WHERE c.id = qs.id
+    )
+    OPTION(RECOMPILE);
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 4: Compute impact_score and high_signals   ║
+    ╚══════════════════════════════════════════════════╝
+
+    impact_score = average of non-NULL percentile ranks.
+    high_signals = dimensions >= 80th percentile.
+    */
+    UPDATE
+        s
+    SET
+        s.impact_score =
+            CONVERT
+            (
+                decimal(5, 2),
+                (
+                    ISNULL(s.cpu_pctl, 0) +
+                    ISNULL(s.duration_pctl, 0) +
+                    ISNULL(s.reads_pctl, 0) +
+                    ISNULL(s.writes_pctl, 0) +
+                    ISNULL(s.grant_pctl, 0) +
+                    ISNULL(s.spills_pctl, 0) +
+                    ISNULL(s.executions_pctl, 0)
+                ) /
+                NULLIF
+                (
+                    CASE WHEN s.cpu_pctl        IS NOT NULL THEN 1 ELSE 0 END +
+                    CASE WHEN s.duration_pctl   IS NOT NULL THEN 1 ELSE 0 END +
+                    CASE WHEN s.reads_pctl      IS NOT NULL THEN 1 ELSE 0 END +
+                    CASE WHEN s.writes_pctl     IS NOT NULL THEN 1 ELSE 0 END +
+                    CASE WHEN s.grant_pctl      IS NOT NULL THEN 1 ELSE 0 END +
+                    CASE WHEN s.spills_pctl     IS NOT NULL THEN 1 ELSE 0 END +
+                    CASE WHEN s.executions_pctl IS NOT NULL THEN 1 ELSE 0 END,
+                    0
+                )
+            ),
+        s.high_signals =
+            CASE WHEN s.cpu_pctl        >= 0.80 THEN N'cpu, '        ELSE N'' END +
+            CASE WHEN s.duration_pctl   >= 0.80 THEN N'duration, '   ELSE N'' END +
+            CASE WHEN s.reads_pctl      >= 0.80 THEN N'reads, '      ELSE N'' END +
+            CASE WHEN s.writes_pctl     >= 0.80 THEN N'writes, '     ELSE N'' END +
+            CASE WHEN s.grant_pctl      >= 0.80 THEN N'memory, '     ELSE N'' END +
+            CASE WHEN s.spills_pctl     >= 0.80 THEN N'spills, '     ELSE N'' END +
+            CASE WHEN s.executions_pctl >= 0.80 THEN N'executions, ' ELSE N'' END
+    FROM #scored AS s
+    OPTION(RECOMPILE);
+
+    /*
+    Trim trailing comma from high_signals
+    */
+    UPDATE
+        s
+    SET
+        s.high_signals =
+            CASE
+                WHEN s.high_signals = N''
+                THEN NULL
+                ELSE LEFT(s.high_signals, LEN(s.high_signals) - 1)
+            END
+    FROM #scored AS s
+    OPTION(RECOMPILE);
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Step 5: Diagnostic heuristics                   ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    UPDATE
+        s
+    SET
+        s.diagnostics =
+            /*
+            Wait-bound: duration >> cpu indicates blocking, locks, I/O waits
+            */
+            CASE
+                WHEN s.total_cpu_ms > 0
+                AND  s.total_duration_ms / s.total_cpu_ms > 5.0
+                THEN N'Wait-bound (duration ' +
+                     CONVERT
+                     (
+                         nvarchar(10),
+                         CONVERT(decimal(10, 1), s.total_duration_ms / s.total_cpu_ms)
+                     ) +
+                     N'x CPU); '
+                ELSE N''
+            END +
+            /*
+            Plan instability: multiple cached plans for the same query
+            */
+            CASE
+                WHEN s.plan_count > 1
+                THEN N'Plan instability (' +
+                     CONVERT(nvarchar(10), s.plan_count) +
+                     N' plans); '
+                ELSE N''
+            END +
+            /*
+            Row count variance: huge gap between min and max rows
+            suggests parameter sensitivity or data skew
+            */
+            CASE
+                WHEN s.min_rows IS NOT NULL
+                AND  s.max_rows IS NOT NULL
+                AND  s.min_rows > 0
+                AND  s.max_rows * 1.0 / s.min_rows >= 100.0
+                THEN N'Row count variance (' +
+                     FORMAT(s.min_rows, N'N0') +
+                     N' to ' +
+                     FORMAT(s.max_rows, N'N0') +
+                     N'); '
+                ELSE N''
+            END +
+            /*
+            Parameter sniffing: execution_count > 3 and either
+            CPU or reads have > 30% variance between min and avg.
+            Uses the same heuristic as sp_BlitzCache.
+            */
+            CASE
+                WHEN s.total_executions > 3
+                AND  s.min_cpu_ms IS NOT NULL
+                AND  s.max_cpu_ms IS NOT NULL
+                AND  s.total_cpu_ms / s.total_executions > 0
+                AND
+                (
+                    s.min_cpu_ms < (s.total_cpu_ms / s.total_executions) * 0.70
+                    OR s.max_cpu_ms > (s.total_cpu_ms / s.total_executions) * 1.30
+                )
+                THEN N'Parameter sniffing (CPU ' +
+                     FORMAT(CONVERT(bigint, s.min_cpu_ms), N'N0') +
+                     N'-' +
+                     FORMAT(CONVERT(bigint, s.max_cpu_ms), N'N0') +
+                     N' ms, avg ' +
+                     FORMAT(CONVERT(bigint, s.total_cpu_ms / s.total_executions), N'N0') +
+                     N' ms); '
+                WHEN s.total_executions > 3
+                AND  s.min_logical_reads IS NOT NULL
+                AND  s.max_logical_reads IS NOT NULL
+                AND  s.total_logical_reads / s.total_executions > 100000
+                AND
+                (
+                    s.min_logical_reads < (s.total_logical_reads / s.total_executions) * 0.70
+                    OR s.max_logical_reads > (s.total_logical_reads / s.total_executions) * 1.30
+                )
+                THEN N'Parameter sniffing (reads ' +
+                     FORMAT(s.min_logical_reads, N'N0') +
+                     N'-' +
+                     FORMAT(s.max_logical_reads, N'N0') +
+                     N', avg ' +
+                     FORMAT(s.total_logical_reads / s.total_executions, N'N0') +
+                     N'); '
+                ELSE N''
+            END +
+            /*
+            Wasteful memory grant: large grant with < 10% utilization
+            */
+            CASE
+                WHEN s.max_grant_mb IS NOT NULL
+                AND  s.max_grant_mb > 1.0
+                AND  s.max_used_grant_mb IS NOT NULL
+                AND  s.max_used_grant_mb * 1.0 /
+                     NULLIF(s.max_grant_mb, 0) < 0.10
+                THEN N'Wasteful grant (' +
+                     CONVERT(nvarchar(20), s.max_grant_mb) +
+                     N' MB granted, ' +
+                     CONVERT
+                     (
+                         nvarchar(10),
+                         CONVERT
+                         (
+                             decimal(5, 1),
+                             s.max_used_grant_mb * 100.0 /
+                             NULLIF(s.max_grant_mb, 0)
+                         )
+                     ) +
+                     N'% used); '
+                ELSE N''
+            END +
+            /*
+            Spilling queries
+            */
+            CASE
+                WHEN ISNULL(s.total_spills, 0) > 0
+                THEN N'Spills (' +
+                     FORMAT(s.total_spills, N'N0') +
+                     N' total); '
+                ELSE N''
+            END +
+            /*
+            Parallel plans with high DOP
+            */
+            CASE
+                WHEN ISNULL(s.max_dop, 0) > 1
+                THEN N'Parallel (max DOP ' +
+                     CONVERT(nvarchar(10), s.max_dop) +
+                     N'); '
+                ELSE N''
+            END +
+            /*
+            Rare but expensive: <= 10 executions but big resource share
+            */
+            CASE
+                WHEN s.total_executions <= 10
+                AND
+                (
+                    s.cpu_share >= 5.0
+                    OR s.reads_share >= 5.0
+                    OR s.grant_share >= 5.0
+                )
+                THEN N'Rare but expensive (' +
+                     CONVERT(nvarchar(20), s.total_executions) +
+                     N' execs); '
+                ELSE N''
+            END +
+            /*
+            Frequently executed: > 100 executions per minute
+            */
+            CASE
+                WHEN s.total_executions > 0
+                AND  s.oldest_plan_creation IS NOT NULL
+                AND  DATEDIFF(MINUTE, s.oldest_plan_creation, GETDATE()) > 0
+                AND  s.total_executions * 1.0 /
+                     NULLIF(DATEDIFF(MINUTE, s.oldest_plan_creation, GETDATE()), 0) > 100.0
+                THEN N'High frequency (' +
+                     FORMAT
+                     (
+                         CONVERT
+                         (
+                             bigint,
+                             s.total_executions * 1.0 /
+                             NULLIF(DATEDIFF(MINUTE, s.oldest_plan_creation, GETDATE()), 0)
+                         ),
+                         N'N0'
+                     ) +
+                     N'/min); '
+                ELSE N''
+            END
+    FROM #scored AS s
+    OPTION(RECOMPILE);
+
+    /*
+    Trim trailing semicolons from diagnostics
+    */
+    UPDATE
+        s
+    SET
+        s.diagnostics =
+            CASE
+                WHEN s.diagnostics = N''
+                THEN NULL
+                ELSE LEFT(s.diagnostics, LEN(s.diagnostics) - 1)
+            END
+    FROM #scored AS s
+    OPTION(RECOMPILE);
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Result set 1: Workload profile summary            ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    DECLARE
+        @surfaced_count bigint = 0,
+        @surfaced_cpu_pct decimal(5, 2) = 0,
+        @surfaced_reads_pct decimal(5, 2) = 0,
+        @surfaced_duration_pct decimal(5, 2) = 0,
+        @surfaced_grant_pct decimal(5, 2) = 0;
+
+    SELECT
+        @surfaced_count = COUNT_BIG(*),
+        @surfaced_cpu_pct = ISNULL(SUM(s.cpu_share), 0),
+        @surfaced_reads_pct = ISNULL(SUM(s.reads_share), 0),
+        @surfaced_duration_pct = ISNULL(SUM(s.duration_share), 0),
+        @surfaced_grant_pct = ISNULL(SUM(s.grant_share), 0)
+    FROM #scored AS s
+    WHERE s.impact_score >= @impact_threshold
+    OPTION(RECOMPILE);
+
+    SELECT
+        total_plan_cache_entries = @total_entries,
+        surfaced_entries = @surfaced_count,
+        cpu_captured_pct = @surfaced_cpu_pct,
+        reads_captured_pct = @surfaced_reads_pct,
+        duration_captured_pct = @surfaced_duration_pct,
+        grant_captured_pct = @surfaced_grant_pct,
+        workload_profile =
+            CASE
+                WHEN @surfaced_cpu_pct >= 50.0
+                OR   @surfaced_reads_pct >= 50.0
+                THEN N'Concentrated — a few queries dominate resource usage'
+                WHEN @surfaced_cpu_pct >= 25.0
+                OR   @surfaced_reads_pct >= 25.0
+                THEN N'Moderate — some clear outliers but workload is spread'
+                ELSE N'Flat — resource usage is distributed across many queries'
+            END,
+        recommendation =
+            CASE
+                WHEN @surfaced_count = 0
+                THEN N'No high-impact queries found. Try lowering @impact_threshold or @minimum_execution_count.'
+                WHEN @surfaced_cpu_pct >= 50.0
+                OR   @surfaced_reads_pct >= 50.0
+                THEN N'Concentrated workload. Tuning the surfaced queries will have outsized impact.'
+                WHEN @surfaced_cpu_pct >= 25.0
+                OR   @surfaced_reads_pct >= 25.0
+                THEN N'Moderate concentration. Focus on queries with the highest impact_score first.'
+                ELSE N'Flat workload. Individual query tuning has limited ROI. Consider systemic improvements (indexing strategy, caching, architecture).'
+            END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Result set 2: High-impact queries               ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    SELECT
+        s.database_name,
+        s.query_type,
+        s.object_name,
+        query_text =
+            CASE
+                WHEN s.query_type = 'Statement'
+                THEN SUBSTRING
+                     (
+                         st.text,
+                         (s.sample_statement_start / 2) + 1,
+                         (
+                             CASE s.sample_statement_end
+                                 WHEN -1
+                                 THEN DATALENGTH(st.text)
+                                 ELSE s.sample_statement_end
+                             END - s.sample_statement_start
+                         ) / 2 + 1
+                     )
+                ELSE st.text
+            END,
+        query_plan =
+            CASE
+                WHEN TRY_CAST(qp.query_plan AS xml) IS NOT NULL
+                THEN TRY_CAST(qp.query_plan AS xml)
+                WHEN TRY_CAST(qp.query_plan AS xml) IS NULL
+                THEN
+                (
+                    SELECT
+                        [processing-instruction(query_plan)] =
+                            N'-- ' + NCHAR(13) + NCHAR(10) +
+                            N'-- This is a huge query plan.' + NCHAR(13) + NCHAR(10) +
+                            N'-- Remove the headers and footers, save it as a .sqlplan file, and re-open it.' + NCHAR(13) + NCHAR(10) +
+                            NCHAR(13) + NCHAR(10) +
+                            REPLACE(qp.query_plan, N'<RelOp', NCHAR(13) + NCHAR(10) + N'<RelOp') +
+                            NCHAR(13) + NCHAR(10) COLLATE Latin1_General_Bin2
+                    FOR
+                        XML
+                        PATH(N''),
+                        TYPE
+                )
+            END,
+        s.query_hash,
+        s.plan_count,
+        s.impact_score,
+        s.high_signals,
+        s.total_executions,
+        s.cpu_share,
+        s.duration_share,
+        s.reads_share,
+        s.writes_share,
+        s.grant_share,
+        s.spills_share,
+        s.executions_share,
+        s.diagnostics,
+        s.total_cpu_ms,
+        s.total_duration_ms,
+        s.total_logical_reads,
+        s.total_logical_writes,
+        s.total_grant_mb,
+        s.total_spills,
+        s.max_grant_mb,
+        s.max_used_grant_mb,
+        s.max_spills,
+        s.max_dop,
+        s.min_rows,
+        s.max_rows,
+        s.oldest_plan_creation,
+        s.last_execution_time,
+        s.sample_sql_handle,
+        s.sample_plan_handle
+    FROM #scored AS s
+    OUTER APPLY sys.dm_exec_sql_text(s.sample_sql_handle) AS st
+    OUTER APPLY sys.dm_exec_text_query_plan
+    (
+        s.sample_plan_handle,
+        ISNULL(s.sample_statement_start, 0),
+        ISNULL(s.sample_statement_end, -1)
+    ) AS qp
+    WHERE s.impact_score >= @impact_threshold
+    ORDER BY
+        s.impact_score DESC
+    OPTION(RECOMPILE);
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Result set 3: Plan cache health findings        ║
+    ╚══════════════════════════════════════════════════╝
+    */
+    SELECT
+        pch.finding_group,
+        pch.finding,
+        pch.database_name,
+        pch.priority,
+        pch.details
+    FROM #plan_cache_health AS pch
+    ORDER BY
+        pch.priority,
+        pch.finding_group,
+        pch.id
+    OPTION(RECOMPILE);
+
+END;
+GO


### PR DESCRIPTION
## Summary
- New stored procedure `sp_QuickieCache`: Pareto (80/20) analysis of the plan cache, companion to `sp_QuickieStore`
- Scores queries across 7 resource dimensions using `PERCENT_RANK`, surfaces the vital few with disproportionate resource consumption
- Collects from all four stat DMVs (query_stats, procedure_stats, function_stats, trigger_stats)
- Plan cache health findings per database (single-use bloat, duplicate plans, age distribution, USERSTORE_TOKENPERM)
- Diagnostic signals: parameter sniffing, plan instability, wait-bound queries, wasteful grants, spills, and more
- Links statement-level queries back to their parent procedures

## Test plan
- [x] Deployed and executed on SQL Server 2016, 2017, 2019, 2022, 2025
- [x] Tested with `@database_name` filter
- [x] Tested with `@start_date` / `@end_date` filters
- [x] Tested with `@debug = 1`
- [x] Tested `@help = 1`
- [x] Verified large plan handling via `dm_exec_text_query_plan` with TRY_CAST fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)