### PR TITLE
sp_QuickieCache: single-use/duplicate modes, @ignore_system_databases fix

### DIFF
--- a/Install-All/DarlingData.sql
+++ b/Install-All/DarlingData.sql
@@ -1,4 +1,4 @@
--- Compile Date: 04/04/2026 14:58:35 UTC
+-- Compile Date: 04/04/2026 15:20:33 UTC
 SET ANSI_NULLS ON;
 SET ANSI_PADDING ON;
 SET ANSI_WARNINGS ON;
@@ -172,6 +172,8 @@ BEGIN
           ON  ap.system_type_id = t.system_type_id
           AND ap.user_type_id = t.user_type_id
         WHERE o.name = N'sp_HealthParser'
+        ORDER BY
+            ap.parameter_id
         OPTION(RECOMPILE);
 
         SELECT
@@ -6480,7 +6482,10 @@ BEGIN
     JOIN sys.types AS t
       ON  ap.system_type_id = t.system_type_id
       AND ap.user_type_id = t.user_type_id
-    WHERE o.name = N'sp_HumanEvents';
+    WHERE o.name = N'sp_HumanEvents'
+    ORDER BY
+        ap.parameter_id
+    OPTION(RECOMPILE);
 
 
     /*Example calls*/
@@ -11370,6 +11375,8 @@ BEGIN
       ON  ap.system_type_id = t.system_type_id
       AND ap.user_type_id = t.user_type_id
     WHERE o.name = N'sp_HumanEventsBlockViewer'
+    ORDER BY
+        ap.parameter_id
     OPTION(RECOMPILE);
 
     SELECT
@@ -15155,6 +15162,8 @@ BEGIN TRY
           ON  ap.system_type_id = t.system_type_id
           AND ap.user_type_id = t.user_type_id
         WHERE o.name = N'sp_IndexCleanup'
+        ORDER BY
+            ap.parameter_id
         OPTION(MAXDOP 1, RECOMPILE);
 
         SELECT
@@ -22198,6 +22207,8 @@ BEGIN
           ON  ap.system_type_id = t.system_type_id
           AND ap.user_type_id = t.user_type_id
         WHERE o.name = N'sp_LogHunter'
+        ORDER BY
+            ap.parameter_id
         OPTION(RECOMPILE);
 
         SELECT
@@ -22929,6 +22940,8 @@ BEGIN
           ON  ap.system_type_id = t.system_type_id
           AND ap.user_type_id = t.user_type_id
         WHERE o.name = N'sp_PerfCheck'
+        ORDER BY
+            ap.parameter_id
         OPTION(MAXDOP 1, RECOMPILE);
 
         SELECT
@@ -28064,6 +28077,8 @@ BEGIN
       ON  ap.system_type_id = t.system_type_id
       AND ap.user_type_id = t.user_type_id
     WHERE o.name = N'sp_PressureDetector'
+    ORDER BY
+        ap.parameter_id
     OPTION(MAXDOP 1, RECOMPILE);
 
     SELECT
@@ -32571,6 +32586,8 @@ BEGIN
       ON  ap.system_type_id = t.system_type_id
       AND ap.user_type_id = t.user_type_id
     WHERE o.name = N'sp_QueryReproBuilder'
+    ORDER BY
+        ap.parameter_id
     OPTION(RECOMPILE);
 
     RETURN;
@@ -36437,7 +36454,7 @@ GO
 ALTER PROCEDURE
     dbo.sp_QuickieCache
 (
-    @top integer = 10, /*candidates per metric dimension before dedup*/
+    @top bigint = 10, /*candidates per metric dimension before dedup*/
     @sort_order varchar(20) = 'cpu', /*secondary sort after impact_score: cpu, duration, reads, writes, memory, spills, executions*/
     @database_name sysname = NULL, /*filter to a specific database*/
     @start_date datetime = NULL, /*only include plans created after this date*/
@@ -36467,6 +36484,21 @@ BEGIN
     */
     IF @help = 1
     BEGIN
+        /*
+        Introduction
+        */
+        SELECT
+            introduction =
+                'hi, i''m sp_QuickieCache!' UNION ALL
+        SELECT 'you got me from https://code.erikdarling.com' UNION ALL
+        SELECT 'i analyze the plan cache to find the vital few queries consuming disproportionate resources' UNION ALL
+        SELECT 'think of me as the plan cache companion to sp_QuickieStore' UNION ALL
+        SELECT 'i score queries across 7 dimensions using Pareto (80/20) analysis' UNION ALL
+        SELECT 'from your loving sql server consultant, erik darling: https://erikdarling.com';
+
+        /*
+        Parameters
+        */
         SELECT
             parameter_name =
                 ap.name,
@@ -36475,44 +36507,97 @@ BEGIN
             description =
                 CASE ap.name
                     WHEN N'@top'
-                    THEN N'Number of candidate queries per metric dimension (cpu, reads, etc.) before dedup. Default: 10.'
+                    THEN N'candidates per metric dimension before dedup'
                     WHEN N'@sort_order'
-                    THEN N'Secondary sort after impact_score. Options: cpu, duration, reads, writes, memory, spills, executions. Default: cpu.'
+                    THEN N'secondary sort after impact_score'
                     WHEN N'@database_name'
-                    THEN N'Filter to a specific database. Default: NULL (all user databases).'
+                    THEN N'filter to a specific database'
                     WHEN N'@start_date'
-                    THEN N'Only include plans created after this date. Default: NULL (no filter).'
+                    THEN N'only include plans created after this date'
                     WHEN N'@end_date'
-                    THEN N'Only include plans created before this date. Default: NULL (no filter).'
+                    THEN N'only include plans created before this date'
                     WHEN N'@minimum_execution_count'
-                    THEN N'Minimum execution count to include a query. Filters single-execution noise. Default: 2.'
+                    THEN N'minimum execution count to include a query'
                     WHEN N'@ignore_system_databases'
-                    THEN N'Exclude system databases (master, model, msdb, tempdb). Default: 1.'
+                    THEN N'exclude system databases (master, model, msdb, tempdb)'
                     WHEN N'@impact_threshold'
-                    THEN N'Minimum impact_score (0.00-1.00) to surface in results. Default: 0.50.'
+                    THEN N'minimum impact_score to surface in results'
                     WHEN N'@debug'
-                    THEN N'Print diagnostic information. Default: 0.'
+                    THEN N'print diagnostic information'
                     WHEN N'@help'
-                    THEN N'You are here. Default: 0.'
+                    THEN N'how you got here'
                     WHEN N'@version'
-                    THEN N'OUTPUT; for support.'
+                    THEN N'OUTPUT; for support'
                     WHEN N'@version_date'
-                    THEN N'OUTPUT; for support.'
+                    THEN N'OUTPUT; for support'
+                    ELSE N''
+                END,
+            valid_inputs =
+                CASE ap.name
+                    WHEN N'@top'
+                    THEN N'a positive integer'
+                    WHEN N'@sort_order'
+                    THEN N'cpu, duration, reads, writes, memory, spills, executions'
+                    WHEN N'@database_name'
+                    THEN N'a valid database name'
+                    WHEN N'@start_date'
+                    THEN N'a valid datetime'
+                    WHEN N'@end_date'
+                    THEN N'a valid datetime'
+                    WHEN N'@minimum_execution_count'
+                    THEN N'a positive integer'
+                    WHEN N'@ignore_system_databases'
+                    THEN N'0 or 1'
+                    WHEN N'@impact_threshold'
+                    THEN N'0.00 to 1.00'
+                    WHEN N'@debug'
+                    THEN N'0 or 1'
+                    WHEN N'@help'
+                    THEN N'0 or 1'
+                    WHEN N'@version'
+                    THEN N'none; OUTPUT'
+                    WHEN N'@version_date'
+                    THEN N'none; OUTPUT'
+                    ELSE N''
+                END,
+            defaults =
+                CASE ap.name
+                    WHEN N'@top'
+                    THEN N'10'
+                    WHEN N'@sort_order'
+                    THEN N'cpu'
+                    WHEN N'@database_name'
+                    THEN N'NULL'
+                    WHEN N'@start_date'
+                    THEN N'NULL'
+                    WHEN N'@end_date'
+                    THEN N'NULL'
+                    WHEN N'@minimum_execution_count'
+                    THEN N'2'
+                    WHEN N'@ignore_system_databases'
+                    THEN N'1'
+                    WHEN N'@impact_threshold'
+                    THEN N'0.50'
+                    WHEN N'@debug'
+                    THEN N'0'
+                    WHEN N'@help'
+                    THEN N'0'
+                    WHEN N'@version'
+                    THEN N'none; OUTPUT'
+                    WHEN N'@version_date'
+                    THEN N'none; OUTPUT'
                     ELSE N''
                 END
         FROM sys.all_parameters AS ap
+        JOIN sys.all_objects AS o
+          ON ap.object_id = o.object_id
         JOIN sys.types AS t
-          ON t.user_type_id = ap.user_type_id
-        WHERE ap.object_id = @@PROCID
+          ON  ap.system_type_id = t.system_type_id
+          AND ap.user_type_id = t.user_type_id
+        WHERE o.name = N'sp_QuickieCache'
         ORDER BY
-            ap.parameter_id;
-
-        SELECT
-            methodology = N'Pareto (80/20) analysis across 7 resource dimensions',
-            dimensions = N'CPU, Duration, Logical Reads, Logical Writes, Memory Grants, Spills, Executions',
-            scoring = N'PERCENT_RANK per dimension, averaged across active dimensions (>= 0.1% of total)',
-            high_signal = N'Dimensions where query ranks >= 80th percentile',
-            output = N'Queries with impact_score >= @impact_threshold, plus workload profile summary';
+            ap.parameter_id
+        OPTION(MAXDOP 1, RECOMPILE);
 
         /*
         License to F5
@@ -38758,6 +38843,8 @@ BEGIN
       ON  ap.system_type_id = t.system_type_id
       AND ap.user_type_id = t.user_type_id
     WHERE o.name = N'sp_QuickieStore'
+    ORDER BY
+        ap.parameter_id
     OPTION(RECOMPILE);
 
     /*

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -62,6 +62,8 @@ ALTER PROCEDURE
     @minimum_execution_count bigint = 2, /*noise floor for single-exec queries*/
     @ignore_system_databases bit = 1, /*exclude master, model, msdb, tempdb*/
     @impact_threshold decimal(3, 2) = 0.50, /*minimum impact_score to surface (0.00-1.00)*/
+    @find_single_use_plans bit = 0, /*show single-use plans consuming the most memory*/
+    @find_duplicate_plans bit = 0, /*show query hashes with multiple cached plans*/
     @debug bit = 0, /*print diagnostics*/
     @help bit = 0, /*display parameter help*/
     @version varchar(30) = NULL OUTPUT, /*OUTPUT; for support*/
@@ -122,6 +124,10 @@ BEGIN
                     THEN N'exclude system databases (master, model, msdb, tempdb)'
                     WHEN N'@impact_threshold'
                     THEN N'minimum impact_score to surface in results'
+                    WHEN N'@find_single_use_plans'
+                    THEN N'show single-use plans consuming the most memory'
+                    WHEN N'@find_duplicate_plans'
+                    THEN N'show query hashes with multiple cached plans'
                     WHEN N'@debug'
                     THEN N'print diagnostic information'
                     WHEN N'@help'
@@ -150,6 +156,10 @@ BEGIN
                     THEN N'0 or 1'
                     WHEN N'@impact_threshold'
                     THEN N'0.00 to 1.00'
+                    WHEN N'@find_single_use_plans'
+                    THEN N'0 or 1'
+                    WHEN N'@find_duplicate_plans'
+                    THEN N'0 or 1'
                     WHEN N'@debug'
                     THEN N'0 or 1'
                     WHEN N'@help'
@@ -178,6 +188,10 @@ BEGIN
                     THEN N'1'
                     WHEN N'@impact_threshold'
                     THEN N'0.50'
+                    WHEN N'@find_single_use_plans'
+                    THEN N'0'
+                    WHEN N'@find_duplicate_plans'
+                    THEN N'0'
                     WHEN N'@debug'
                     THEN N'0'
                     WHEN N'@help'
@@ -323,6 +337,134 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
        )
     BEGIN
         RAISERROR(N'@sort_order must be one of: cpu, duration, reads, writes, memory, spills, executions.', 16, 1) WITH NOWAIT;
+        RETURN;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Single-use plans mode                           ║
+    ╚══════════════════════════════════════════════════╝
+
+    Shows the largest single-use plans by cached size,
+    sorted by memory consumption descending.
+    */
+    IF @find_single_use_plans = 1
+    BEGIN
+        SELECT TOP (@top)
+            database_name =
+                DB_NAME(CONVERT(integer, pa.value)),
+            cached_plan_size_kb =
+                cp.size_in_bytes / 1024,
+            query_text =
+                st.text,
+            query_plan =
+                CASE
+                    WHEN TRY_CAST(qp.query_plan AS xml) IS NOT NULL
+                    THEN TRY_CAST(qp.query_plan AS xml)
+                    WHEN TRY_CAST(qp.query_plan AS xml) IS NULL
+                    THEN
+                    (
+                        SELECT
+                            [processing-instruction(query_plan)] =
+                                N'-- ' + NCHAR(13) + NCHAR(10) +
+                                N'-- This is a huge query plan.' + NCHAR(13) + NCHAR(10) +
+                                N'-- Remove the headers and footers, save it as a .sqlplan file, and re-open it.' + NCHAR(13) + NCHAR(10) +
+                                NCHAR(13) + NCHAR(10) +
+                                REPLACE(qp.query_plan, N'<RelOp', NCHAR(13) + NCHAR(10) + N'<RelOp') +
+                                NCHAR(13) + NCHAR(10) COLLATE Latin1_General_Bin2
+                        FOR
+                            XML
+                            PATH(N''),
+                            TYPE
+                    )
+                END,
+            qs.query_hash,
+            qs.query_plan_hash,
+            qs.creation_time,
+            qs.last_execution_time,
+            qs.sql_handle,
+            qs.plan_handle
+        FROM sys.dm_exec_query_stats AS qs
+        JOIN sys.dm_exec_cached_plans AS cp
+          ON cp.plan_handle = qs.plan_handle
+        CROSS APPLY
+        (
+            SELECT TOP (1)
+                value = pa.value
+            FROM sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
+            WHERE pa.attribute = N'dbid'
+        ) AS pa
+        CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
+        OUTER APPLY sys.dm_exec_text_query_plan
+        (
+            qs.plan_handle,
+            qs.statement_start_offset,
+            qs.statement_end_offset
+        ) AS qp
+        WHERE qs.execution_count = 1
+        AND   (@ignore_system_databases = 0 OR ISNULL(CONVERT(integer, pa.value), 0) NOT IN (1, 2, 3, 4))
+        AND   ISNULL(CONVERT(integer, pa.value), 0) < 32761
+        AND   (@database_id IS NULL OR CONVERT(integer, pa.value) = @database_id)
+        ORDER BY
+            cp.size_in_bytes DESC
+        OPTION(RECOMPILE, MAXDOP 1);
+
+        RETURN;
+    END;
+
+    /*
+    ╔══════════════════════════════════════════════════╗
+    ║  Duplicate plans mode                            ║
+    ╚══════════════════════════════════════════════════╝
+
+    Shows query hashes that have been compiled into
+    multiple cached plans, sorted by plan count descending.
+    */
+    IF @find_duplicate_plans = 1
+    BEGIN
+        SELECT TOP (@top)
+            database_name =
+                DB_NAME(CONVERT(integer, MAX(pa.value))),
+            qs.query_hash,
+            plan_count =
+                COUNT_BIG(DISTINCT qs.plan_handle),
+            total_executions =
+                SUM(qs.execution_count),
+            total_cpu_ms =
+                SUM(qs.total_worker_time) / 1000.0,
+            total_logical_reads =
+                SUM(qs.total_logical_reads),
+            total_cached_size_kb =
+                SUM(cp.size_in_bytes) / 1024,
+            oldest_plan =
+                MIN(qs.creation_time),
+            newest_plan =
+                MAX(qs.creation_time),
+            sample_query_text =
+                MAX(st.text)
+        FROM sys.dm_exec_query_stats AS qs
+        JOIN sys.dm_exec_cached_plans AS cp
+          ON cp.plan_handle = qs.plan_handle
+        CROSS APPLY
+        (
+            SELECT TOP (1)
+                value = pa.value
+            FROM sys.dm_exec_plan_attributes(qs.plan_handle) AS pa
+            WHERE pa.attribute = N'dbid'
+        ) AS pa
+        CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
+        WHERE qs.query_hash <> 0x0000000000000000
+        AND   (@ignore_system_databases = 0 OR ISNULL(CONVERT(integer, pa.value), 0) NOT IN (1, 2, 3, 4))
+        AND   ISNULL(CONVERT(integer, pa.value), 0) < 32761
+        AND   (@database_id IS NULL OR CONVERT(integer, pa.value) = @database_id)
+        GROUP BY
+            qs.query_hash
+        HAVING
+            COUNT_BIG(DISTINCT qs.plan_handle) > 1
+        ORDER BY
+            COUNT_BIG(DISTINCT qs.plan_handle) DESC
+        OPTION(RECOMPILE, MAXDOP 1);
+
         RETURN;
     END;
 
@@ -537,7 +679,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             WHERE pa.attribute = N'dbid'
         ) AS pa
         WHERE pa.value IS NOT NULL
-        AND   CONVERT(integer, pa.value) NOT IN (1, 2, 3, 4)
+        AND   (@ignore_system_databases = 0 OR CONVERT(integer, pa.value) NOT IN (1, 2, 3, 4))
         AND   CONVERT(integer, pa.value) < 32761
         AND   (@database_id IS NULL OR CONVERT(integer, pa.value) = @database_id)
         GROUP BY
@@ -646,7 +788,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             WHERE pa.attribute = N'dbid'
         ) AS pa
         WHERE pa.value IS NOT NULL
-        AND   CONVERT(integer, pa.value) NOT IN (1, 2, 3, 4)
+        AND   (@ignore_system_databases = 0 OR CONVERT(integer, pa.value) NOT IN (1, 2, 3, 4))
         AND   CONVERT(integer, pa.value) < 32761
         AND   (@database_id IS NULL OR CONVERT(integer, pa.value) = @database_id)
         GROUP BY


### PR DESCRIPTION
## Summary
- Add `@find_single_use_plans` mode: shows largest single-use plans by cached size
- Add `@find_duplicate_plans` mode: shows query hashes with multiple cached plans
- All system database filters now consistently respect `@ignore_system_databases`

## Test plan
- [x] `@find_single_use_plans = 1` returns results sorted by cached size
- [x] `@find_duplicate_plans = 1` returns results sorted by plan count
- [x] Both modes respect `@database_name` and `@top`
- [x] Verified all 6 system database filter locations are conditional

🤖 Generated with [Claude Code](https://claude.com/claude-code)