### PR TITLE
Fix arithmetic overflow in sp_QuickieStore wait stats

### DIFF
--- a/Install-All/DarlingData.sql
+++ b/Install-All/DarlingData.sql
@@ -43467,7 +43467,7 @@ OPTION(RECOMPILE);' + @nc10;
                             N', ' +
                             ws2.wait_category_desc +
                             N' (' +
-                            CONVERT(nvarchar(20), CONVERT(integer, ws2.total_wait_ms)) +
+                            CONVERT(nvarchar(20), CONVERT(bigint, ws2.total_wait_ms)) +
                             N' ms)'
                         FROM #hi_wait_staging AS ws2
                         WHERE ws2.query_hash = ws.query_hash

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -5029,7 +5029,7 @@ OPTION(RECOMPILE);' + @nc10;
                             N', ' +
                             ws2.wait_category_desc +
                             N' (' +
-                            CONVERT(nvarchar(20), CONVERT(integer, ws2.total_wait_ms)) +
+                            CONVERT(nvarchar(20), CONVERT(bigint, ws2.total_wait_ms)) +
                             N' ms)'
                         FROM #hi_wait_staging AS ws2
                         WHERE ws2.query_hash = ws.query_hash


### PR DESCRIPTION
## Summary
- Fixed `CONVERT(integer, ws2.total_wait_ms)` → `CONVERT(bigint, ws2.total_wait_ms)` in the high impact section's wait category string formatting
- The `total_wait_ms` column is `decimal(38, 6)` (summed from `bigint` DMV column) and overflows `int` (~2.1B ms / ~24 days) on busy servers

## Test plan
- [x] Deployed and tested on SQL2016, SQL2017, SQL2019, SQL2022, SQL2025
- [x] Verified with `@wait_filter = 'cpu'` on SQL2022 and SQL2025
- [x] Audited all other `CONVERT(integer, ...)` in the high impact section — remaining ones are all ratios (max-min)/avg, bounded by CASE guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)