### PR TITLE
Ask for @debug output in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,6 +90,16 @@ body:
       required: false
 
   - type: textarea
+    id: debug
+    attributes:
+      label: Debug Output
+      description: |
+        If the script supports `@debug = 1` (sp_QuickieStore, sp_HealthParser, sp_PressureDetector, sp_PerfCheck, sp_IndexCleanup, sp_LogHunter, sp_HumanEvents, sp_QueryStoreCleanup, sp_QueryReproBuilder), please re-run with `@debug = 1` and paste the **Messages tab** output — especially the last `current_table` value and the failing dynamic SQL block. This pinpoints which section is broken and is usually all we need to ship a fix.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
     id: context
     attributes:
       label: Additional Context


### PR DESCRIPTION
## Summary
- Add a **Debug Output** textarea to `bug_report.yml` asking reporters to re-run with `@debug = 1` and paste the Messages output (last `current_table` value + failing dynamic SQL).
- Lists all procs that currently support `@debug`.
- Motivated by #767 — without `@debug` output, an Azure SQL DB conversion error is hard to localize without a round trip.

## Test plan
- [ ] Open a new test issue in a fork to verify the new field renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)