### PR TITLE
sp_IndexCleanup: show uptime in header row, fix UDF false positives

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -1786,49 +1786,60 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         column_name = c.name,
         definition = cc.definition,
         /*
-        UDF detection: Looks for schema-qualified object references like [schema].[function]
-        Note: This is a heuristic check and may have rare false positives if ].[  appears
-        in string literals or comments within the computed column definition
+        UDF detection: Uses sys.sql_expression_dependencies, filtered to user-defined
+        function object types (FN, IF, TF, FS, FT). This avoids the false positives
+        the previous string-heuristic produced for schema-qualified type names,
+        system functions called as [sys].[fn_xxx](), and ].[ embedded in string
+        literals or comments.
         */
         contains_udf =
             CASE
-                WHEN cc.definition LIKE ''%|].|[%'' ESCAPE ''|''
-                AND  cc.definition LIKE ''%|].|[%(%'' ESCAPE ''|''
+                WHEN refs.udf_names IS NOT NULL
                 THEN 1
                 ELSE 0
             END,
-        udf_names =
-            CASE
-                WHEN cc.definition LIKE ''%|].|[%'' ESCAPE ''|''
-                AND  cc.definition LIKE ''%|].|[%(%'' ESCAPE ''|''
-                AND  CHARINDEX(N''['', cc.definition) > 0
-                AND  CHARINDEX(N''].['', cc.definition) > 0
-                AND  CHARINDEX(N'']'', cc.definition, CHARINDEX(N''].['', cc.definition) + 3) > 0
-                THEN
-                    SUBSTRING
-                    (
-                        cc.definition,
-                        CHARINDEX(N''['', cc.definition),
-                        CHARINDEX
-                        (
-                            N'']'',
-                            cc.definition,
-                            CHARINDEX
-                            (
-                                N''].['',
-                                cc.definition
-                            ) + 3
-                        ) -
-                        CHARINDEX(N''['', cc.definition) + 1
-                    )
-                ELSE NULL
-            END
+        udf_names = refs.udf_names
     FROM #filtered_objects AS fo
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.columns AS c
       ON fo.object_id = c.object_id
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.computed_columns AS cc
       ON  c.object_id = cc.object_id
       AND c.column_id = cc.column_id
+    OUTER APPLY
+    (
+        SELECT
+            udf_names =
+                STUFF
+                (
+                    (
+                        SELECT
+                            N'', '' +
+                            QUOTENAME(s.name) +
+                            N''.'' +
+                            QUOTENAME(o.name)
+                        FROM ' + QUOTENAME(@current_database_name) + N'.sys.sql_expression_dependencies AS sed
+                        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
+                          ON o.object_id = sed.referenced_id
+                        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.schemas AS s
+                          ON s.schema_id = o.schema_id
+                        WHERE sed.referencing_id = cc.object_id
+                        AND   sed.referencing_minor_id = cc.column_id
+                        AND   sed.referencing_class = 1
+                        AND   sed.referenced_class = 1
+                        AND   o.type IN (N''FN'', N''IF'', N''TF'', N''FS'', N''FT'')
+                        ORDER BY
+                            s.name,
+                            o.name
+                        FOR
+                            XML
+                            PATH(N''''),
+                            TYPE
+                    ).value(''.'', ''nvarchar(max)''),
+                    1,
+                    2,
+                    N''''
+                )
+    ) AS refs
     OPTION(RECOMPILE);';
 
     IF @debug = 1
@@ -1883,46 +1894,56 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         constraint_name = cc.name,
         definition = cc.definition,
         /*
-        UDF detection: Looks for schema-qualified object references like [schema].[function]
-        Note: This is a heuristic check and may have rare false positives if ].[  appears
-        in string literals or comments within the computed column definition
+        UDF detection: Uses sys.sql_expression_dependencies, filtered to user-defined
+        function object types (FN, IF, TF, FS, FT). This avoids the false positives
+        the previous string-heuristic produced for schema-qualified type names,
+        system functions called as [sys].[fn_xxx](), and ].[ embedded in string
+        literals or comments.
         */
         contains_udf =
             CASE
-                WHEN cc.definition LIKE ''%|].|[%'' ESCAPE ''|''
-                AND  cc.definition LIKE ''%|].|[%(%'' ESCAPE ''|''
+                WHEN refs.udf_names IS NOT NULL
                 THEN 1
                 ELSE 0
             END,
-        udf_names =
-            CASE
-                WHEN cc.definition LIKE ''%|].|[%'' ESCAPE ''|''
-                AND  cc.definition LIKE ''%|].|[%(%'' ESCAPE ''|''
-                AND  CHARINDEX(N''['', cc.definition) > 0
-                AND  CHARINDEX(N''].['', cc.definition) > 0
-                AND  CHARINDEX(N'']'', cc.definition, CHARINDEX(N''].['', cc.definition) + 3) > 0
-                THEN
-                    SUBSTRING
-                    (
-                        cc.definition,
-                        CHARINDEX(N''['', cc.definition),
-                        CHARINDEX
-                        (
-                            N'']'',
-                            cc.definition,
-                            CHARINDEX
-                            (
-                                N''].['',
-                                cc.definition
-                            ) + 3
-                        ) -
-                        CHARINDEX(N''['', cc.definition) + 1
-                    )
-                ELSE NULL
-            END
+        udf_names = refs.udf_names
     FROM #filtered_objects AS fo
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.check_constraints AS cc
       ON fo.object_id = cc.parent_object_id
+    OUTER APPLY
+    (
+        SELECT
+            udf_names =
+                STUFF
+                (
+                    (
+                        SELECT
+                            N'', '' +
+                            QUOTENAME(s.name) +
+                            N''.'' +
+                            QUOTENAME(o.name)
+                        FROM ' + QUOTENAME(@current_database_name) + N'.sys.sql_expression_dependencies AS sed
+                        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
+                          ON o.object_id = sed.referenced_id
+                        JOIN ' + QUOTENAME(@current_database_name) + N'.sys.schemas AS s
+                          ON s.schema_id = o.schema_id
+                        WHERE sed.referencing_id = cc.object_id
+                        AND   sed.referencing_class = 1
+                        AND   sed.referenced_class = 1
+                        AND   o.type IN (N''FN'', N''IF'', N''TF'', N''FS'', N''FT'')
+                        ORDER BY
+                            s.name,
+                            o.name
+                        FOR
+                            XML
+                            PATH(N''''),
+                            TYPE
+                    ).value(''.'', ''nvarchar(max)''),
+                    1,
+                    2,
+                    N''''
+                )
+    ) AS refs
     OPTION(RECOMPILE);';
 
     IF @debug = 1
@@ -4127,7 +4148,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             ),
         table_name = N'brought to you by erikdarling.com',
         index_name = N'for support: https://code.erikdarling.com/',
-        consolidation_rule = N'run date: ' + CONVERT(nvarchar(30), SYSDATETIME(), 120),
+        consolidation_rule =
+            N'run date: ' +
+            CONVERT(nvarchar(30), SYSDATETIME(), 120) +
+            N' | ' +
+            CASE
+                WHEN @uptime_warning = 1
+                THEN N'WARNING: Server uptime only ' +
+                     @uptime_days +
+                     N' days - usage data may be incomplete!'
+                ELSE N'Server uptime: ' +
+                     @uptime_days +
+                     N' days'
+            END,
         script_type = N'Index Cleanup Scripts',
         additional_info = N'A detailed index analysis report appears after these scripts',
         target_index_name = N'ALWAYS TEST THESE RECOMMENDATIONS',


### PR DESCRIPTION
## Summary
- Append server uptime to the run-date header row's `consolidation_rule` column. Renders as `Server uptime: N days`, or `WARNING: Server uptime only N days - usage data may be incomplete!` when `@uptime_warning = 1` (uptime < 14 days). Previously the day count only appeared in the summary `database_info` cell.
- Replace the `LIKE '%].[%(%'` string heuristic for detecting UDFs in computed columns and check constraints with a `sys.sql_expression_dependencies` join filtered to `FN`/`IF`/`TF`/`FS`/`FT` object types. The heuristic produced false positives for any definition containing `].[(` — including string literals with bracketed text, `OBJECT_ID(N'[schema].[name](x)')` calls, and any system function called as `[sys].[fn_xxx]()`. The dependency view is the catalog-supported source of truth.
- `udf_names` now reports a clean comma-delimited `[schema].[name]` list. Previously it ran `SUBSTRING` from the first `[` in the definition, producing strings like `[col1]+[dbo].[fn_x]`.

## Test plan
Tested against `Crap` on SQL2022 with purpose-built false-positive bait:

| object | definition | old heuristic | new logic |
|---|---|---|---|
| `test_udf_realudf.doubled` | `([dbo].[fn_test_real_udf]([base_val]))` | flagged ✓ | flagged ✓ |
| `test_udf_falsepos.string_with_brackets` | `(CONVERT([varchar](100),N'foo].[bar(')+[raw_text])` | flagged (FP) | not flagged ✓ |
| `test_udf_falsepos.has_table_flag` | `(case when object_id(N'[dbo].[some_table](x)') ...)` | flagged (FP) | not flagged ✓ |
| `ck_realudf_uses_fn` | `([dbo].[fn_test_real_udf]([base_val])>=(0))` | flagged ✓ | flagged ✓ |
| `ck_falsepos_strlit` | `([raw_text]<>N'a].[b(')` | flagged (FP) | not flagged ✓ |
| `ck_falsepos_objectid` | `(object_id(N'[dbo].[some_table](x)') ...)` | flagged (FP) | not flagged ✓ |

- [x] Standalone dependency query returns expected `contains_udf` and `udf_names` for all 6 cases
- [x] Full `EXECUTE sp_IndexCleanup @debug = 1` against each test table populates `#computed_columns_analysis` / `#check_constraints_analysis` correctly
- [x] `COMPUTED COLUMNS WITH UDF REFERENCES` and `CHECK CONSTRAINTS WITH UDF REFERENCES` finding sections appear only for the real-UDF table
- [x] Header row's `consolidation_rule` shows uptime alongside run date (verified on a server with low uptime that triggers `@uptime_warning = 1`)
- [x] Dynamic SQL escaping in `sp_executesql` calls clean — no `Msg`/syntax errors