### PR TITLE
Type plan_force_flat ids as bigint in @expert_mode parser

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -11082,30 +11082,42 @@ FROM
         plan_force_json.score,
         plan_force_json.last_refresh,
         regressed_plan_id =
-            SUBSTRING
+            TRY_CAST
             (
-                plan_force_json.detail,
-                CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN(''regressedPlanId: ''),
-                IIF
+                LTRIM
                 (
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
-                    LEN(plan_force_json.detail),
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('',''))
-                )
-                - LEN(''regressedPlanId: '') - CHARINDEX(''regressedPlanId: '', plan_force_json.detail)
+                    SUBSTRING
+                    (
+                        plan_force_json.detail,
+                        CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN(''regressedPlanId: ''),
+                        IIF
+                        (
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
+                            LEN(plan_force_json.detail),
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('',''))
+                        )
+                        - LEN(''regressedPlanId: '') - CHARINDEX(''regressedPlanId: '', plan_force_json.detail)
+                    )
+                ) AS bigint
             ),
         recommended_plan_id =
-            SUBSTRING
+            TRY_CAST
             (
-                plan_force_json.detail,
-                CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN(''recommendedPlanId: ''),
-                IIF
+                LTRIM
                 (
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
-                    LEN(plan_force_json.detail),
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('',''))
-                )
-                - LEN(''recommendedPlanId: '') - CHARINDEX(''recommendedPlanId: '', plan_force_json.detail)
+                    SUBSTRING
+                    (
+                        plan_force_json.detail,
+                        CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN(''recommendedPlanId: ''),
+                        IIF
+                        (
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
+                            LEN(plan_force_json.detail),
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('',''))
+                        )
+                        - LEN(''recommendedPlanId: '') - CHARINDEX(''recommendedPlanId: '', plan_force_json.detail)
+                    )
+                ) AS bigint
             )
     FROM
     (
@@ -11127,7 +11139,7 @@ WHERE EXISTS
           SELECT
               1/0
           FROM #query_store_plan AS qsp
-          WHERE TRY_CAST(plan_force_flat.regressed_plan_id AS bigint) = qsp.plan_id
+          WHERE plan_force_flat.regressed_plan_id = qsp.plan_id
       )
 OPTION(RECOMPILE);' + @nc10;
 


### PR DESCRIPTION
Refs #767, follow-up to #771.

## Summary
- The string-split path that parses `sys.dm_db_tuning_recommendations.details` (the pre-2017-compat fallback) returns `regressed_plan_id` / `recommended_plan_id` with a leading space — the REPLACE chain inserts `': '` after every colon, and the SUBSTRING math doesn't account for it.
- The original code relied on the implicit cast on insert into `#tuning_recommendations` (defined as `bigint NULL`) to silently strip the space. PR #771 added `TRY_CAST(... AS bigint)` in the WHERE clause to survive the same surface in another spot.
- This change moves the type intent to the projection: `TRY_CAST(LTRIM(SUBSTRING(...)) AS bigint)` so the derived-table columns leave the parser already typed.
- Drops the now-redundant `TRY_CAST` from the WHERE clause that #771 added.
- Does **not** touch the SUBSTRING/CHARINDEX/IIF math — that lattice is fragile and the leading-space symptom isn't actually a math bug, it's a REPLACE side-effect.

Credit: @ClaudioESSilva confirmed via repro on Hyperscale that no truncation is happening, just the leading space, and the implicit cast was the silent rescuer.

## Test plan
- [x] Installed updated proc on SQL2022.
- [x] `EXEC dbo.sp_QuickieStore @expert_mode = 1, @top = 1` against StackOverflow2013 — no conversion error, no 8114/8145.
- [ ] Repro tenant on Azure SQL DB Hyperscale (per @ravirajch / @ClaudioESSilva) — would appreciate a confirmation run.