### PR TITLE
Release: bump all procs to X.6 for 5/1/2026

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -72,8 +72,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.5',
-        @version_date = '20260420';
+        @version = '3.6',
+        @version_date = '20260501';
 
     IF @help = 1
     BEGIN

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,8 +88,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.5',
-    @version_date = '20260420';
+    @version = '7.6',
+    @version_date = '20260501';
 
 IF @help = 1
 BEGIN

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -93,8 +93,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.5',
-    @version_date = '20260420';
+    @version = '5.6',
+    @version_date = '20260501';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -72,8 +72,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.5',
-        @version_date = '20260420';
+        @version = '2.6',
+        @version_date = '20260501';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,8 +73,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.5',
-        @version_date = '20260420';
+        @version = '3.6',
+        @version_date = '20260501';
 
     IF @help = 1
     BEGIN

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -64,8 +64,8 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.5',
-        @version_date = N'20260420';
+        @version = N'2.6',
+        @version_date = N'20260501';
 
     /*
     Help section, for help.

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,8 +78,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.5',
-    @version_date = '20260420';
+    @version = '6.6',
+    @version_date = '20260501';
 
 
 IF @help = 1

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -84,8 +84,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.5',
-    @version_date = '20260420';
+    @version = '1.6',
+    @version_date = '20260501';
 
 /*Help*/
 IF @help = 1

--- a/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
+++ b/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
@@ -53,8 +53,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.5',
-        @version_date = '20260420';
+        @version = '1.6',
+        @version_date = '20260501';
 
     /*
     Help section

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -76,8 +76,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.5',
-        @version_date = '20260420';
+        @version = '1.6',
+        @version_date = '20260501';
 
     /*
     ╔══════════════════════════════════════════════════╗

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -127,8 +127,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.5',
-    @version_date = '20260420';
+    @version = '6.6',
+    @version_date = '20260501';
 
 /*
 Helpful section! For help.


### PR DESCRIPTION
Mass version bump to prep the May 1, 2026 release. All 11 procs X.5 → X.6, @version_date set to 20260501. No code changes beyond the version metadata. All 11 install cleanly on SQL2022.