### PR TITLE
Release Updates_20260501 - May 2026 release

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -72,8 +72,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.5',
-        @version_date = '20260420';
+        @version = '3.6',
+        @version_date = '20260501';
 
     IF @help = 1
     BEGIN

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,8 +88,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.5',
-    @version_date = '20260420';
+    @version = '7.6',
+    @version_date = '20260501';
 
 IF @help = 1
 BEGIN

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -93,8 +93,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.5',
-    @version_date = '20260420';
+    @version = '5.6',
+    @version_date = '20260501';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -72,8 +72,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.5',
-        @version_date = '20260420';
+        @version = '2.6',
+        @version_date = '20260501';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,8 +73,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.5',
-        @version_date = '20260420';
+        @version = '3.6',
+        @version_date = '20260501';
 
     IF @help = 1
     BEGIN

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -64,8 +64,8 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.5',
-        @version_date = N'20260420';
+        @version = N'2.6',
+        @version_date = N'20260501';
 
     /*
     Help section, for help.

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,8 +78,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.5',
-    @version_date = '20260420';
+    @version = '6.6',
+    @version_date = '20260501';
 
 
 IF @help = 1

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -630,10 +630,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     total_mb_read decimal(38,2) NULL,
                     total_read_count bigint NULL,
                     avg_read_stall_ms decimal(38,2) NULL,
+                    avg_read_kb decimal(38,2) NULL,
                     total_gb_written decimal(38,2) NULL,
                     total_mb_written decimal(38,2) NULL,
                     total_write_count bigint NULL,
                     avg_write_stall_ms decimal(38,2) NULL,
+                    avg_write_kb decimal(38,2) NULL,
+                    num_of_bytes_read bigint NULL,
+                    num_of_bytes_written bigint NULL,
                     io_stall_read_ms bigint NULL,
                     io_stall_write_ms bigint NULL,
                     PRIMARY KEY CLUSTERED (collection_time, id)
@@ -1052,10 +1056,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
         total_mb_read decimal(38,2),
         total_read_count bigint,
         avg_read_stall_ms decimal(38,2),
+        avg_read_kb decimal(38,2),
         total_gb_written decimal(38,2),
         total_mb_written decimal(38,2),
         total_write_count bigint,
         avg_write_stall_ms decimal(38,2),
+        avg_write_kb decimal(38,2),
+        num_of_bytes_read bigint,
+        num_of_bytes_written bigint,
         io_stall_read_ms bigint,
         io_stall_write_ms bigint,
         sample_time datetime
@@ -1698,6 +1706,21 @@ OPTION(MAXDOP 1, RECOMPILE);',
                         0.
                     )
                 ),
+            avg_read_kb =
+                CONVERT
+                (
+                    decimal(38, 2),
+                    ISNULL
+                    (
+                        (vfs.num_of_bytes_read / 1024.) /
+                          CONVERT
+                          (
+                              decimal(38, 2),
+                              NULLIF(vfs.num_of_reads, 0.)
+                          ),
+                        0.
+                    )
+                ),
             total_gb_written =
                 CASE
                     WHEN vfs.num_of_bytes_written > 0
@@ -1735,6 +1758,25 @@ OPTION(MAXDOP 1, RECOMPILE);',
                         0.
                     )
                 ),
+            avg_write_kb =
+                CONVERT
+                (
+                    decimal(38, 2),
+                    ISNULL
+                    (
+                        (vfs.num_of_bytes_written / 1024.) /
+                          CONVERT
+                          (
+                              decimal(38, 2),
+                              NULLIF(vfs.num_of_writes, 0.)
+                          ),
+                        0.
+                    )
+                ),
+            num_of_bytes_read =
+                vfs.num_of_bytes_read,
+            num_of_bytes_written =
+                vfs.num_of_bytes_written,
             io_stall_read_ms,
             io_stall_write_ms,
             sample_time =
@@ -1790,10 +1832,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
             total_mb_read,
             total_read_count,
             avg_read_stall_ms,
+            avg_read_kb,
             total_gb_written,
             total_mb_written,
             total_write_count,
             avg_write_stall_ms,
+            avg_write_kb,
+            num_of_bytes_read,
+            num_of_bytes_written,
             io_stall_read_ms,
             io_stall_write_ms,
             sample_time
@@ -1816,6 +1862,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                         fm.file_size_gb,
                         fm.avg_read_stall_ms,
                         fm.avg_write_stall_ms,
+                        fm.avg_read_kb,
+                        fm.avg_write_kb,
                         fm.total_gb_read,
                         fm.total_gb_written,
                         total_read_count =
@@ -1838,6 +1886,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     fm.avg_read_stall_ms,
                     fm.avg_write_stall_ms,
                     fm.total_avg_stall_ms,
+                    fm.avg_read_kb,
+                    fm.avg_write_kb,
                     fm.total_gb_read,
                     fm.total_gb_written,
                     fm.total_read_count,
@@ -1855,6 +1905,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     avg_read_stall_ms = 0,
                     avg_write_stall_ms = 0,
                     total_avg_stall_ms = 0,
+                    avg_read_kb = 0,
+                    avg_write_kb = 0,
                     total_gb_read = 0,
                     total_gb_written = 0,
                     total_read_count = N'0',
@@ -1927,6 +1979,30 @@ OPTION(MAXDOP 1, RECOMPILE);',
                                         )
                                     )
                             END,
+                        avg_read_kb =
+                            CASE
+                                WHEN (fm2.total_read_count - fm.total_read_count) = 0
+                                THEN 0.00
+                                ELSE
+                                    CONVERT
+                                    (
+                                        decimal(38, 2),
+                                        ((fm2.num_of_bytes_read - fm.num_of_bytes_read) / 1024.) /
+                                        (fm2.total_read_count - fm.total_read_count)
+                                    )
+                            END,
+                        avg_write_kb =
+                            CASE
+                                WHEN (fm2.total_write_count - fm.total_write_count) = 0
+                                THEN 0.00
+                                ELSE
+                                    CONVERT
+                                    (
+                                        decimal(38, 2),
+                                        ((fm2.num_of_bytes_written - fm.num_of_bytes_written) / 1024.) /
+                                        (fm2.total_write_count - fm.total_write_count)
+                                    )
+                            END,
                         total_mb_read =
                             (fm2.total_mb_read - fm.total_mb_read),
                         total_mb_written =
@@ -1954,6 +2030,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     f.avg_read_stall_ms,
                     f.avg_write_stall_ms,
                     f.total_avg_stall,
+                    f.avg_read_kb,
+                    f.avg_write_kb,
                     total_mb_read =
                         FORMAT(f.total_mb_read, 'N0'),
                     total_mb_written =
@@ -2003,10 +2081,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
                    total_mb_read,
                    total_read_count,
                    avg_read_stall_ms,
+                   avg_read_kb,
                    total_gb_written,
                    total_mb_written,
                    total_write_count,
                    avg_write_stall_ms,
+                   avg_write_kb,
+                   num_of_bytes_read,
+                   num_of_bytes_written,
                    io_stall_read_ms,
                    io_stall_write_ms
                )
@@ -2020,10 +2102,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
                    fm.total_mb_read,
                    fm.total_read_count,
                    fm.avg_read_stall_ms,
+                   fm.avg_read_kb,
                    fm.total_gb_written,
                    fm.total_mb_written,
                    fm.total_write_count,
                    fm.avg_write_stall_ms,
+                   fm.avg_write_kb,
+                   fm.num_of_bytes_read,
+                   fm.num_of_bytes_written,
                    fm.io_stall_read_ms,
                    fm.io_stall_write_ms
                FROM #file_metrics AS fm;

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -84,8 +84,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.5',
-    @version_date = '20260420';
+    @version = '1.6',
+    @version_date = '20260501';
 
 /*Help*/
 IF @help = 1

--- a/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
+++ b/sp_QueryStoreCleanup/sp_QueryStoreCleanup.sql
@@ -53,8 +53,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.5',
-        @version_date = '20260420';
+        @version = '1.6',
+        @version_date = '20260501';
 
     /*
     Help section

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -76,8 +76,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.5',
-        @version_date = '20260420';
+        @version = '1.6',
+        @version_date = '20260501';
 
     /*
     ╔══════════════════════════════════════════════════╗

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -11127,7 +11127,7 @@ WHERE EXISTS
           SELECT
               1/0
           FROM #query_store_plan AS qsp
-          WHERE plan_force_flat.regressed_plan_id = qsp.plan_id
+          WHERE TRY_CAST(plan_force_flat.regressed_plan_id AS bigint) = qsp.plan_id
       )
 OPTION(RECOMPILE);' + @nc10;
 

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -127,8 +127,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.5',
-    @version_date = '20260420';
+    @version = '6.6',
+    @version_date = '20260501';
 
 /*
 Helpful section! For help.

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -11082,30 +11082,42 @@ FROM
         plan_force_json.score,
         plan_force_json.last_refresh,
         regressed_plan_id =
-            SUBSTRING
+            TRY_CAST
             (
-                plan_force_json.detail,
-                CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN(''regressedPlanId: ''),
-                IIF
+                LTRIM
                 (
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
-                    LEN(plan_force_json.detail),
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('',''))
-                )
-                - LEN(''regressedPlanId: '') - CHARINDEX(''regressedPlanId: '', plan_force_json.detail)
+                    SUBSTRING
+                    (
+                        plan_force_json.detail,
+                        CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN(''regressedPlanId: ''),
+                        IIF
+                        (
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
+                            LEN(plan_force_json.detail),
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('',''))
+                        )
+                        - LEN(''regressedPlanId: '') - CHARINDEX(''regressedPlanId: '', plan_force_json.detail)
+                    )
+                ) AS bigint
             ),
         recommended_plan_id =
-            SUBSTRING
+            TRY_CAST
             (
-                plan_force_json.detail,
-                CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN(''recommendedPlanId: ''),
-                IIF
+                LTRIM
                 (
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
-                    LEN(plan_force_json.detail),
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('',''))
-                )
-                - LEN(''recommendedPlanId: '') - CHARINDEX(''recommendedPlanId: '', plan_force_json.detail)
+                    SUBSTRING
+                    (
+                        plan_force_json.detail,
+                        CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN(''recommendedPlanId: ''),
+                        IIF
+                        (
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
+                            LEN(plan_force_json.detail),
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('',''))
+                        )
+                        - LEN(''recommendedPlanId: '') - CHARINDEX(''recommendedPlanId: '', plan_force_json.detail)
+                    )
+                ) AS bigint
             )
     FROM
     (
@@ -11127,7 +11139,7 @@ WHERE EXISTS
           SELECT
               1/0
           FROM #query_store_plan AS qsp
-          WHERE TRY_CAST(plan_force_flat.regressed_plan_id AS bigint) = qsp.plan_id
+          WHERE plan_force_flat.regressed_plan_id = qsp.plan_id
       )
 OPTION(RECOMPILE);' + @nc10;
 


### PR DESCRIPTION
May 2026 release. 8 substantive commits since v4.20. All 11 stored procs bumped to X.6 / 20260501.

## New

### sp_QueryReproBuilder — `@query_plan_xml` parameter
Feed a single query plan XML directly and skip Query Store entirely. Useful for iterating on a slow-to-parse plan in isolation.

When `@query_plan_xml` is supplied:
- Database-existence and Query-Store-existence checks are skipped
- The Query Store population region is bypassed (`IF @query_plan_xml IS NULL`)
- A synthetic `plan_id`/`query_id = -1` row is seeded into `#query_store_plan`, `#query_store_query`, `#query_store_query_text`, `#query_store_runtime_stats`, and `#query_context_settings` so synthetic rows can't collide with real Query Store data
- Statement text is extracted from `StmtSimple/@StatementText` to feed `#query_store_query_text`
- Parameter extraction, warnings, embedded-constants, and repro-build phases all run unmodified against the synthetic data

The generated repro's `USE database;` scaffold is gated on `@database_name` being supplied so synthetic-mode output doesn't emit `USE NULL;`.

### sp_QuickieStore — `@primary_window` filter on `@find_high_impact`
Narrow `@find_high_impact` results to queries whose majority activity falls in a single window. Accepts any prefix of `business` / `off-hours` / `weekend` (case-insensitive — `b` / `o` / `w` is enough). Validated up front: errors out unless `@find_high_impact = 1` and the value starts with `b`, `o`, or `w`. Filter applied in the final dynamic SELECT against the existing `primary_window` classification (its >50% rule). Queries whose `primary_window` is `Spread` are excluded by design.

### sp_QuickieStore + sp_QuickieCache — `resource_metrics` XML rollup
The eight individual `total_*` columns plus `max_dop` in `@find_high_impact` (sp_QuickieStore) and twelve total/max columns in sp_QuickieCache's main result set are replaced with a single clickable `resource_metrics` XML column. Built natively with `FOR XML PATH(N'metrics'), TYPE` and attribute-path aliases — no `STRING_AGG`, no string concatenation. The XML also surfaces avg/min/max per-execution metrics that were previously computed but not projected.

Shape (sp_QuickieStore):
```xml
<metrics>
  <cpu total_ms avg_ms min_ms max_ms/>
  <duration total_ms avg_ms min_ms max_ms/>
  <physical_reads total_mb avg_mb min_mb max_mb/>
  <writes total_mb avg_mb min_mb max_mb/>
  <memory total_mb avg_mb min_mb max_mb/>
  <tempdb total_mb avg_mb/>
  <executions total/>
  <rows total avg/>
  <parallelism max_dop/>
</metrics>
```

Share columns (`cpu_share`, `duration_share`, etc.) remain dedicated sortable columns rather than folded into the XML. The underlying `total_*` storage is unchanged so debug dumps are unaffected.

### sp_PressureDetector — average I/O size per file
Adds `avg_read_kb` and `avg_write_kb` to the file metrics output, computed from `sys.dm_io_virtual_file_stats.num_of_bytes_read / num_of_reads` (and write counterparts). Values flow through the snapshot temp table, the `@log_to_table` path, and both the snapshot and delta CTE branches.

A high `avg_read_stall_ms` with a small `avg_read_kb` points at random small reads (index seeks, lookups). The same stall with a large `avg_read_kb` points at large sequential pulls (read-ahead, scans, restores). Different remediations, same wait — surfacing the size disambiguates.

## Fixes

### sp_HumanEventsBlockViewer — chain-lead attribution for top blocking queries (#760 follow-up)
The "Top Blocking Query" rollup previously summed each blocked-process-report's victim wait against the **direct** blocker's `sql_handle`. In a chain `A blocks B blocks C`, `B` was reported as a blocker "responsible" for `C`'s wait — but `B` was itself stuck behind `A`. Only `A` actually needs tuning.

This release rewrites the rollup so every BPR's victim wait cascades up to the chain's lead blocker (the level-0 session in the monitor loop):

- New `#session_leads` temp table materializes a `(monitor_loop, lead_desc, session_desc)` map via a recursive CTE. Anchor rows are lead blockers (sessions never appearing as a `blocked_desc` in the same monitor loop); recursion walks downstream keeping `lead_desc` constant.
- Cycle guard mirrors the existing hierarchy CTE pattern (`lead_path LIKE` check, `MAXRECURSION 100`).
- Fallback pass inserts any `blocking_desc` not reached by the recursion as its own lead — catches true cycle cases (mutual blocking before deadlock detection fires) so their waits don't silently drop.
- BPR-level filter application (rather than chain-level) keeps cross-object waits visible in the rollup.
- Final finding renamed `Top Blocking Query` → `Top Lead Blocker`; finding text now reads "This lead blocker accounted for ... across N blocked sessions in its chain." to make the cascaded-attribution semantic explicit.

Intermediate blockers (sessions that blocked downstream but were themselves victims) no longer appear in the rollup — their apparent blocking time has been attributed to whoever's actually holding the lock at the top of the chain.

### sp_IndexCleanup — uptime in header, accurate UDF detection
- Append a `Server uptime: N days` clause to the run-date header row's `consolidation_rule`, so the day count is visible alongside per-row warnings rather than only in the summary block. Warning variant when uptime < 14 days.
- Replace the `LIKE '%].[%(%'` heuristic that flagged computed columns and check constraints as "containing UDFs". The pattern fired on string literals containing `].[`, schema-qualified system functions like `[sys].[fn_xxx]()`, and OBJECT_ID literals that include schema-qualified names. Now uses `sys.sql_expression_dependencies` filtered to FN/IF/TF/FS/FT object types, joined to `sys.objects` for the clean `[schema].[name]` list.

### sp_QuickieStore — Azure SQL DB conversion error in `@expert_mode` (#767, #771, #772)
On Azure SQL DB Hyperscale (and likely other tiers), `EXEC dbo.sp_QuickieStore @expert_mode = 1` failed with **Msg 8114 — Error converting data type nvarchar to bigint** while inserting into `#tuning_recommendations`.

Root cause: the string-split path that parses `sys.dm_db_tuning_recommendations.details` (the pre-2017-compat fallback) returns `regressed_plan_id` and `recommended_plan_id` with a **leading space** — the REPLACE chain inserts `': '` after every colon, and the SUBSTRING math doesn't account for it. The implicit cast on insert into `#tuning_recommendations` was silently rescuing the value on the box product, but Hyperscale errored on the same shape.

- **#771** (@ClaudioESSilva): added `TRY_CAST(... AS bigint)` to the `WHERE` clause so the join survived the leading-space text.
- **#772**: moved the type intent to the projection — `regressed_plan_id` / `recommended_plan_id` now leave the derived table already typed via `TRY_CAST(LTRIM(SUBSTRING(...)) AS bigint)`. The redundant `TRY_CAST` in the WHERE clause is removed. Splitting math is left alone.

Thanks to @ravirajch for the report and the Hyperscale repro, and to @ClaudioESSilva for the diagnosis and patch.

## Repo
- Bug-report template now asks for `@debug = 1` output.