### PR TITLE
Promote dev to main: HAS_DBACCESS preflight + Express edition fixes

### DIFF
--- a/Install-All/DarlingData.sql
+++ b/Install-All/DarlingData.sql
@@ -1,4 +1,4 @@
--- Compile Date: 04/27/2026 23:04:36 UTC
+-- Compile Date: 04/29/2026 21:01:51 UTC
 SET ANSI_NULLS ON;
 SET ANSI_PADDING ON;
 SET ANSI_WARNINGS ON;
@@ -73,8 +73,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.5',
-        @version_date = '20260420';
+        @version = '3.6',
+        @version_date = '20260501';
 
     IF @help = 1
     BEGIN
@@ -6364,8 +6364,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.5',
-    @version_date = '20260420';
+    @version = '7.6',
+    @version_date = '20260501';
 
 IF @help = 1
 BEGIN
@@ -11376,8 +11376,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.5',
-    @version_date = '20260420';
+    @version = '5.6',
+    @version_date = '20260501';
 
 IF @help = 1
 BEGIN
@@ -15590,8 +15590,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.5',
-        @version_date = '20260420';
+        @version = '2.6',
+        @version_date = '20260501';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */
@@ -22773,8 +22773,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.5',
-        @version_date = '20260420';
+        @version = '3.6',
+        @version_date = '20260501';
 
     IF @help = 1
     BEGIN
@@ -23542,8 +23542,8 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.5',
-        @version_date = N'20260420';
+        @version = N'2.6',
+        @version_date = N'20260501';
 
     /*
     Help section, for help.
@@ -28680,8 +28680,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.5',
-    @version_date = '20260420';
+    @version = '6.6',
+    @version_date = '20260501';
 
 
 IF @help = 1
@@ -29232,10 +29232,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     total_mb_read decimal(38,2) NULL,
                     total_read_count bigint NULL,
                     avg_read_stall_ms decimal(38,2) NULL,
+                    avg_read_kb decimal(38,2) NULL,
                     total_gb_written decimal(38,2) NULL,
                     total_mb_written decimal(38,2) NULL,
                     total_write_count bigint NULL,
                     avg_write_stall_ms decimal(38,2) NULL,
+                    avg_write_kb decimal(38,2) NULL,
+                    num_of_bytes_read bigint NULL,
+                    num_of_bytes_written bigint NULL,
                     io_stall_read_ms bigint NULL,
                     io_stall_write_ms bigint NULL,
                     PRIMARY KEY CLUSTERED (collection_time, id)
@@ -29654,10 +29658,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
         total_mb_read decimal(38,2),
         total_read_count bigint,
         avg_read_stall_ms decimal(38,2),
+        avg_read_kb decimal(38,2),
         total_gb_written decimal(38,2),
         total_mb_written decimal(38,2),
         total_write_count bigint,
         avg_write_stall_ms decimal(38,2),
+        avg_write_kb decimal(38,2),
+        num_of_bytes_read bigint,
+        num_of_bytes_written bigint,
         io_stall_read_ms bigint,
         io_stall_write_ms bigint,
         sample_time datetime
@@ -30300,6 +30308,21 @@ OPTION(MAXDOP 1, RECOMPILE);',
                         0.
                     )
                 ),
+            avg_read_kb =
+                CONVERT
+                (
+                    decimal(38, 2),
+                    ISNULL
+                    (
+                        (vfs.num_of_bytes_read / 1024.) /
+                          CONVERT
+                          (
+                              decimal(38, 2),
+                              NULLIF(vfs.num_of_reads, 0.)
+                          ),
+                        0.
+                    )
+                ),
             total_gb_written =
                 CASE
                     WHEN vfs.num_of_bytes_written > 0
@@ -30337,6 +30360,25 @@ OPTION(MAXDOP 1, RECOMPILE);',
                         0.
                     )
                 ),
+            avg_write_kb =
+                CONVERT
+                (
+                    decimal(38, 2),
+                    ISNULL
+                    (
+                        (vfs.num_of_bytes_written / 1024.) /
+                          CONVERT
+                          (
+                              decimal(38, 2),
+                              NULLIF(vfs.num_of_writes, 0.)
+                          ),
+                        0.
+                    )
+                ),
+            num_of_bytes_read =
+                vfs.num_of_bytes_read,
+            num_of_bytes_written =
+                vfs.num_of_bytes_written,
             io_stall_read_ms,
             io_stall_write_ms,
             sample_time =
@@ -30392,10 +30434,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
             total_mb_read,
             total_read_count,
             avg_read_stall_ms,
+            avg_read_kb,
             total_gb_written,
             total_mb_written,
             total_write_count,
             avg_write_stall_ms,
+            avg_write_kb,
+            num_of_bytes_read,
+            num_of_bytes_written,
             io_stall_read_ms,
             io_stall_write_ms,
             sample_time
@@ -30418,6 +30464,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                         fm.file_size_gb,
                         fm.avg_read_stall_ms,
                         fm.avg_write_stall_ms,
+                        fm.avg_read_kb,
+                        fm.avg_write_kb,
                         fm.total_gb_read,
                         fm.total_gb_written,
                         total_read_count =
@@ -30440,6 +30488,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     fm.avg_read_stall_ms,
                     fm.avg_write_stall_ms,
                     fm.total_avg_stall_ms,
+                    fm.avg_read_kb,
+                    fm.avg_write_kb,
                     fm.total_gb_read,
                     fm.total_gb_written,
                     fm.total_read_count,
@@ -30457,6 +30507,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     avg_read_stall_ms = 0,
                     avg_write_stall_ms = 0,
                     total_avg_stall_ms = 0,
+                    avg_read_kb = 0,
+                    avg_write_kb = 0,
                     total_gb_read = 0,
                     total_gb_written = 0,
                     total_read_count = N'0',
@@ -30529,6 +30581,30 @@ OPTION(MAXDOP 1, RECOMPILE);',
                                         )
                                     )
                             END,
+                        avg_read_kb =
+                            CASE
+                                WHEN (fm2.total_read_count - fm.total_read_count) = 0
+                                THEN 0.00
+                                ELSE
+                                    CONVERT
+                                    (
+                                        decimal(38, 2),
+                                        ((fm2.num_of_bytes_read - fm.num_of_bytes_read) / 1024.) /
+                                        (fm2.total_read_count - fm.total_read_count)
+                                    )
+                            END,
+                        avg_write_kb =
+                            CASE
+                                WHEN (fm2.total_write_count - fm.total_write_count) = 0
+                                THEN 0.00
+                                ELSE
+                                    CONVERT
+                                    (
+                                        decimal(38, 2),
+                                        ((fm2.num_of_bytes_written - fm.num_of_bytes_written) / 1024.) /
+                                        (fm2.total_write_count - fm.total_write_count)
+                                    )
+                            END,
                         total_mb_read =
                             (fm2.total_mb_read - fm.total_mb_read),
                         total_mb_written =
@@ -30556,6 +30632,8 @@ OPTION(MAXDOP 1, RECOMPILE);',
                     f.avg_read_stall_ms,
                     f.avg_write_stall_ms,
                     f.total_avg_stall,
+                    f.avg_read_kb,
+                    f.avg_write_kb,
                     total_mb_read =
                         FORMAT(f.total_mb_read, 'N0'),
                     total_mb_written =
@@ -30605,10 +30683,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
                    total_mb_read,
                    total_read_count,
                    avg_read_stall_ms,
+                   avg_read_kb,
                    total_gb_written,
                    total_mb_written,
                    total_write_count,
                    avg_write_stall_ms,
+                   avg_write_kb,
+                   num_of_bytes_read,
+                   num_of_bytes_written,
                    io_stall_read_ms,
                    io_stall_write_ms
                )
@@ -30622,10 +30704,14 @@ OPTION(MAXDOP 1, RECOMPILE);',
                    fm.total_mb_read,
                    fm.total_read_count,
                    fm.avg_read_stall_ms,
+                   fm.avg_read_kb,
                    fm.total_gb_written,
                    fm.total_mb_written,
                    fm.total_write_count,
                    fm.avg_write_stall_ms,
+                   fm.avg_write_kb,
+                   fm.num_of_bytes_read,
+                   fm.num_of_bytes_written,
                    fm.io_stall_read_ms,
                    fm.io_stall_write_ms
                FROM #file_metrics AS fm;
@@ -33249,8 +33335,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.5',
-    @version_date = '20260420';
+    @version = '1.6',
+    @version_date = '20260501';
 
 /*Help*/
 IF @help = 1
@@ -37506,8 +37592,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.5',
-        @version_date = '20260420';
+        @version = '1.6',
+        @version_date = '20260501';
 
     /*
     ╔══════════════════════════════════════════════════╗
@@ -39986,8 +40072,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.5',
-    @version_date = '20260420';
+    @version = '6.6',
+    @version_date = '20260501';
 
 /*
 Helpful section! For help.
@@ -50941,30 +51027,42 @@ FROM
         plan_force_json.score,
         plan_force_json.last_refresh,
         regressed_plan_id =
-            SUBSTRING
+            TRY_CAST
             (
-                plan_force_json.detail,
-                CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN(''regressedPlanId: ''),
-                IIF
+                LTRIM
                 (
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
-                    LEN(plan_force_json.detail),
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('',''))
-                )
-                - LEN(''regressedPlanId: '') - CHARINDEX(''regressedPlanId: '', plan_force_json.detail)
+                    SUBSTRING
+                    (
+                        plan_force_json.detail,
+                        CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN(''regressedPlanId: ''),
+                        IIF
+                        (
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
+                            LEN(plan_force_json.detail),
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''regressedPlanId: '', plan_force_json.detail) + LEN('',''))
+                        )
+                        - LEN(''regressedPlanId: '') - CHARINDEX(''regressedPlanId: '', plan_force_json.detail)
+                    )
+                ) AS bigint
             ),
         recommended_plan_id =
-            SUBSTRING
+            TRY_CAST
             (
-                plan_force_json.detail,
-                CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN(''recommendedPlanId: ''),
-                IIF
+                LTRIM
                 (
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
-                    LEN(plan_force_json.detail),
-                    CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('',''))
-                )
-                - LEN(''recommendedPlanId: '') - CHARINDEX(''recommendedPlanId: '', plan_force_json.detail)
+                    SUBSTRING
+                    (
+                        plan_force_json.detail,
+                        CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN(''recommendedPlanId: ''),
+                        IIF
+                        (
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('','')) = 0,
+                            LEN(plan_force_json.detail),
+                            CHARINDEX('','', plan_force_json.detail, CHARINDEX(''recommendedPlanId: '', plan_force_json.detail) + LEN('',''))
+                        )
+                        - LEN(''recommendedPlanId: '') - CHARINDEX(''recommendedPlanId: '', plan_force_json.detail)
+                    )
+                ) AS bigint
             )
     FROM
     (

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -61,6 +61,7 @@ ALTER PROCEDURE
     @get_all_databases bit = 'false', /*looks for all accessible user databases and returns combined results*/
     @include_databases nvarchar(MAX) = NULL, /*comma-separated list of databases to include (only when @get_all_databases = 1)*/
     @exclude_databases nvarchar(MAX) = NULL, /*comma-separated list of databases to exclude (only when @get_all_databases = 1)*/
+    @sort_order varchar(20) = 'default', /*controls final result ordering: default (script type first) or object (cluster all rows for the same database/schema/table/index)*/
     @help bit = 'false', /*learn about the procedure and parameters*/
     @debug bit = 'false', /*print dynamic sql, show temp table contents*/
     @version varchar(20) = NULL OUTPUT, /*script version number*/
@@ -148,6 +149,7 @@ BEGIN TRY
                     WHEN N'@get_all_databases' THEN 'set to 1 to analyze all accessible user databases'
                     WHEN N'@include_databases' THEN 'comma-separated list of databases to include when @get_all_databases = 1'
                     WHEN N'@exclude_databases' THEN 'comma-separated list of databases to exclude when @get_all_databases = 1'
+                    WHEN N'@sort_order' THEN 'controls final result ordering: default groups by script type within each database, object groups all rows for the same index together'
                     WHEN N'@help' THEN 'displays this help information'
                     WHEN N'@debug' THEN 'prints debug information during execution'
                     WHEN N'@version' THEN 'returns the version number of the procedure'
@@ -168,6 +170,7 @@ BEGIN TRY
                     WHEN N'@get_all_databases' THEN '0 or 1'
                     WHEN N'@include_databases' THEN 'comma-separated list of database names'
                     WHEN N'@exclude_databases' THEN 'comma-separated list of database names'
+                    WHEN N'@sort_order' THEN 'default or object'
                     WHEN N'@help' THEN '0 or 1'
                     WHEN N'@debug' THEN '0 or 1'
                     WHEN N'@version' THEN 'OUTPUT parameter'
@@ -188,6 +191,7 @@ BEGIN TRY
                     WHEN N'@get_all_databases' THEN 'false'
                     WHEN N'@include_databases' THEN 'NULL'
                     WHEN N'@exclude_databases' THEN 'NULL'
+                    WHEN N'@sort_order' THEN 'default'
                     WHEN N'@help' THEN 'false'
                     WHEN N'@debug' THEN 'false'
                     WHEN N'@version' THEN 'NULL'
@@ -236,6 +240,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         RETURN;
     END;
 
+    /*
+    Validate @sort_order
+    */
+    SET @sort_order = LOWER(LTRIM(RTRIM(ISNULL(@sort_order, N'default'))));
+
+    IF @sort_order NOT IN (N'default', N'object')
+    BEGIN
+        RAISERROR(N'@sort_order must be either ''default'' or ''object''.', 16, 1);
+        RETURN;
+    END;
+
     IF @debug = 1
     BEGIN
         RAISERROR('Declaring variables', 0, 0) WITH NOWAIT;
@@ -274,7 +289,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                       (
                           integer,
                           SERVERPROPERTY('EngineEdition')
-                      ) = 2
+                      ) IN (2, 4)
                       AND CONVERT
                           (
                               integer,
@@ -299,8 +314,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 /* Azure SQL DB or Managed Instance */
                 WHEN CONVERT(integer, SERVERPROPERTY('EngineEdition')) IN (5, 8)
                 THEN 1
-                /* SQL Server 2019+ (Enterprise or Standard) */
-                WHEN CONVERT(integer, SERVERPROPERTY('EngineEdition')) IN (2, 3)
+                /* SQL Server 2019+ (Enterprise, Standard, Web, or Express) */
+                WHEN CONVERT(integer, SERVERPROPERTY('EngineEdition')) IN (2, 3, 4)
                      AND CONVERT
                          (
                              integer,
@@ -6458,9 +6473,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     WHERE ir.rn = 1 /* Take only the first row for each index */
     ORDER BY
         ir.database_name,
+        /* Object mode: cluster by schema/table/index before script type */
+        CASE WHEN @sort_order = N'object' THEN ir.schema_name END,
+        CASE WHEN @sort_order = N'object' THEN ir.table_name END,
+        CASE WHEN @sort_order = N'object' THEN ir.index_name END,
+        /* Always order by script type within the current grouping */
         ir.sort_order,
-        /* Within each sort_order group, prioritize by size and usage */
+        /* Default mode: within each sort_order group, prioritize by size and usage */
         CASE
+            WHEN @sort_order <> N'default'
+            THEN NULL
             /* For SUMMARY, keep the original order */
             WHEN ir.result_type = 'SUMMARY'
             THEN 0
@@ -6468,6 +6490,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             ELSE ISNULL(ir.index_size_gb, 0)
         END DESC,
         CASE
+            WHEN @sort_order <> N'default'
+            THEN NULL
             /* For SUMMARY, keep the original order */
             WHEN ir.result_type = 'SUMMARY'
             THEN 0

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -1221,6 +1221,34 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         /* Single database mode */
         IF @database_name IS NOT NULL
         BEGIN
+            /*
+            Preflight: if the database exists and is otherwise eligible but the current
+            principal has no access, fail loud rather than letting downstream queries hang.
+            sp_IndexCleanup queries sys.dm_db_partition_stats via three-part name, which
+            under a SQL Server permission/recompile bug spins at 100% CPU forever instead
+            of erroring (Msg 916). See PerformanceMonitor issue #915.
+            */
+            IF EXISTS
+               (
+                   SELECT
+                       1/0
+                   FROM sys.databases AS d
+                   WHERE d.name = @database_name
+                   AND   d.state = 0
+                   AND   d.is_in_standby = 0
+                   AND   d.is_read_only = 0
+               )
+            AND ISNULL(HAS_DBACCESS(@database_name), 0) = 0
+            BEGIN
+                SET @error_msg =
+                    N'The current login has no access to database ' +
+                    QUOTENAME(@database_name) +
+                    N'. Run, against that database: CREATE USER [<login>] FOR LOGIN [<login>]; GRANT VIEW DATABASE STATE; GRANT VIEW DEFINITION;';
+
+                RAISERROR(@error_msg, 16, 1);
+                RETURN;
+            END;
+
             INSERT INTO
                 #databases
             WITH
@@ -1237,6 +1265,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             AND   d.state = 0
             AND   d.is_in_standby = 0
             AND   d.is_read_only = 0
+            AND   HAS_DBACCESS(d.name) = 1
             OPTION(RECOMPILE);
 
             /* Get the database_id for backwards compatibility */
@@ -1248,7 +1277,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     END
     ELSE
     BEGIN
-        /* Multi-database mode */
+        /*
+        Multi-database mode. HAS_DBACCESS gates which databases the current principal can
+        actually query; without this filter, three-part-name queries against
+        sys.dm_db_partition_stats hang indefinitely under a SQL Server permission/recompile
+        bug. See PerformanceMonitor issue #915.
+        */
         INSERT INTO
             #databases
         WITH
@@ -1265,6 +1299,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   d.state = 0
         AND   d.is_in_standby = 0
         AND   d.is_read_only = 0
+        AND   HAS_DBACCESS(d.name) = 1
         AND   (
                 @include_databases IS NULL
                 OR EXISTS (SELECT 1/0 FROM #include_databases AS id WHERE id.database_name = d.name)
@@ -1274,6 +1309,81 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 OR NOT EXISTS (SELECT 1/0 FROM #exclude_databases AS ed WHERE ed.database_name = d.name)
               )
         OPTION(RECOMPILE);
+
+        /*
+        Track databases that would otherwise qualify but were skipped because the current
+        principal has no access. These surface in the SUMMARY row so the operator knows
+        which databases need GRANT before they will be analyzed.
+        */
+        INSERT INTO
+            #requested_but_skipped_databases
+        WITH
+            (TABLOCK)
+        (
+            database_name,
+            reason
+        )
+        SELECT
+            d.name,
+            reason = N'No database access for current login'
+        FROM sys.databases AS d
+        WHERE d.database_id > 4
+        AND   d.state = 0
+        AND   d.is_in_standby = 0
+        AND   d.is_read_only = 0
+        AND   ISNULL(HAS_DBACCESS(d.name), 0) = 0
+        AND   (
+                @include_databases IS NULL
+                OR EXISTS (SELECT 1/0 FROM #include_databases AS id WHERE id.database_name = d.name)
+              )
+        AND   (
+                @exclude_databases IS NULL
+                OR NOT EXISTS (SELECT 1/0 FROM #exclude_databases AS ed WHERE ed.database_name = d.name)
+              )
+        OPTION(RECOMPILE);
+
+        /*
+        Surface a non-fatal warning listing the skipped databases. Severity 10 with NOWAIT
+        matches existing progress messages and is visible regardless of @debug. Skipped
+        databases never produce result-set rows; they appear in the SUMMARY row's
+        "skipped databases" column.
+        */
+        IF EXISTS
+           (
+               SELECT
+                   1/0
+               FROM #requested_but_skipped_databases AS rbs
+               WHERE rbs.reason = N'No database access for current login'
+           )
+        BEGIN
+            SET @error_msg = N'';
+
+            SELECT
+                @error_msg =
+                    @error_msg +
+                    rbs.database_name +
+                    N', '
+            FROM #requested_but_skipped_databases AS rbs
+            WHERE rbs.reason = N'No database access for current login'
+            ORDER BY
+                rbs.database_name
+            OPTION(RECOMPILE);
+
+            IF DATALENGTH(@error_msg) > 0
+            BEGIN
+                SET @error_msg = LEFT(@error_msg, DATALENGTH(@error_msg) / 2 - 2);
+
+                SET @error_msg =
+                    N'Skipping these databases - current login has no access: ' +
+                    @error_msg +
+                    N'. Run, against each: CREATE USER [<login>] FOR LOGIN [<login>]; GRANT VIEW DATABASE STATE; GRANT VIEW DEFINITION;';
+
+                RAISERROR(@error_msg, 10, 1) WITH NOWAIT;
+
+                /* Reset for subsequent uses below. */
+                SET @error_msg = N'';
+            END;
+        END;
     END;
 
     /* Check for empty database list */
@@ -1322,6 +1432,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     THEN 'Database is read-only'
                     WHEN d.database_id <= 4
                     THEN 'System database'
+                    WHEN ISNULL(HAS_DBACCESS(d.name), 0) = 0
+                    THEN 'No database access for current login'
                     ELSE 'Other issue'
                 END
         FROM #include_databases AS id
@@ -1333,6 +1445,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                       1/0
                   FROM #databases AS db
                   WHERE db.database_name = id.database_name
+              )
+        /* HAS_DBACCESS skips were already recorded above; avoid PK conflicts. */
+        AND   NOT EXISTS
+              (
+                  SELECT
+                      1/0
+                  FROM #requested_but_skipped_databases AS rbs
+                  WHERE rbs.database_name = id.database_name
               )
         OPTION(RECOMPILE);
 

--- a/sp_IndexCleanup/tests/no_access_test.py
+++ b/sp_IndexCleanup/tests/no_access_test.py
@@ -1,0 +1,203 @@
+"""
+sp_IndexCleanup HAS_DBACCESS Preflight Test
+============================================
+Verifies sp_IndexCleanup does NOT hang when invoked by a login that lacks
+access to the target user database(s).
+
+Background: PerformanceMonitor #915. Without the preflight, three-part-name
+queries against sys.dm_db_partition_stats spin at 100% CPU forever instead
+of erroring (Msg 916).
+
+What this script does:
+  1. Connects as sa, creates a temp login with VIEW SERVER STATE only
+     (no user mapping in any user database).
+  2. Runs sp_IndexCleanup as that login, both single-DB and multi-DB,
+     under a hard wall-clock timeout.
+  3. Asserts the call returns within seconds (proving no hang) and does
+     not produce result-set rows for inaccessible databases.
+  4. Drops the temp login.
+
+Usage:
+    python no_access_test.py [--server SQL2022] [--password "L!nt0044"]
+"""
+
+import subprocess
+import sys
+import time
+import secrets
+
+TEST_LOGIN = f"sp_indexcleanup_no_access_test_{secrets.token_hex(4)}"
+TEST_PASSWORD = "T3st!" + secrets.token_hex(8) + "Aa1"
+TIMEOUT_SECONDS = 30
+
+
+def run_sqlcmd_as_sa(server, sa_password, sql):
+    """Execute a SQL statement as sa."""
+    cmd = [
+        "sqlcmd", "-S", server, "-U", "sa", "-P", sa_password,
+        "-d", "master", "-b", "-Q", sql,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(f"sa SQL failed:\n{result.stderr}\n{result.stdout}")
+    return result.stdout
+
+
+def run_sqlcmd_as_test_login(server, sql, timeout):
+    """Execute a SQL statement as the test login, with a wall-clock timeout."""
+    cmd = [
+        "sqlcmd", "-S", server, "-U", TEST_LOGIN, "-P", TEST_PASSWORD,
+        "-d", "master", "-Q", sql,
+    ]
+    start = time.monotonic()
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return None, "TIMED OUT", time.monotonic() - start
+    elapsed = time.monotonic() - start
+    return result.stdout, result.stderr, elapsed
+
+
+def setup_login(server, sa_password):
+    print(f"  Creating test login {TEST_LOGIN}...")
+    run_sqlcmd_as_sa(server, sa_password, f"""
+        IF SUSER_ID(N'{TEST_LOGIN}') IS NOT NULL
+            DROP LOGIN [{TEST_LOGIN}];
+        CREATE LOGIN [{TEST_LOGIN}] WITH PASSWORD = N'{TEST_PASSWORD}',
+            CHECK_POLICY = OFF;
+        GRANT VIEW SERVER STATE TO [{TEST_LOGIN}];
+    """)
+    run_sqlcmd_as_sa(server, sa_password, f"""
+        USE master;
+        IF DATABASE_PRINCIPAL_ID(N'{TEST_LOGIN}') IS NULL
+            CREATE USER [{TEST_LOGIN}] FOR LOGIN [{TEST_LOGIN}];
+        GRANT EXECUTE ON dbo.sp_IndexCleanup TO [{TEST_LOGIN}];
+    """)
+
+
+def teardown_login(server, sa_password):
+    print(f"  Dropping test login {TEST_LOGIN}...")
+    try:
+        run_sqlcmd_as_sa(server, sa_password, f"""
+            USE master;
+            IF DATABASE_PRINCIPAL_ID(N'{TEST_LOGIN}') IS NOT NULL
+                DROP USER [{TEST_LOGIN}];
+        """)
+        run_sqlcmd_as_sa(server, sa_password, f"""
+            IF SUSER_ID(N'{TEST_LOGIN}') IS NOT NULL
+                DROP LOGIN [{TEST_LOGIN}];
+        """)
+    except Exception as e:
+        print(f"  Warning: cleanup failed: {e}")
+
+
+def find_test_database(server, sa_password):
+    """Pick any online user database with no mapping for the test login."""
+    out = run_sqlcmd_as_sa(server, sa_password, """
+        SET NOCOUNT ON;
+        SELECT TOP (1) name
+        FROM sys.databases
+        WHERE database_id > 4
+          AND state = 0
+          AND is_in_standby = 0
+          AND is_read_only = 0
+        ORDER BY database_id;
+    """)
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or line.startswith("-") or line.lower() == "name":
+            continue
+        return line
+    raise RuntimeError("No eligible user database found for test")
+
+
+def assert_returned_quickly(label, elapsed):
+    if elapsed >= TIMEOUT_SECONDS:
+        print(f"  [FAIL] {label}: hung past {TIMEOUT_SECONDS}s")
+        return False
+    print(f"  [PASS] {label}: returned in {elapsed:.2f}s")
+    return True
+
+
+def main():
+    server = "SQL2022"
+    sa_password = "L!nt0044"
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--server" and i + 1 < len(args):
+            server = args[i + 1]
+        elif arg == "--password" and i + 1 < len(args):
+            sa_password = args[i + 1]
+
+    print(f"sp_IndexCleanup HAS_DBACCESS preflight test against {server}")
+    print()
+
+    setup_login(server, sa_password)
+    try:
+        target_db = find_test_database(server, sa_password)
+        print(f"  Using target database: {target_db}")
+        print()
+
+        passed = 0
+        failed = 0
+
+        # Test 1: explicit @database_name with no access -> clear error, no hang
+        print(f"Test 1: explicit @database_name = '{target_db}', no user mapping")
+        sql_single = (
+            f"EXECUTE master.dbo.sp_IndexCleanup "
+            f"@database_name = N'{target_db}', @dedupe_only = 1;"
+        )
+        stdout, stderr, elapsed = run_sqlcmd_as_test_login(server, sql_single, TIMEOUT_SECONDS)
+        if not assert_returned_quickly("returns quickly", elapsed):
+            failed += 1
+        else:
+            passed += 1
+
+        if stderr is None:
+            failed += 1
+        elif "no access" in (stderr or "").lower() or "no access" in (stdout or "").lower():
+            print("  [PASS] error mentions 'no access'")
+            passed += 1
+        else:
+            print("  [FAIL] expected 'no access' in error output")
+            print(f"    stdout: {(stdout or '')[:300]}")
+            print(f"    stderr: {(stderr or '')[:300]}")
+            failed += 1
+
+        # Test 2: @get_all_databases with no access -> warn + no result rows for skipped
+        print()
+        print("Test 2: @get_all_databases = 1, no user mappings anywhere")
+        sql_multi = (
+            "EXECUTE master.dbo.sp_IndexCleanup "
+            "@get_all_databases = 1, @dedupe_only = 1;"
+        )
+        stdout, stderr, elapsed = run_sqlcmd_as_test_login(server, sql_multi, TIMEOUT_SECONDS)
+        if not assert_returned_quickly("returns quickly", elapsed):
+            failed += 1
+        else:
+            passed += 1
+
+        # In multi-DB mode every user DB will be inaccessible, so the proc raises
+        # "No valid databases found to process." after first surfacing the no-access
+        # warning. Both behaviors prove we did not hang.
+        combined = ((stdout or "") + " " + (stderr or "")).lower()
+        if "no valid databases" in combined or "no access" in combined:
+            print("  [PASS] surfaced no-access / no-valid-databases message")
+            passed += 1
+        else:
+            print("  [FAIL] expected no-access or no-valid-databases message")
+            print(f"    stdout: {(stdout or '')[:400]}")
+            print(f"    stderr: {(stderr or '')[:400]}")
+            failed += 1
+
+        print()
+        print(f"Results: {passed} passed, {failed} failed")
+        if failed:
+            sys.exit(1)
+        print("All HAS_DBACCESS preflight tests passed!")
+    finally:
+        teardown_login(server, sa_password)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Promotes two fixes from `dev` so Dashboard users pulling from `main` get them:

- **#778** — `sp_IndexCleanup` HAS_DBACCESS preflight. Avoids the indefinite 100% CPU hang when the executing principal has no user mapping in a target database (PerformanceMonitor [#915](https://github.com/erikdarlingdata/PerformanceMonitor/issues/915)). Engine bug: the compiled three-part-name plan trips a permission check at execute time, gets misclassified as "needs recompile," and loops. Fix preflights via `HAS_DBACCESS` and either errors clearly (single DB) or skips with a non-fatal warning (multi-DB).
- **#776 / #777** — `sp_IndexCleanup` recognizes Express edition; adds `@sort_order` parameter.

## Test plan

- [x] CI green on `dev` for all four SQL Server versions (2017/2019/2022/2025).
- [x] Adversarial suite 26/26 + new `no_access_test.py` 4/4 passing on SQL2022.