### PR TITLE
sp_QuickieStore: add 'failed' to @execution_type_desc that bundles aborted+exception

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -62,7 +62,7 @@ ALTER PROCEDURE
     @timezone sysname = NULL, /*user specified time zone to override dates displayed in results*/
     @execution_count bigint = NULL, /*the minimum number of executions a query must have*/
     @duration_ms bigint = NULL, /*the minimum duration a query must have to show up in results*/
-    @execution_type_desc nvarchar(60) = NULL, /*the type of execution you want to filter by (regular, aborted, exception)*/
+    @execution_type_desc nvarchar(60) = NULL, /*the type of execution you want to filter by (regular, aborted, exception, failed); failed bundles aborted and exception*/
     @procedure_schema sysname = NULL, /*the schema of the procedure you're searching for*/
     @procedure_name sysname = NULL, /*the name of the programmable object you're searching for*/
     @include_plan_ids nvarchar(4000) = NULL, /*a list of plan ids to search for*/
@@ -165,7 +165,7 @@ BEGIN
                 WHEN N'@timezone' THEN 'user specified time zone to override dates displayed in results'
                 WHEN N'@execution_count' THEN 'the minimum number of executions a query must have'
                 WHEN N'@duration_ms' THEN 'the minimum duration a query must have to show up in results'
-                WHEN N'@execution_type_desc' THEN 'the type of execution you want to filter by (regular, aborted, exception)'
+                WHEN N'@execution_type_desc' THEN 'the type of execution you want to filter by (regular, aborted, exception, failed); failed bundles aborted and exception'
                 WHEN N'@procedure_schema' THEN 'the schema of the procedure you''re searching for'
                 WHEN N'@procedure_name' THEN 'the name of the programmable object you''re searching for'
                 WHEN N'@include_plan_ids' THEN 'a list of plan ids to search for'
@@ -228,7 +228,7 @@ BEGIN
                 WHEN N'@timezone' THEN 'SELECT tzi.* FROM sys.time_zone_info AS tzi;'
                 WHEN N'@execution_count' THEN 'a positive integer between 1 and 9,223,372,036,854,775,807'
                 WHEN N'@duration_ms' THEN 'a positive integer between 1 and 9,223,372,036,854,775,807'
-                WHEN N'@execution_type_desc' THEN 'regular, aborted, exception'
+                WHEN N'@execution_type_desc' THEN 'regular, aborted, exception, failed'
                 WHEN N'@procedure_schema' THEN 'a valid schema in your database'
                 WHEN N'@procedure_name' THEN 'a valid programmable object in your database, can use wildcards'
                 WHEN N'@include_plan_ids' THEN 'a string; comma separated for multiple ids'
@@ -2888,13 +2888,14 @@ Error out if the @execution_type_desc value is invalid.
 IF
 (
     @execution_type_desc IS NOT NULL
-AND @execution_type_desc NOT IN ('regular', 'aborted', 'exception')
+AND @execution_type_desc NOT IN ('regular', 'aborted', 'exception', 'failed')
 )
 BEGIN
-    RAISERROR('@execution_type_desc can only take one of these three non-NULL values:
+    RAISERROR('@execution_type_desc can only take one of these four non-NULL values:
     1) ''regular'' (meaning a successful execution),
     2) ''aborted'' (meaning that the client cancelled the query),
-    3) ''exception'' (meaning that an exception cancelled the query).
+    3) ''exception'' (meaning that an exception cancelled the query),
+    4) ''failed'' (a convenience value that bundles both ''aborted'' and ''exception'').
 
 You supplied ''%s''.
 
@@ -6852,8 +6853,16 @@ END;
 
 IF @execution_type_desc IS NOT NULL
 BEGIN
-    SELECT
-        @where_clause += N'    AND   qsrs.execution_type_desc = @execution_type_desc' + @nc10;
+    IF @execution_type_desc = N'failed'
+    BEGIN
+        SELECT
+            @where_clause += N'    AND   qsrs.execution_type_desc IN (N''aborted'', N''exception'')' + @nc10;
+    END;
+    ELSE
+    BEGIN
+        SELECT
+            @where_clause += N'    AND   qsrs.execution_type_desc = @execution_type_desc' + @nc10;
+    END;
 END;
 
 IF @workdays = 1


### PR DESCRIPTION
## Summary
- Adds `'failed'` as a fourth accepted value for `@execution_type_desc`. When supplied, the dynamic WHERE clause emits `qsrs.execution_type_desc IN (N'aborted', N'exception')` instead of the existing single-value `=` form.
- Validation list, RAISERROR text, parameter inline comment, and the `Parameter description` / `Valid inputs` switch arms in the help block all updated to mention `'failed'`.
- The three pre-existing values (`'regular'`, `'aborted'`, `'exception'`) continue to use the original parameterized comparison — no behavior change for existing callers.

## Test plan
Verified locally on SQL 2022 against `master.dbo.sp_QuickieStore`:
- [x] `@execution_type_desc = N'bogus'` → RAISERROR fires with the new 4-value message that includes `'failed'`.
- [x] `@execution_type_desc = N'failed'` with `@debug = 1` → generated WHERE clause contains `qsrs.execution_type_desc IN (N'aborted', N'exception')`.
- [x] `@execution_type_desc = N'aborted'` with `@debug = 1` → generated WHERE clause still contains `qsrs.execution_type_desc = @execution_type_desc` (regression check on the original three values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)