### PR TITLE
sp_HumanEvents: fix view creation when @output_schema_name is not dbo (#785)

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -4032,9 +4032,12 @@ BEGIN
                                 N'.'  +
                                 vc.output_table
                             ),
-                            N'[dbo]' +
-                            '.' +
-                            QUOTENAME(vc.view_name),
+                            /* view bodies are stored unbracketed as
+                               "dbo.<view_name>" — match that form, not
+                               "[dbo].[<view_name>]", or the swap to the
+                               user's @output_schema_name silently no-ops */
+                            N'dbo.' +
+                            vc.view_name,
                             QUOTENAME(vc.output_schema) +
                             '.' +
                             QUOTENAME(vc.view_name)


### PR DESCRIPTION
## Summary
- The view-creation block in `sp_HumanEvents` stores view bodies as binary literals and uses a 3-way `REPLACE` to retarget the database/schema at runtime.
- The middle `REPLACE` searched for the **bracketed** form `[dbo].[<view_name>]`, but back in commit 12293f1 (Oct 2023) the stored view definitions were rewritten to the **unbracketed** form (`CREATE VIEW dbo.HumanEvents_Blocking ...`) and the REPLACE pattern was never updated.
- Result: with any `@output_schema_name <> N'dbo'`, the schema swap silently no-op'd and view creation failed with `Invalid object name 'dbo.HumanEvents_Blocking'`.
- One-line fix: search for `N'dbo.' + vc.view_name` (unbracketed) so it actually matches what's stored.

## Test plan
- [x] Install procedure cleanly
- [ ] Run with `@output_database_name = N'<db>', @output_schema_name = N'<non-dbo schema>'` and confirm views are created in that schema with no errors
- [ ] Run with default `@output_schema_name = N'dbo'` and confirm no regression

Fixes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)