### PR TITLE
sp_HumanEvents: fix stray AS sqlhandle in blocking-table INSERT (#785)

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -4308,7 +4308,7 @@ FROM
                     varbinary(64),
                     bd.value(''(process/executionStack/frame/@sqlhandle)[1]'', ''nvarchar(260)''),
                     1
-                ) AS sqlhandle,
+                ),
             process_report = oa.c.query(''.'')
         FROM #human_events_xml_internal AS xet
         OUTER APPLY xet.human_events_xml.nodes(''//event'') AS oa(c)


### PR DESCRIPTION
## Summary
- Follow-up to #786. With the schema-replace bug fixed, the reporter on #785 advanced to a new error from the blocking-table INSERT path:

  > Msg 156, Level 15, State 1, Line 79 — Incorrect syntax near the keyword 'AS'.

- Root cause: the Sept 2024 "Cursor variables" refactor (9d3cff3) switched column aliases from \`expr AS alias\` to \`alias = expr\`, but for one column it left both forms in place:

  \`\`\`sql
  sqlhandle =
      CONVERT
      (
          varbinary(64),
          bd.value('(process/executionStack/frame/@sqlhandle)[1]', 'nvarchar(260)'),
          1
      ) AS sqlhandle,
  \`\`\`

  T-SQL rejects \`alias = expr AS alias\`. Dropped the trailing \`AS sqlhandle\`.

- Was masked for ~14 months because anyone using a non-dbo \`@output_schema_name\` hit the schema-replace bug first; dbo users probably weren't exercising the blocking + table-output path.

## Test plan
- [ ] Run with non-dbo schema and \`@event_type = N'blocking'\` (or default), confirm the blocking INSERT executes cleanly
- [ ] Run with dbo schema and same params, confirm no regression

Refs #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)