### PR TITLE
sp_QuickieStore: fix plan_count/query_count under-count in @find_high_impact

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -6238,8 +6238,29 @@ OPTION(RECOMPILE);' + @nc10;
                 THEN qw.top_waits
             END,
         s.query_hash,
-        s.query_count,
-        s.plan_count,
+        /*
+        query_count and plan_count are the all-time number of distinct
+        query_ids and plans for this query_hash (matching query_id_list
+        and plan_id_list), not just the ones active in the analyzed
+        window. The #hi_query_stats counts only cover window-active
+        query_ids and plans, which under-counts here; #hi_query_stats.
+        plan_count is still used below for the window-scoped plan
+        instability diagnostics.
+        */
+        query_count =
+        (
+            SELECT
+                COUNT_BIG(DISTINCT sq.query_id)
+            FROM #hi_id_staging_queries AS sq
+            WHERE sq.query_hash = s.query_hash
+        ),
+        plan_count =
+        (
+            SELECT
+                COUNT_BIG(DISTINCT sp.plan_id)
+            FROM #hi_id_staging_plans AS sp
+            WHERE sp.query_hash = s.query_hash
+        ),
         qi.query_id_list,
         qi.plan_id_list,
         impact_score =


### PR DESCRIPTION
## Problem

In the `@find_high_impact` code path, the `plan_count` and `query_count` columns were sourced from `#hi_query_stats`, which only aggregates plans and queries that were **active within the analyzed time window**. The adjacent `plan_id_list` and `query_id_list` columns are built from the unfiltered `#hi_id_staging_*` tables (all-time).

Result: any `query_hash` with retired plans showed a `plan_count` lower than the number of IDs actually listed in `plan_id_list` (and likewise for `query_count`). The help text documents both columns as all-time totals ("across all variants" / "share this hash").

## Fix

Source the displayed `plan_count` and `query_count` from `#hi_id_staging_plans` and `#hi_id_staging_queries` so they match their `_id_list` counterparts. The window-scoped `#hi_query_stats.plan_count` is retained for the in-window plan instability diagnostics, which intentionally describe churn within the window.

## Test plan

Verified on SQL Server 2025 against StackOverflow2013, which has query_hashes with retired plans:

| query_hash | plan_count (after fix) | plan_id_list entries | plan_count before fix |
|---|---|---|---|
| `0x11ACF1DF8D17C1F6` | 9 | 9 | 7 |
| `0xF1C03AF2954FFC95` | 3 | 3 | 2 |
| `0xDD142572DE1019CB` | 4 | 4 | 3 |

`plan_count` and `query_count` now exactly equal the number of IDs in their respective `_id_list` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)