### PR TITLE
Updates_20260601 release prep

### DIFF
--- a/ProtectSession/ProtectSession.sql
+++ b/ProtectSession/ProtectSession.sql
@@ -75,7 +75,7 @@ BEGIN
 
     SELECT
         @version = '1.0',
-        @version_date = '20260522';
+        @version_date = '20260601';
 
     BEGIN TRY
         IF @help = 1
@@ -161,6 +161,26 @@ BEGIN
             ORDER BY
                 ap.parameter_id
             OPTION(MAXDOP 1, RECOMPILE);
+
+            /*
+            Example calls
+            */
+            SELECT
+                example_calls = N'EXAMPLE CALLS' UNION ALL
+            SELECT N'run this from a separate connection -- not the session you''re protecting' UNION ALL
+            SELECT REPLICATE(N'-', 100) UNION ALL
+            SELECT N'basic: protect spid 55, kill any read or temp-table blocker holding it up for 10+ seconds' UNION ALL
+            SELECT REPLICATE(N'-', 100) UNION ALL
+            SELECT N'EXECUTE dbo.ProtectSession @protected_session_id = 55, @block_threshold_seconds = 10;' UNION ALL
+            SELECT REPLICATE(N'-', 100) UNION ALL
+            SELECT N'aggressive: kill anyone in the way, including blockers actively modifying permanent data (rolls back their work)' UNION ALL
+            SELECT REPLICATE(N'-', 100) UNION ALL
+            SELECT N'EXECUTE dbo.ProtectSession @protected_session_id = 55, @block_threshold_seconds = 10, @kill_modification_blockers = 1;' UNION ALL
+            SELECT REPLICATE(N'-', 100) UNION ALL
+            SELECT N'defensive: when blocked by a permanent-data modification, kill the PROTECTED session instead (preserves the blocker''s work)' UNION ALL
+            SELECT REPLICATE(N'-', 100) UNION ALL
+            SELECT N'EXECUTE dbo.ProtectSession @protected_session_id = 55, @block_threshold_seconds = 10, @abort_on_modification_block = 1, @abort_reason = N''import job blocked by reporting query'';' UNION ALL
+            SELECT REPLICATE(N'-', 100);
 
             /*
             MIT License

--- a/TestBackupPerformance/TestBackupPerformance.sql
+++ b/TestBackupPerformance/TestBackupPerformance.sql
@@ -106,8 +106,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '1.0',
-    @version_date = '20260327';
+    @version = '1.1',
+    @version_date = '20260601';
 
 
 IF @help = 1

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,8 +88,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.6',
-    @version_date = '20260501';
+    @version = '7.7',
+    @version_date = '20260601';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -73,8 +73,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.6',
-        @version_date = '20260501';
+        @version = '2.7',
+        @version_date = '20260601';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -127,8 +127,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.6',
-    @version_date = '20260501';
+    @version = '6.7',
+    @version_date = '20260601';
 
 /*
 Helpful section! For help.


### PR DESCRIPTION
## Summary
- Bump @version + @version_date on the five procs touched since the last release (Updates_20260501)
- Add an EXAMPLE CALLS result set to ProtectSession's @help = 1 output (matches sp_HumanEvents pattern); was the only first-release polish item from the audit

| Proc | Version | Date | Notes |
|---|---|---|---|
| sp_IndexCleanup | 2.6 → 2.7 | → 20260601 | #778 HAS_DBACCESS preflight |
| sp_QuickieStore | 6.6 → 6.7 | → 20260601 | #784 'failed' execution_type, #793 plan_count fix |
| sp_HumanEvents | 7.6 → 7.7 | → 20260601 | #786 view-creation fix, #787 stray AS sqlhandle |
| TestBackupPerformance | 1.0 → 1.1 | 20260327 → 20260601 | #797 @encryption_list feature |
| ProtectSession | 1.0 | 20260522 → 20260601 | First public release |

Audits ran across all five files (style + structure + recent-change sanity). Zero blockers found. Pre-existing style debt (uppercase `nvarchar(MAX)`, `CAST` vs `CONVERT`) is being addressed in a separate cleanup PR.

## Test plan
- [ ] Visual diff confirms only the @version / @version_date lines changed in 4 of 5 files
- [ ] ProtectSession @help = 1 now returns an EXAMPLE CALLS result set with three invocations (basic / aggressive / defensive)
- [ ] All five procs compile cleanly on a target instance
- [ ] sys.dm_sql_referenced_entities returns nothing unexpected (self-contained, no external helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)