### PR TITLE
sp_IndexCleanup: fix silent early exit on Azure SQL DB/Hyperscale when index usage stats are empty

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -1674,7 +1674,28 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 ps.object_id
             HAVING
                 SUM(ps.row_count) >= @min_rows
-        )
+        )';
+
+    /*
+    Only filter on index usage when the caller actually asked for a read or write
+    minimum. sys.dm_db_index_usage_stats has no row for an index that hasn't been
+    touched since usage stats were last reset, and on Azure SQL DB / Hyperscale
+    those stats reset on every failover and scaling operation. Appending this
+    EXISTS unconditionally drops every index whenever the DMV is empty, which
+    silently empties #filtered_objects and makes the procedure exit with no result
+    set and no error. With the defaults (@min_reads = 0, @min_writes = 0) we want
+    to analyze every index, including never-used ones (the whole point of the tool).
+    @min_reads and @min_writes are validated to non-NULL, non-negative above.
+    */
+    IF  @min_reads > 0
+    OR  @min_writes > 0
+    BEGIN
+        IF @debug = 1
+        BEGIN
+            RAISERROR('adding index usage reads/writes filter', 0, 0) WITH NOWAIT;
+        END;
+
+        SET @sql += N'
         AND EXISTS
         (
             SELECT
@@ -1688,7 +1709,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 SUM(ius.user_seeks + ius.user_scans + ius.user_lookups) >= @min_reads
             OR
                 SUM(ius.user_updates) >= @min_writes
-        )
+        )';
+    END;
+
+    SET @sql += N'
         OPTION(RECOMPILE);
     ';
 
@@ -1735,15 +1759,16 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     BEGIN
         IF @debug = 1
         BEGIN
-            RAISERROR('No rows inserted into #filtered_objects from %s, continuing to next database...', 10, 0, @current_database_name) WITH NOWAIT;
+            RAISERROR('No rows inserted into #filtered_objects from %s; no indexes met the analysis criteria.', 10, 0, @current_database_name) WITH NOWAIT;
         END;
 
-        IF @get_all_databases = 0
-        BEGIN
-            RETURN;
-        END;
-
-        /* Get the next database and continue the loop */
+        /*
+        Advance the cursor instead of bare-RETURNing. A bare RETURN here (the old
+        single-database behavior) exited the procedure with no result set and no
+        error. Falling through lets the database surface in the 'DATABASES WITH NO
+        QUALIFYING OBJECTS' result set below, so the caller always gets feedback. In
+        single-database mode the cursor is now exhausted and the loop ends normally.
+        */
         FETCH NEXT
         FROM @database_cursor
         INTO


### PR DESCRIPTION
## Problem

On Azure SQL Database / Hyperscale, `sp_IndexCleanup` exits immediately and returns **no result set and no error**.

When populating `#filtered_objects`, the proc gated every table behind an `EXISTS` against `sys.dm_db_index_usage_stats`:

```sql
AND EXISTS
(
    ... FROM [db].sys.dm_db_index_usage_stats AS ius
    WHERE ius.object_id = i.object_id ...
    HAVING SUM(reads) >= @min_reads OR SUM(writes) >= @min_writes
)
```

That DMV only has a row for an index touched since the last stats reset — and **Azure SQL DB / Hyperscale reset it on every failover and scaling operation**. With the DMV empty, no table passes the `EXISTS` even at the defaults `@min_reads = 0` / `@min_writes = 0`, so `#filtered_objects` comes back empty → `@rc = 0` → a bare `RETURN` whose only diagnostic was `@debug`-gated at severity 10. The prior uptime/auto-dedupe work didn't help because dedupe builds from the same empty `#filtered_objects`.

## Fix

1. **Gate the index-usage `EXISTS`** so it's only appended when `@min_reads > 0 OR @min_writes > 0`. At the defaults, usage is no longer consulted for filtering, so an empty/reset DMV can't empty the result, and never-used indexes (the point of the tool) are analyzed. Also fixes freshly-restarted on-prem instances.
2. **Replace the silent single-database `RETURN`** with a fall-through, so an empty database surfaces in the existing `'DATABASES WITH NO QUALIFYING OBJECTS'` result instead of returning nothing.

No `@version` / `@version_date` bump (not a release).

## Test plan

Validated on freshly created **Azure SQL Database (Basic→S1)** and **Hyperscale (HS_Gen5)** instances, with `dm_db_index_usage_stats` reset to empty via a service-objective scale:

| | OLD (committed) | NEW (fixed) |
|---|---|---|
| Azure SQL DB | no result, no error | flags `ix_a_two` as Exact Duplicate of `ix_a_one` |
| Hyperscale | no result, no error | same + emits `ALTER INDEX [ix_a_two] … DISABLE;` |

In both, the DMV stayed at `0` after the old proc ran, confirming it bailed at the silent `RETURN` before reaching the table. Also re-verified a normal populated run on SQL Server 2022 still returns full results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)