### PR TITLE
sp_HumanEvents: stop CATCH cleanup from masking pre-creation errors (blocking + blocked process threshold = 0)

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -501,6 +501,7 @@ DECLARE
     @requested_memory_mb_filter nvarchar(max) = N'',
     @compile_events bit = 0,
     @parameterization_events bit = 0,
+    @session_exists bit = 0,
     @fully_formed_babby nvarchar(1000) = N'',
     @s_out integer,
     @s_sql nvarchar(max) = N'',
@@ -4998,19 +4999,56 @@ BEGIN CATCH
             IF (@output_database_name = N''
                   AND @output_schema_name IN (N'', N'dbo'))
             BEGIN
-                IF @debug = 1
+                /*
+                Only stop and drop the session if it actually got created.
+                If setup failed before the session existed (for example, when
+                @event_type = 'blocking' but the blocked process report isn't
+                configured), trying to stop a session that was never created
+                raises its own error (Msg 15151) that masks the real problem.
+                */
+                IF @azure = 0
                 BEGIN
-                    RAISERROR(@stop_sql, 0, 1) WITH NOWAIT;
-                    RAISERROR(N'all done, stopping session', 0, 1) WITH NOWAIT;
+                    IF EXISTS
+                    (
+                        SELECT
+                            1/0
+                        FROM sys.server_event_sessions AS ses
+                        WHERE ses.name = @session_name
+                    )
+                    BEGIN
+                        SET @session_exists = 1;
+                    END;
                 END;
-                EXECUTE (@stop_sql);
+                ELSE
+                BEGIN
+                    IF EXISTS
+                    (
+                        SELECT
+                            1/0
+                        FROM sys.database_event_sessions AS ses
+                        WHERE ses.name = @session_name
+                    )
+                    BEGIN
+                        SET @session_exists = 1;
+                    END;
+                END;
 
-                IF @debug = 1
+                IF @session_exists = 1
                 BEGIN
-                    RAISERROR(@drop_sql, 0, 1) WITH NOWAIT;
-                    RAISERROR(N'and dropping session', 0, 1) WITH NOWAIT;
+                    IF @debug = 1
+                    BEGIN
+                        RAISERROR(@stop_sql, 0, 1) WITH NOWAIT;
+                        RAISERROR(N'all done, stopping session', 0, 1) WITH NOWAIT;
+                    END;
+                    EXECUTE (@stop_sql);
+
+                    IF @debug = 1
+                    BEGIN
+                        RAISERROR(@drop_sql, 0, 1) WITH NOWAIT;
+                        RAISERROR(N'and dropping session', 0, 1) WITH NOWAIT;
+                    END;
+                    EXECUTE (@drop_sql);
                 END;
-                EXECUTE (@drop_sql);
             END;
 
             THROW;

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -5005,33 +5005,51 @@ BEGIN CATCH
                 @event_type = 'blocking' but the blocked process report isn't
                 configured), trying to stop a session that was never created
                 raises its own error (Msg 15151) that masks the real problem.
+
+                This existence check runs inside the CATCH, so it gets its own
+                TRY/CATCH: if the check itself fails (for example, missing
+                permission on the catalog views), default to leaving the
+                session alone so the original error still surfaces via THROW.
+                Azure SQL DB uses database-scoped sessions, so the catalog
+                view differs; that's the only reason for the @azure branch.
                 */
-                IF @azure = 0
-                BEGIN
-                    IF EXISTS
-                    (
-                        SELECT
-                            1/0
-                        FROM sys.server_event_sessions AS ses
-                        WHERE ses.name = @session_name
-                    )
+                BEGIN TRY
+                    IF @azure = 0
                     BEGIN
-                        SET @session_exists = 1;
-                    END;
-                END;
-                ELSE
-                BEGIN
-                    IF EXISTS
-                    (
                         SELECT
-                            1/0
-                        FROM sys.database_event_sessions AS ses
-                        WHERE ses.name = @session_name
-                    )
-                    BEGIN
-                        SET @session_exists = 1;
+                            @session_exists =
+                                CASE
+                                    WHEN EXISTS
+                                         (
+                                             SELECT
+                                                 1
+                                             FROM sys.server_event_sessions AS ses
+                                             WHERE ses.name = @session_name
+                                         )
+                                    THEN 1
+                                    ELSE 0
+                                END;
                     END;
-                END;
+                    ELSE
+                    BEGIN
+                        SELECT
+                            @session_exists =
+                                CASE
+                                    WHEN EXISTS
+                                         (
+                                             SELECT
+                                                 1
+                                             FROM sys.database_event_sessions AS ses
+                                             WHERE ses.name = @session_name
+                                         )
+                                    THEN 1
+                                    ELSE 0
+                                END;
+                    END;
+                END TRY
+                BEGIN CATCH
+                    SET @session_exists = 0;
+                END CATCH;
 
                 IF @session_exists = 1
                 BEGIN


### PR DESCRIPTION
## Summary

Fixes #807.

`sp_HumanEvents @event_type = 'blocking'` fails with a misleading `Msg 15151 ... Cannot alter the event session ..., because it does not exist` when the server's `blocked process threshold` is `0`, instead of showing the existing helpful message about configuring the blocked process report.

## Root cause

The existing `blocked process threshold = 0` guard raises a **severity-11** message. Because it runs inside the procedure-wide `BEGIN TRY`, control transfers to the `CATCH` (the `RETURN` never executes). The `CATCH` then unconditionally ran `ALTER EVENT SESSION ... STATE = STOP` against a session that was never created, which itself throws **Msg 15151** and masks the real message. This affected every pre-session-creation validation, not just blocking.

## Fix

Guard the `CATCH` cleanup so it only stops/drops the session when it actually exists, using the proc's existing `@azure`-branched `sys.server_event_sessions` / `sys.database_event_sessions` existence-check pattern. A new `@session_exists bit` flag tracks this.

## Testing

Verified against **SQL Server 2025 (17.0.4045.5)**:

| Scenario | Before (unpatched 7.7) | After (patched) |
| --- | --- | --- |
| `@event_type='blocking'`, threshold = 0 | `Msg 15151 ... Cannot alter the event session` | Helpful `Msg 50000` instructions to configure the blocked process report |
| `@event_type='blocking'`, threshold = 5 | n/a | Session created, sampled, and dropped cleanly — no error, no leftover session |
| `@event_type='waits'` (regression) | n/a | Runs and self-cleans, unaffected |

Per CONTRIBUTING, this PR targets the `dev` branch and has an associated issue (#807).
