### PR TITLE
Updates_20260701 minor version bumps

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -72,7 +72,7 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.6',
+        @version = '3.7',
         @version_date = '20260701';
 
     IF @help = 1

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,7 +88,7 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.7',
+    @version = '7.8',
     @version_date = '20260701';
 
 IF @help = 1

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -94,7 +94,7 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.6',
+    @version = '5.7',
     @version_date = '20260701';
 
 IF @help = 1

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -75,7 +75,7 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.7',
+        @version = '2.8',
         @version_date = '20260701';
 
     IF

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,7 +73,7 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.6',
+        @version = '3.7',
         @version_date = '20260701';
 
     IF @help = 1

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -66,7 +66,7 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.6',
+        @version = N'2.7',
         @version_date = N'20260701';
 
     /*

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,7 +78,7 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.6',
+    @version = '6.7',
     @version_date = '20260701';
 
 

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -90,7 +90,7 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.6',
+    @version = '1.7',
     @version_date = '20260701';
 
 /*Help*/

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -78,7 +78,7 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.6',
+        @version = '1.7',
         @version_date = '20260701';
 
     /*

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -127,7 +127,7 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.7',
+    @version = '6.8',
     @version_date = '20260701';
 
 /*


### PR DESCRIPTION
Standard +0.1 minor bump on all 10 combined-install procs for Updates_20260701 (the prior release commit bumped @version_date only, leaving minors unchanged). Bundle regeneration left to the Format-and-Build CI job.