### PR TITLE
Align proc versions to .7 for Updates_20260701

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -88,7 +88,7 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.8',
+    @version = '7.7',
     @version_date = '20260701';
 
 IF @help = 1

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -75,7 +75,7 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.8',
+        @version = '2.7',
         @version_date = '20260701';
 
     IF

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -127,7 +127,7 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.8',
+    @version = '6.7',
     @version_date = '20260701';
 
 /*


### PR DESCRIPTION
Realign all 10 combined-install procs to X.7 for July. A May 2026 over-bump left sp_HumanEvents, sp_IndexCleanup, and sp_QuickieStore a month ahead (they had reached .8); bringing them back to .7 so the whole suite matches the calendar month. Bundle regeneration left to the Format-and-Build CI job.