### PR TITLE
sp_IndexCleanup: source merged includes from #index_details; assert the rules

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -3944,83 +3944,62 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         superset.scope_hash,
         superset.index_name,
         superset.key_columns,
+        /*
+        Merge the superset's own includes with those of every subset it
+        supersedes.
+
+        This reads #index_details, one row per column, instead of splitting the
+        included_columns strings on ', '. A column name may legally contain a
+        comma and a space, so that delimiter could tear [Last, First] into two
+        fragments and the DISTINCT sort could then slot another column between
+        them, emitting a broken INCLUDE list while the paired DISABLE still ran.
+        Reading the columns directly also removes the need to escape entities for
+        the XML round-trip.
+        */
         merged_includes =
             STUFF
             (
                 (
-                    SELECT DISTINCT
+                    SELECT
                         N', ' +
-                        t.c.value('.', 'nvarchar(258)')
-                    FROM
+                        QUOTENAME(idc.column_name)
+                    FROM #index_details AS idc
+                    WHERE idc.is_included_column = 1
+                    AND
                     (
-                        /*
-                        Superset's own includes. Entities are escaped before the
-                        split or CONVERT(xml, ...) fails outright with Msg 9411
-                        on a legal column name like [A&B].
-                        */
+                        /* The superset's own includes */
+                        idc.index_hash = superset.index_hash
+                        /* Plus those of every subset it supersedes */
+                        OR EXISTS
+                           (
+                               SELECT
+                                   1/0
+                               FROM #index_analysis AS subset
+                               WHERE subset.scope_hash = superset.scope_hash
+                               AND   subset.target_index_name = superset.index_name
+                               AND   subset.action = N'DISABLE'
+                               AND   subset.consolidation_rule = N'Key Subset'
+                               AND   subset.index_hash = idc.index_hash
+                           )
+                    )
+                    /*
+                    A column already in the superset's key doesn't need
+                    including. Matching column names exactly beats searching the
+                    key_columns string for one.
+                    */
+                    AND NOT EXISTS
+                    (
                         SELECT
-                            x = CONVERT
-                            (
-                                xml,
-                                N'<c>' +
-                                REPLACE
-                                (
-                                    REPLACE
-                                    (
-                                        REPLACE
-                                        (
-                                            REPLACE(superset.included_columns, N'&', N'&amp;'),
-                                            N'<',
-                                            N'&lt;'
-                                        ),
-                                        N'>',
-                                        N'&gt;'
-                                    ),
-                                    N', ',
-                                    N'</c><c>'
-                                ) +
-                                N'</c>'
-                            )
-                        WHERE superset.included_columns IS NOT NULL
-
-                        UNION ALL
-
-                        /* ALL subsets' includes */
-                        SELECT
-                            x = CONVERT
-                            (
-                                xml,
-                                N'<c>' +
-                                REPLACE
-                                (
-                                    REPLACE
-                                    (
-                                        REPLACE
-                                        (
-                                            REPLACE(subset.included_columns, N'&', N'&amp;'),
-                                            N'<',
-                                            N'&lt;'
-                                        ),
-                                        N'>',
-                                        N'&gt;'
-                                    ),
-                                    N', ',
-                                    N'</c><c>'
-                                ) +
-                                N'</c>'
-                            )
-                        FROM #index_analysis AS subset
-                        WHERE subset.scope_hash = superset.scope_hash
-                        AND   subset.target_index_name = superset.index_name
-                        AND   subset.action = N'DISABLE'
-                        AND   subset.consolidation_rule = N'Key Subset'
-                        AND   subset.included_columns IS NOT NULL
-                    ) AS a
-                    CROSS APPLY a.x.nodes('/c') AS t(c)
-                    /* Filter out columns already in superset's key */
-                    WHERE CHARINDEX(t.c.value('.', 'nvarchar(258)'), superset.key_columns) = 0
-                    AND   LEN(t.c.value('.', 'nvarchar(258)')) > 0
-                    /* TYPE plus .value() so the entities don't come back re-encoded */
+                            1/0
+                        FROM #index_details AS idk
+                        WHERE idk.index_hash = superset.index_hash
+                        AND   idk.is_included_column = 0
+                        AND   idk.column_name = idc.column_name
+                    )
+                    GROUP BY
+                        idc.column_name
+                    ORDER BY
+                        idc.column_name
                     FOR
                         XML
                         PATH(''),
@@ -4510,94 +4489,60 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     UPDATE
         ia_winner
     SET
+        /*
+        Merge the disabled Key Duplicates' includes into the index being made
+        unique.
+
+        Sourced from #index_details, one row per column, rather than splitting
+        included_columns on ', '. A column name may legally contain a comma and
+        a space, which made that delimiter ambiguous: [Last, First] tore into two
+        fragments the DISTINCT sort could separate, producing a broken INCLUDE
+        list on a script whose paired DISABLE still ran.
+
+        Winner and losers are key duplicates, so their keys match and SQL Server
+        would not allow a key column to also be an include. No key exclusion is
+        needed.
+        */
         ia_winner.included_columns =
-        (
-            SELECT
-                combined_cols =
-                    STUFF
+            STUFF
+            (
+                (
+                    SELECT
+                        N', ' +
+                        QUOTENAME(idc.column_name)
+                    FROM #index_details AS idc
+                    WHERE idc.is_included_column = 1
+                    AND
                     (
-                        (
-                            SELECT DISTINCT
-                                N', ' + t.c.value('.', 'nvarchar(258)')
-                            FROM
-                            (
-                                /*
-                                Winner's includes. Entities are escaped first or
-                                CONVERT(xml, ...) fails with Msg 9411 on a legal
-                                column name like [A&B].
-                                */
-                                SELECT
-                                    x = CONVERT
-                                    (
-                                        xml,
-                                        N'<c>' +
-                                        REPLACE
-                                        (
-                                            REPLACE
-                                            (
-                                                REPLACE
-                                                (
-                                                    REPLACE(ISNULL(ia_winner.included_columns, N''), N'&', N'&amp;'),
-                                                    N'<',
-                                                    N'&lt;'
-                                                ),
-                                                N'>',
-                                                N'&gt;'
-                                            ),
-                                            N', ',
-                                            N'</c><c>'
-                                        ) +
-                                        N'</c>'
-                                    )
-                                WHERE ia_winner.included_columns IS NOT NULL
-
-                                UNION ALL
-
-                                /* Loser's includes */
-                                SELECT
-                                    x = CONVERT
-                                    (
-                                        xml,
-                                        N'<c>' +
-                                        REPLACE
-                                        (
-                                            REPLACE
-                                            (
-                                                REPLACE
-                                                (
-                                                    REPLACE(ia_loser.included_columns, N'&', N'&amp;'),
-                                                    N'<',
-                                                    N'&lt;'
-                                                ),
-                                                N'>',
-                                                N'&gt;'
-                                            ),
-                                            N', ',
-                                            N'</c><c>'
-                                        ) +
-                                        N'</c>'
-                                    )
-                                FROM #index_analysis AS ia_loser
-                                WHERE ia_loser.scope_hash = ia_winner.scope_hash
-                                AND   ia_loser.key_filter_hash = ia_winner.key_filter_hash
-                                AND   ia_loser.action = N'DISABLE'
-                                AND   ia_loser.consolidation_rule = N'Key Duplicate'
-                                AND   ia_loser.target_index_name = ia_winner.index_name
-                                AND   ia_loser.included_columns IS NOT NULL
-                            ) AS a
-                            CROSS APPLY a.x.nodes('/c') AS t(c)
-                            WHERE LEN(t.c.value('.', 'nvarchar(258)')) > 0
-                            /* TYPE plus .value() so the entities don't come back re-encoded */
-                            FOR
-                                XML
-                                PATH(''),
-                                TYPE
-                        ).value('text()[1]', 'nvarchar(max)'),
-                        1,
-                        2,
-                        ''
+                        /* The winner's own includes */
+                        idc.index_hash = ia_winner.index_hash
+                        /* Plus those of every duplicate being disabled for it */
+                        OR EXISTS
+                           (
+                               SELECT
+                                   1/0
+                               FROM #index_analysis AS ia_loser
+                               WHERE ia_loser.scope_hash = ia_winner.scope_hash
+                               AND   ia_loser.key_filter_hash = ia_winner.key_filter_hash
+                               AND   ia_loser.action = N'DISABLE'
+                               AND   ia_loser.consolidation_rule = N'Key Duplicate'
+                               AND   ia_loser.target_index_name = ia_winner.index_name
+                               AND   ia_loser.index_hash = idc.index_hash
+                           )
                     )
-        ),
+                    GROUP BY
+                        idc.column_name
+                    ORDER BY
+                        idc.column_name
+                    FOR
+                        XML
+                        PATH(''),
+                        TYPE
+                ).value('text()[1]', 'nvarchar(max)'),
+                1,
+                2,
+                ''
+            ),
         ia_winner.superseded_by =
             CASE
                 WHEN ia_winner.superseded_by IS NULL
@@ -4998,124 +4943,64 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         RAISERROR('Merging included columns from Key Duplicate indexes', 0, 0) WITH NOWAIT;
     END;
 
-    WITH
-        KeyDuplicateIncludes AS
-    (
-        SELECT
-            winner.database_id,
-            winner.object_id,
-            winner.index_id,
-            winner.index_name,
-            winner.index_hash,
-            winner.included_columns AS winner_includes,
-            loser.included_columns AS loser_includes
-        FROM #index_analysis AS winner
-        JOIN #key_duplicate_dedupe AS kdd
-          ON  winner.scope_hash = kdd.scope_hash
-          AND winner.key_filter_hash = kdd.key_filter_hash
-          AND winner.index_name = kdd.winning_index_name
-        JOIN #index_analysis AS loser
-          ON  loser.scope_hash = kdd.scope_hash
-          AND loser.key_filter_hash = kdd.key_filter_hash
-          AND loser.index_name <> kdd.winning_index_name
-          AND loser.action = N'DISABLE'
-          AND loser.consolidation_rule = N'Key Duplicate'
-        WHERE winner.action = N'MERGE INCLUDES'
-        AND   winner.consolidation_rule = N'Key Duplicate'
-    )
+    /*
+    Merge every disabled duplicate's includes into the winner.
+
+    This reads #index_details rather than splitting the winner's and losers'
+    included_columns strings apart on ', '. That delimiter is ambiguous: a column
+    name is allowed to contain a comma and a space, so [Last, First] used to tear
+    into [Last and First], and the DISTINCT sort could then slot another column
+    between the halves - emitting INCLUDE ([col_b], [Last, [zzz], First]), which
+    fails with Msg 102 while the paired DISABLE of the loser still runs.
+
+    #index_details already holds one row per column, so there is nothing to parse
+    and nothing to re-escape. Winner and losers share key_filter_hash, meaning
+    identical keys, and SQL Server will not let a key column also be an include,
+    so no key-column exclusion is needed here.
+    */
     UPDATE
         ia
     SET
         ia.included_columns =
-        (
-            SELECT
-                /* Combine all includes from winner and all losers, removing duplicates */
-                combined_cols =
-                    STUFF
+            STUFF
+            (
+                (
+                    SELECT
+                        N', ' +
+                        QUOTENAME(idc.column_name)
+                    FROM #index_details AS idc
+                    WHERE idc.is_included_column = 1
+                    AND
                     (
-                        (
-                            SELECT DISTINCT
-                                N', ' +
-                                t.c.value('.', 'nvarchar(258)')
-                            FROM
-                            (
-                                /*
-                                Create XML from winner's includes. Entities are
-                                escaped first or CONVERT(xml, ...) fails with
-                                Msg 9411 on a legal column name like [A&B].
-                                */
-                                SELECT
-                                    x = CONVERT
-                                    (
-                                        xml,
-                                        N'<c>' +
-                                        REPLACE
-                                        (
-                                            REPLACE
-                                            (
-                                                REPLACE
-                                                (
-                                                    REPLACE(ISNULL(kdi.winner_includes, N''), N'&', N'&amp;'),
-                                                    N'<',
-                                                    N'&lt;'
-                                                ),
-                                                N'>',
-                                                N'&gt;'
-                                            ),
-                                            N', ',
-                                            N'</c><c>'
-                                        ) +
-                                        N'</c>'
-                                    )
-                                FROM KeyDuplicateIncludes AS kdi
-                                WHERE kdi.index_hash = ia.index_hash
-                                AND   kdi.winner_includes IS NOT NULL
-
-                                UNION ALL
-
-                                /* Create XML from each loser's includes */
-                                SELECT
-                                    x = CONVERT
-                                    (
-                                        xml,
-                                        N'<c>' +
-                                        REPLACE
-                                        (
-                                            REPLACE
-                                            (
-                                                REPLACE
-                                                (
-                                                    REPLACE(kdi.loser_includes, N'&', N'&amp;'),
-                                                    N'<',
-                                                    N'&lt;'
-                                                ),
-                                                N'>',
-                                                N'&gt;'
-                                            ),
-                                            N', ',
-                                            N'</c><c>'
-                                        ) +
-                                        N'</c>'
-                                    )
-                                FROM KeyDuplicateIncludes AS kdi
-                                WHERE kdi.index_hash = ia.index_hash
-                                AND   kdi.loser_includes IS NOT NULL
-                            ) AS a
-                            /* Split XML into individual columns */
-                            CROSS APPLY a.x.nodes('/c') AS t(c)
-                            /* Filter out empty strings that can result from NULL handling */
-                            WHERE LEN(t.c.value('.', 'nvarchar(258)')) > 0
-                            /* TYPE plus .value() so the entities don't come back re-encoded */
-                            FOR
-                                XML
-                                PATH(''),
-                                TYPE
-                        ).value('text()[1]', 'nvarchar(max)'),
-                        1,
-                        2,
-                        ''
+                        /* The winner's own includes */
+                        idc.index_hash = ia.index_hash
+                        /* Plus every duplicate it is about to disable */
+                        OR EXISTS
+                           (
+                               SELECT
+                                   1/0
+                               FROM #index_analysis AS loser
+                               WHERE loser.scope_hash = ia.scope_hash
+                               AND   loser.key_filter_hash = ia.key_filter_hash
+                               AND   loser.index_name <> ia.index_name
+                               AND   loser.action = N'DISABLE'
+                               AND   loser.consolidation_rule = N'Key Duplicate'
+                               AND   loser.index_hash = idc.index_hash
+                           )
                     )
-        )
+                    GROUP BY
+                        idc.column_name
+                    ORDER BY
+                        idc.column_name
+                    FOR
+                        XML
+                        PATH(''),
+                        TYPE
+                ).value('text()[1]', 'nvarchar(max)'),
+                1,
+                2,
+                N''
+            )
     FROM #index_analysis AS ia
     WHERE ia.action = N'MERGE INCLUDES'
     AND   ia.consolidation_rule = N'Key Duplicate'
@@ -5186,6 +5071,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     that accepts CREATE UNIQUE INDEX ... INCLUDE (...) WITH (DROP_EXISTING = ON),
     so the merge is safe to emit.
 
+    Includes come from #index_details, one row per column, rather than from
+    splitting included_columns on ', ' - a column name may legally contain a
+    comma and a space, which made that delimiter ambiguous.
+
     Only rows whose merged list actually differs from what the winner already
     covers are recorded. When a loser's includes are a subset of the winner's,
     the existing KEEP plus the loser's DISABLE is already correct, and emitting a
@@ -5217,95 +5106,33 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 STUFF
                 (
                     (
-                        SELECT DISTINCT
+                        SELECT
                             N', ' +
-                            t.c.value('.', 'nvarchar(258)')
-                        FROM
+                            QUOTENAME(idc.column_name)
+                        FROM #index_details AS idc
+                        WHERE idc.is_included_column = 1
+                        AND
                         (
                             /* The winner's own includes */
-                            SELECT
-                                x =
-                                    CONVERT
-                                    (
-                                        xml,
-                                        N'<c>' +
-                                        REPLACE
-                                        (
-                                            REPLACE
-                                            (
-                                                REPLACE
-                                                (
-                                                    REPLACE(ia.included_columns, N'&', N'&amp;'),
-                                                    N'<',
-                                                    N'&lt;'
-                                                ),
-                                                N'>',
-                                                N'&gt;'
-                                            ),
-                                            N', ',
-                                            N'</c><c>'
-                                        ) +
-                                        N'</c>'
-                                    )
-                            WHERE ia.included_columns IS NOT NULL
-
-                            UNION ALL
-
-                            /* Every duplicate this winner is about to disable */
-                            SELECT
-                                x =
-                                    CONVERT
-                                    (
-                                        xml,
-                                        N'<c>' +
-                                        REPLACE
-                                        (
-                                            REPLACE
-                                            (
-                                                REPLACE
-                                                (
-                                                    REPLACE(loser.included_columns, N'&', N'&amp;'),
-                                                    N'<',
-                                                    N'&lt;'
-                                                ),
-                                                N'>',
-                                                N'&gt;'
-                                            ),
-                                            N', ',
-                                            N'</c><c>'
-                                        ) +
-                                        N'</c>'
-                                    )
-                            FROM #index_analysis AS loser
-                            WHERE loser.scope_hash = ia.scope_hash
-                            AND   loser.key_filter_hash = ia.key_filter_hash
-                            AND   loser.target_index_name = ia.index_name
-                            AND   loser.action = N'DISABLE'
-                            AND   loser.consolidation_rule = N'Key Duplicate'
-                            AND   loser.included_columns IS NOT NULL
-                        ) AS a
-                        CROSS APPLY a.x.nodes('/c') AS t(c)
-                        /*
-                        nvarchar(258), not sysname. A column name does max out at
-                        128 characters, but these values are already wrapped by
-                        QUOTENAME, and QUOTENAME returns nvarchar(258): a
-                        128-character name comes back 130 characters long, and
-                        pulling that through a sysname bucket lops off the closing
-                        bracket. The merge script then fails with Msg 103 while the
-                        paired DISABLE of the loser still runs.
-                        */
-                        /* A column already in the key doesn't need including */
-                        WHERE CHARINDEX(t.c.value('.', 'nvarchar(258)'), ia.key_columns) = 0
-                        AND   LEN(t.c.value('.', 'nvarchar(258)')) > 0
-                        /*
-                        TYPE plus .value() on the way out is not optional here.
-                        A bare FOR XML PATH('') returns nvarchar and re-encodes
-                        entities, so a column named [A&B] would come back out as
-                        [A&amp;B] and land in the generated script, which then
-                        fails with Msg 1911 (column does not exist) while the
-                        paired DISABLE of the loser still runs - the exact silent
-                        include loss this block exists to prevent.
-                        */
+                            idc.index_hash = ia.index_hash
+                            /* Plus every duplicate it is about to disable */
+                            OR EXISTS
+                               (
+                                   SELECT
+                                       1/0
+                                   FROM #index_analysis AS loser
+                                   WHERE loser.scope_hash = ia.scope_hash
+                                   AND   loser.key_filter_hash = ia.key_filter_hash
+                                   AND   loser.target_index_name = ia.index_name
+                                   AND   loser.action = N'DISABLE'
+                                   AND   loser.consolidation_rule = N'Key Duplicate'
+                                   AND   loser.index_hash = idc.index_hash
+                               )
+                        )
+                        GROUP BY
+                            idc.column_name
+                        ORDER BY
+                            idc.column_name
                         FOR
                             XML
                             PATH(''),

--- a/sp_IndexCleanup/tests/README.md
+++ b/sp_IndexCleanup/tests/README.md
@@ -14,16 +14,54 @@ script at all -- the paired `DISABLE` still runs.
 | --- | --- |
 | `run_tests.py` | Runs `adversarial_test.sql`, parses the output, asserts 28 expectations across 12 rule groups. |
 | `adversarial_test.sql` | Builds synthetic `test_ic_*` tables covering unique constraints, sort directions, filters, include merges, indexed views, heaps, and rule interactions. Self-cleaning. Driven by `run_tests.py`; run it directly only to eyeball output. |
+| `fixture_cases_test.py` | Drives `fixtures_more_dupe_indexes.sql` and asserts the `Expected:` comments in it -- cases 1 through 8d -- against the real `Users` table. **Also executes every generated MERGE/DISABLE script** inside a rolled-back transaction. ~2 minutes. |
+| `rule_coverage_test.py` | Small synthetic fixture in `Crap`. Covers unused-index detection (or the uptime guard, see below) and the `@min_reads`/`@min_writes` index-level screen. Fast. |
 | `no_access_test.py` | Creates a login with no user-database access and asserts the `HAS_DBACCESS` preflight returns instead of spinning at 100% CPU forever (PerformanceMonitor #915). Drops the login afterward. |
 
 ```
 cd sp_IndexCleanup/tests
 python run_tests.py --server SQL2022
+python fixture_cases_test.py --server SQL2022
+python rule_coverage_test.py --server SQL2022
 python no_access_test.py --server SQL2022
 ```
 
-Both take `--server` and `--password` (default `SQL2022` / the standard local sa
-password). Expect `28 passed` and `4 passed`.
+All take `--server` and `--password` (default `SQL2022` / the standard local sa
+password). Expect `28`, `31`, `11`, and `4` passed.
+
+### The execute check is the one that earns its keep
+
+`fixture_cases_test.py` runs every generated script for real, each in its own
+`BEGIN TRANSACTION ... ROLLBACK`. That is not belt-and-braces -- it is the check
+that catches this procedure's characteristic bug.
+
+Every defect found in it so far has had the same shape: **a merge script that
+cannot execute, paired with a `DISABLE` that can**, so the loser's covering
+column disappears with nothing absorbing it. Compiling does not catch it. Reading
+the output does not catch it. Only running the script does.
+
+Pointed at the build from before those fixes, this suite goes red on exactly
+those bugs, including `Msg 1907 - Cannot recreate index ... does not match the
+constraint being enforced by the existing index` surfacing purely from the
+execute check. `SET PARSEONLY ON` would sail straight past it: 1907 is a semantic
+error, not a syntax one.
+
+### Uptime guard: unused-index detection cannot run on a fresh instance
+
+`sp_IndexCleanup` auto-enables `@dedupe_only` when server uptime is <= 7 days,
+which skips Rule 1 entirely. That is deliberate -- usage stats are meaningless on
+a just-restarted server -- and it is not overridable by parameter.
+
+The practical consequence: **on a freshly restarted instance, unused-index
+detection will look broken when it is not.** Run with `@debug = 1` and you will
+see the procedure say so: `Server uptime is less than 7 days. Automatically
+enabling @dedupe_only mode.` Check that before concluding Rule 1 is broken.
+
+`rule_coverage_test.py` handles this by asserting whichever is true: on a
+long-uptime instance it asserts Rule 1 flags the unused index; on a fresh one it
+asserts the guard fired and suppressed it. It never silently skips, and it proves
+the index was analyzed and genuinely has zero reads first, so the absence of an
+`Unused Index` row means the guard, not an invisible index.
 
 These are **not** wired into CI. `.github/workflows/sql-tests.yml` only runs
 basic-execution and help-output smoke tests, which is why behavioral regressions
@@ -75,9 +113,9 @@ cleanly, and that the automated suite did not cover:
   vanished. A plain unique *index* does accept `DROP_EXISTING` with an added
   `INCLUDE` (unlike a constraint), so the merge is legal and now happens.
 
-Both were found by diffing output against these comments by hand. Nothing here
-asserts them automatically -- **wiring these cases into `run_tests.py` is the
-most valuable improvement available to this directory.**
+Both were found by diffing output against these comments by hand. They are now
+asserted automatically by `fixture_cases_test.py`, so a regression against either
+fails a test rather than waiting to be noticed.
 
 ## Verifying a change
 

--- a/sp_IndexCleanup/tests/fixture_cases_test.py
+++ b/sp_IndexCleanup/tests/fixture_cases_test.py
@@ -1,0 +1,536 @@
+"""
+sp_IndexCleanup Fixture Case Assertions
+=======================================
+Drives fixtures_more_dupe_indexes.sql and asserts the "Expected:" comments in it.
+Those comments are the specification: two of them caught bugs that shipped, that
+compiled cleanly, and that the adversarial suite did not cover. Until now nothing
+asserted them automatically -- the README called wiring them up "the most
+valuable improvement available to this directory". This is that.
+
+The fixture is self-contained: it drops every nonclustered index in the database,
+builds cases 1 through 8d on StackOverflow2013.dbo.Users, drives reads through
+each one, and ends by running the procedure with @dedupe_only = 1. It takes about
+two minutes, most of it in the read-generation loop.
+
+HOW GENERATED SCRIPTS ARE VALIDATED: they are EXECUTED, not parsed.
+
+Every MERGE SCRIPT, DISABLE SCRIPT, and DISABLE CONSTRAINT SCRIPT in the output
+is run for real, each inside its own BEGIN TRANSACTION ... ROLLBACK, via
+sp_executesql inside TRY/CATCH so that a compile error surfaces as a catchable
+error rather than killing the batch. Each script is rolled back individually, so
+database state is identical before and after and the captured output stays valid.
+
+This matters, and SET PARSEONLY ON would not do. Every bug found in this
+procedure so far had the same shape: a script that reads correctly and parses
+correctly but cannot execute. The canonical example is case 7c, where the
+procedure emitted a merge into a unique constraint and SQL Server rejected it
+with Msg 1907 ("The new index definition does not match the constraint being
+enforced by the existing index") -- a semantic error that PARSEONLY sails right
+past, while the paired DISABLE ran fine and quietly cost a covering index.
+Executing is the only check that tells the two apart.
+
+Cleanup: drops the three unique constraints (uq_test_c1/c2/c3 -- DropIndexes does
+not reliably remove constraints) and runs StackOverflow2013.dbo.DropIndexes.
+
+Prerequisites:
+  - A scratch StackOverflow2013 (the fixture drops every nonclustered index).
+  - A dbo.DropIndexes helper procedure in that database.
+  - sp_IndexCleanup installed in master.
+
+Usage:
+    python fixture_cases_test.py [--server SQL2022] [--password "L!nt0044"]
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIXTURE_FILE = os.path.join(HERE, "fixtures_more_dupe_indexes.sql")
+
+# Rows that represent a dedupe action. A COMPRESSION SCRIPT row is not one of
+# these: an index that gets no dedupe action still gets compression advice, and
+# that is expected, so "no dedupe action" means none of these three.
+DEDUPE_SCRIPT_TYPES = ("DISABLE SCRIPT", "MERGE SCRIPT", "DISABLE CONSTRAINT SCRIPT")
+
+
+def run_sqlcmd(server, password, input_file=None, query=None,
+               database="StackOverflow2013", timeout=600):
+    """Run SQL from a file or a query string and capture output."""
+    cmd = [
+        "sqlcmd", "-S", server, "-U", "sa", "-P", password,
+        "-d", database,
+        "-W",  # trim trailing spaces
+        "-s", "\t",  # tab delimiter
+    ]
+    if input_file is not None:
+        cmd += ["-i", input_file]
+    else:
+        cmd += ["-Q", query]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return result.stdout, result.stderr
+
+
+def parse_output(stdout):
+    """
+    Parse sp_IndexCleanup tab-delimited output into rows.
+
+    Bounded to the script result set. The procedure emits several result sets and
+    the ones after this share nothing but a tab delimiter, so parsing stops at the
+    blank line that ends this one. Without that bound the summary rows get zipped
+    against these headers and land in the same list, which matters here because
+    several assertions below are assertions of absence.
+
+    Column order, verified empirically against the running procedure:
+        script_type, additional_info, database_name, schema_name, table_name,
+        index_name, consolidation_rule, target_index_name, superseded_info,
+        index_size_gb, index_rows, index_reads, index_writes,
+        original_index_definition, script
+    """
+    rows = []
+    lines = stdout.split("\n")
+    headers = None
+    started = False
+
+    for line in lines:
+        if headers is None:
+            if "script_type" in line and "index_name" in line:
+                headers = [h.strip() for h in line.split("\t")]
+            continue
+
+        if line.startswith("---"):
+            continue
+
+        if not line.strip():
+            # Blank line ends the result set once rows have started.
+            if started:
+                break
+            continue
+
+        cols = [c.strip() for c in line.split("\t")]
+        if len(cols) >= len(headers):
+            rows.append(dict(zip(headers, cols)))
+            started = True
+
+    return rows
+
+
+def find_rows(rows, **filters):
+    """Find rows matching all filter criteria."""
+    matches = []
+    for row in rows:
+        match = True
+        for key, value in filters.items():
+            if key.endswith("__like"):
+                col = key[:-6]
+                if col not in row or value.lower() not in row[col].lower():
+                    match = False
+                    break
+            elif key.endswith("__in"):
+                col = key[:-4]
+                if col not in row or row[col] not in value:
+                    match = False
+                    break
+            else:
+                if key not in row or row[key] != value:
+                    match = False
+                    break
+        if match:
+            matches.append(row)
+    return matches
+
+
+def dedupe_rows(rows, index_name):
+    """Every dedupe-action row for an index. Compression rows are not included."""
+    return [
+        r for r in rows
+        if r.get("index_name") == index_name
+        and r.get("script_type") in DEDUPE_SCRIPT_TYPES
+    ]
+
+
+def include_columns(script):
+    """The contents of a script's INCLUDE (...) clause, or '' if it has none."""
+    match = re.search(r"INCLUDE\s*\(([^)]*)\)", script or "", re.IGNORECASE)
+    return match.group(1) if match else ""
+
+
+def script_rows(rows):
+    """Every generated script row worth executing, in output order."""
+    seen = []
+    for r in rows:
+        if r.get("script_type") not in DEDUPE_SCRIPT_TYPES:
+            continue
+        script = r.get("script", "")
+        if not script or script == "NULL":
+            continue
+        seen.append(r)
+    return seen
+
+
+def validate_scripts(server, password, rows):
+    """
+    Execute every generated script inside its own rolled-back transaction.
+
+    sp_executesql inside TRY/CATCH, so a compile error in a generated script is
+    catchable instead of aborting the batch. Returns a list of
+    (index_name, script_type, error_or_None).
+    """
+    targets = script_rows(rows)
+    if not targets:
+        return []
+
+    batches = [
+        "SET NOCOUNT ON;",
+        "SET XACT_ABORT OFF;",
+    ]
+    for i, r in enumerate(targets):
+        escaped = r["script"].replace("'", "''")
+        tag = "SCRIPTCHECK~%d~" % i
+        batches.append(
+            "BEGIN TRY\n"
+            "    BEGIN TRANSACTION;\n"
+            "    EXECUTE sys.sp_executesql N'" + escaped + "';\n"
+            "    IF @@TRANCOUNT > 0 ROLLBACK;\n"
+            "    SELECT r = CONVERT(varchar(1000), '" + tag + "OK');\n"
+            "END TRY\n"
+            "BEGIN CATCH\n"
+            "    IF @@TRANCOUNT > 0 ROLLBACK;\n"
+            "    SELECT r = CONVERT(varchar(1000), '" + tag + "ERROR: Msg ' + "
+            "CONVERT(varchar(10), ERROR_NUMBER()) + ' - ' + ERROR_MESSAGE());\n"
+            "END CATCH;"
+        )
+
+    path = None
+    try:
+        handle, path = tempfile.mkstemp(suffix=".sql", prefix="ic_scriptcheck_")
+        with os.fdopen(handle, "w") as f:
+            f.write("\nGO\n".join(batches) + "\nGO\n")
+
+        stdout, _ = run_sqlcmd(server, password, input_file=path, timeout=600)
+    finally:
+        if path and os.path.exists(path):
+            os.remove(path)
+
+    results = {}
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if not line.startswith("SCRIPTCHECK~"):
+            continue
+        _, index, outcome = line.split("~", 2)
+        results[int(index)] = outcome
+
+    out = []
+    for i, r in enumerate(targets):
+        outcome = results.get(i)
+        if outcome is None:
+            error = "no result captured for this script"
+        elif outcome == "OK":
+            error = None
+        else:
+            error = outcome
+        out.append((r["index_name"], r["script_type"], error))
+    return out
+
+
+def run_tests(rows, script_results):
+    """Run all assertions and return results."""
+    results = []
+
+    def assert_test(group, name, condition, detail=""):
+        results.append({
+            "group": group,
+            "name": name,
+            "passed": condition,
+            "detail": detail,
+        })
+
+    # ---- Case 1: Exact duplicates (same keys, same includes) ----
+    # ix_test_1 / ix_test_2 on (DisplayName) INCLUDE (Reputation).
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_test_2",
+                        script_type="DISABLE SCRIPT")
+    assert_test("1-Exact-Dup", "ix_test_2 disabled (exact duplicate of ix_test_1)",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # ---- Case 2: Key duplicates with different includes ----
+    # ix_test_3 INCLUDE (Reputation) / ix_test_4 INCLUDE (UpVotes) on (AccountId).
+    # Expected: one kept with includes merged, other disabled.
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_test_4",
+                        script_type="DISABLE SCRIPT")
+    assert_test("2-Key-Dup", "ix_test_4 disabled (key duplicate of ix_test_3)",
+                len(matches) == 1, "found %d" % len(matches))
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_test_3",
+                        script_type="MERGE SCRIPT")
+    includes = include_columns(matches[0]["script"]) if matches else ""
+    merged = ("Reputation" in includes) and ("UpVotes" in includes)
+    assert_test("2-Key-Dup", "ix_test_3 merged, INCLUDE has both Reputation and UpVotes",
+                len(matches) == 1 and merged,
+                "found %d merge rows, INCLUDE=(%s)" % (len(matches), includes))
+
+    # ---- Case 3: Key duplicates, one a unique INDEX ----
+    # uq_test_1 UNIQUE (Location, Id) / ix_test_5 (Location, Id) INCLUDE
+    # (LastAccessDate). Expected: unique index kept, includes merged in.
+    #
+    # This is one of the two cases that caught a shipped bug: ix_test_5 used to be
+    # disabled with uq_test_1 as its target while nothing merged the include into
+    # uq_test_1, silently dropping LastAccessDate coverage. Unlike a constraint, a
+    # plain unique index does accept DROP_EXISTING with an added INCLUDE, so the
+    # merge is legal and must happen.
+
+    matches = find_rows(rows, table_name="Users", index_name="uq_test_1",
+                        script_type="MERGE SCRIPT")
+    script = matches[0]["script"] if matches else ""
+    assert_test("3-Unique-Index", "uq_test_1 merged and script has CREATE UNIQUE",
+                len(matches) == 1 and "CREATE UNIQUE" in script,
+                "found %d merge rows, CREATE UNIQUE=%s"
+                % (len(matches), "CREATE UNIQUE" in script))
+
+    includes = include_columns(script)
+    assert_test("3-Unique-Index", "uq_test_1 INCLUDE absorbed LastAccessDate",
+                "LastAccessDate" in includes, "INCLUDE=(%s)" % includes)
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_test_5",
+                        script_type="DISABLE SCRIPT")
+    assert_test("3-Unique-Index", "ix_test_5 disabled (its include went to uq_test_1)",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # ---- Case 4: Superset/subset keys, neither unique ----
+    # ix_test_6 (Age) is a subset of ix_test_7 (Age, CreationDate).
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_test_6",
+                        script_type="DISABLE SCRIPT")
+    assert_test("4-Key-Subset", "ix_test_6 disabled (subset of ix_test_7)",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # ---- Case 5: Superset/subset with a unique narrower index ----
+    # uq_test_2 UNIQUE (EmailHash, Id) / ix_test_8 (EmailHash, Id, WebsiteUrl).
+    # Expected: both kept. A unique index must not be folded into a wider
+    # non-unique one -- the wider index cannot enforce the uniqueness.
+
+    matches = dedupe_rows(rows, "uq_test_2")
+    assert_test("5-Unique-Subset", "uq_test_2 gets no dedupe action",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    matches = dedupe_rows(rows, "ix_test_8")
+    assert_test("5-Unique-Subset", "ix_test_8 gets no dedupe action",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    # ---- Case 6: Mismatched key orders (Rule 8) ----
+    # ix_test_9 (CreationDate, LastAccessDate, Views) vs
+    # ix_test_10 (CreationDate, Views, LastAccessDate).
+    # Expected: flagged "Same Keys Different Order" for review. This surfaces as
+    # an analysis report row with script_type NEEDS REVIEW and a NULL script, not
+    # as generated DDL, so it is not a dedupe action and must not be one.
+
+    matches = [
+        r for r in rows
+        if r.get("index_name") in ("ix_test_9", "ix_test_10")
+        and r.get("script_type") == "NEEDS REVIEW"
+        and r.get("consolidation_rule") == "Same Keys Different Order"
+    ]
+    targets_each_other = all(
+        m.get("target_index_name") in ("ix_test_9", "ix_test_10") for m in matches
+    )
+    assert_test("6-Key-Order", "ix_test_9/ix_test_10 flagged Same Keys Different Order",
+                len(matches) >= 1 and targets_each_other,
+                "found %d review rows (%s)"
+                % (len(matches),
+                   [(m["index_name"], m["target_index_name"]) for m in matches]))
+
+    # ---- Case 7a: Unique CONSTRAINT with an exact-match nonclustered index ----
+    # uq_test_c1 UNIQUE (DownVotes, Id) / ix_c1 (DownVotes, Id) INCLUDE (AboutMe).
+    # Expected: constraint dropped, index made unique to take over enforcement.
+
+    matches = find_rows(rows, table_name="Users", index_name="uq_test_c1",
+                        script_type="DISABLE CONSTRAINT SCRIPT")
+    assert_test("7a-UC-Replace", "uq_test_c1 gets DISABLE CONSTRAINT",
+                len(matches) == 1, "found %d" % len(matches))
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_c1",
+                        script_type="MERGE SCRIPT")
+    script = matches[0]["script"] if matches else ""
+    assert_test("7a-UC-Replace", "ix_c1 merged and script has CREATE UNIQUE",
+                len(matches) == 1 and "CREATE UNIQUE" in script,
+                "found %d merge rows, CREATE UNIQUE=%s"
+                % (len(matches), "CREATE UNIQUE" in script))
+
+    # ---- Case 7b: Unique constraint vs a WIDER nonclustered index ----
+    # uq_test_c2 UNIQUE (UpVotes, Id) / ix_c2 (UpVotes, Id, Reputation).
+    # Expected: no action, keys do not match exactly.
+
+    matches = dedupe_rows(rows, "uq_test_c2")
+    assert_test("7b-UC-Wider-NC", "uq_test_c2 gets no dedupe action",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    matches = dedupe_rows(rows, "ix_c2")
+    assert_test("7b-UC-Wider-NC", "ix_c2 gets no dedupe action",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    # ---- Case 7c: Unique constraint WIDER than the nonclustered index ----
+    # uq_test_c3 UNIQUE (Id, DisplayName) / ix_c3 (Id) INCLUDE (LastAccessDate).
+    # Expected: no action, keys do not match exactly.
+    #
+    # Load-bearing. The procedure used to emit a merge into the constraint --
+    # CREATE INDEX ... WITH (DROP_EXISTING = ON) against a constraint-backed
+    # index, which SQL Server rejects with Msg 1907 -- while still emitting a
+    # runnable DISABLE of ix_c3. The merge failed, the disable succeeded, and
+    # ix_c3's LastAccessDate coverage vanished with nothing absorbing it. The
+    # dividing line is is_unique_constraint, not is_unique: contrast case 3,
+    # where a plain unique index is a legal merge target.
+
+    matches = dedupe_rows(rows, "uq_test_c3")
+    assert_test("7c-UC-Wider", "uq_test_c3 gets no dedupe action (Msg 1907 merge)",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    matches = dedupe_rows(rows, "ix_c3")
+    assert_test("7c-UC-Wider", "ix_c3 gets no dedupe action (would lose LastAccessDate)",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    # ---- Case 8a: Filtered indexes with matching filters ----
+    # ix_filtered_1 / ix_filtered_2, both WHERE (Reputation > 1000).
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_filtered_2",
+                        script_type="DISABLE SCRIPT")
+    assert_test("8a-Filter-Match", "ix_filtered_2 disabled (same filter as ix_filtered_1)",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # ---- Case 8b: Filtered index with a different filter ----
+    # ix_filtered_3 WHERE (Reputation > 2000). Covers different rows, keep it.
+
+    matches = dedupe_rows(rows, "ix_filtered_3")
+    assert_test("8b-Filter-Diff", "ix_filtered_3 gets no dedupe action (different filter)",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    # ---- Case 8c: Matching descending sort orders ----
+    # ix_desc_1 / ix_desc_2, both (Reputation DESC).
+
+    matches = find_rows(rows, table_name="Users", index_name="ix_desc_2",
+                        script_type="DISABLE SCRIPT")
+    assert_test("8c-Sort-Match", "ix_desc_2 disabled (same sort as ix_desc_1)",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # ---- Case 8d: Different sort direction ----
+    # ix_desc_3 (Reputation ASC). Different ordering, different query patterns.
+
+    matches = dedupe_rows(rows, "ix_desc_3")
+    assert_test("8d-Sort-Diff", "ix_desc_3 gets no dedupe action (different sort)",
+                len(matches) == 0,
+                "found %d (%s)" % (len(matches), [m["script_type"] for m in matches]))
+
+    # ---- Every generated script must actually execute ----
+    # A script that reads correctly but cannot run is the bug this procedure keeps
+    # producing. Each was executed inside a rolled-back transaction.
+
+    for index_name, script_type, error in script_results:
+        assert_test("9-Executable", "%s (%s) executes" % (index_name, script_type),
+                    error is None, error if error else "rolled back clean")
+
+    return results
+
+
+def cleanup(server, password):
+    """
+    Drop the three unique constraints and every nonclustered index the fixture
+    built. DropIndexes does not reliably remove constraints, so they go first and
+    explicitly.
+    """
+    query = """
+SET NOCOUNT ON;
+IF EXISTS (SELECT 1/0 FROM sys.key_constraints AS kc WHERE kc.name = N'uq_test_c1')
+BEGIN
+    ALTER TABLE dbo.Users DROP CONSTRAINT uq_test_c1;
+END;
+IF EXISTS (SELECT 1/0 FROM sys.key_constraints AS kc WHERE kc.name = N'uq_test_c2')
+BEGIN
+    ALTER TABLE dbo.Users DROP CONSTRAINT uq_test_c2;
+END;
+IF EXISTS (SELECT 1/0 FROM sys.key_constraints AS kc WHERE kc.name = N'uq_test_c3')
+BEGIN
+    ALTER TABLE dbo.Users DROP CONSTRAINT uq_test_c3;
+END;
+EXECUTE StackOverflow2013.dbo.DropIndexes;
+"""
+    run_sqlcmd(server, password, query=query, timeout=600)
+
+
+def main():
+    server = "SQL2022"
+    password = "L!nt0044"
+
+    # Parse args
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--server" and i + 1 < len(args):
+            server = args[i + 1]
+        elif arg == "--password" and i + 1 < len(args):
+            password = args[i + 1]
+
+    print("Running fixture case tests against %s..." % server)
+    print("Building fixtures and generating reads (about two minutes)...")
+    print()
+
+    try:
+        stdout, stderr = run_sqlcmd(server, password, input_file=FIXTURE_FILE,
+                                    timeout=600)
+
+        if "Msg " in stderr and "Level 16" in stderr:
+            print("ERROR: SQL errors detected:")
+            print(stderr)
+            sys.exit(1)
+
+        rows = parse_output(stdout)
+        print("Captured %d output rows from sp_IndexCleanup" % len(rows))
+
+        if len(rows) == 0:
+            print("ERROR: No output rows captured. Check SQL setup.")
+            print("stderr:", stderr[:500] if stderr else "(empty)")
+            sys.exit(1)
+
+        targets = script_rows(rows)
+        print("Executing %d generated scripts in rolled-back transactions..."
+              % len(targets))
+        print()
+        script_results = validate_scripts(server, password, rows)
+
+        results = run_tests(rows, script_results)
+    finally:
+        cleanup(server, password)
+
+    # Report
+    passed = sum(1 for r in results if r["passed"])
+    failed = sum(1 for r in results if not r["passed"])
+
+    for r in results:
+        status = "PASS" if r["passed"] else "FAIL"
+        print("  [%s] %s: %s  (%s)" % (status, r["group"], r["name"], r["detail"]))
+
+    print()
+    print("Results: %d passed, %d failed, %d total" % (passed, failed, len(results)))
+
+    if failed > 0:
+        print()
+        print("FAILED TESTS:")
+        for r in results:
+            if not r["passed"]:
+                print("  %s: %s  (%s)" % (r["group"], r["name"], r["detail"]))
+        sys.exit(1)
+    else:
+        print("All tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/sp_IndexCleanup/tests/rule_coverage_test.py
+++ b/sp_IndexCleanup/tests/rule_coverage_test.py
@@ -1,0 +1,559 @@
+"""
+sp_IndexCleanup Rule Coverage Tests
+===================================
+Covers two things nothing else in this directory tests: Rule 1 (unused index
+detection) and the @min_reads / @min_writes index-level screen.
+
+Builds its own synthetic fixture in the Crap database -- three ~20,000 row tables,
+scoped with @table_name so each procedure run is fast. It deliberately does not
+touch StackOverflow2013: fixture_cases_test.py already spends two minutes there,
+and this one is meant to be quick. Drops its tables afterward.
+
+(a) Rule 1, unused index detection.
+
+    The procedure auto-enables @dedupe_only when server uptime is <= 7 days, and
+    Rule 1 only runs when @dedupe_only = 0. So on a recently restarted instance
+    Rule 1 cannot be reached through the public interface at all. That is correct,
+    deliberate behavior: usage data on a freshly started instance is worthless,
+    and recommending index drops from it would be actively harmful.
+
+    Rather than skip, this asserts whichever statement is true on the instance in
+    front of it:
+
+      - uptime > 7 days:  the never-read index gets a DISABLE with a consolidation
+                          rule of 'Unused Index'.
+      - uptime <= 7 days: the GUARD holds. @dedupe_only was auto-enabled (proven
+                          by the procedure's own @debug message) and no 'Unused
+                          Index' rows appear anywhere.
+
+    The guard branch is a real assertion, not a silent pass. It is kept honest by
+    positive controls: the harness first proves the index was analyzed (it appears
+    in the output) and that it genuinely has zero reads, so the absence of an
+    'Unused Index' row is the guard doing its job rather than the index being
+    invisible for some unrelated reason.
+
+(b) The @min_reads / @min_writes index-level screen.
+
+    The screen gates DEDUPE ONLY. It must not take compression recommendations
+    with it -- an index can be far too cold to bother deduping and still be worth
+    compressing. It is also an OR: an index clears by meeting EITHER floor.
+
+    The write-floor cases run against a table whose clustered PK carries reads
+    (an UPDATE seeks it) while ix_w1/ix_w2 have none. The table therefore clears
+    the object-level filter on its own, which means these cases exercise the
+    index-level screen specifically rather than the coarser per-table filter.
+
+Usage:
+    python rule_coverage_test.py [--server SQL2022] [--password "L!nt0044"]
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+TEST_DATABASE = "Crap"
+
+# Rows that represent a dedupe action. A COMPRESSION SCRIPT row is not one.
+DEDUPE_SCRIPT_TYPES = ("DISABLE SCRIPT", "MERGE SCRIPT", "DISABLE CONSTRAINT SCRIPT")
+
+GUARD_MESSAGE = "Automatically enabling @dedupe_only mode"
+
+SETUP_SQL = """
+SET NOCOUNT ON;
+
+DROP TABLE IF EXISTS dbo.ic_min_reads_test;
+DROP TABLE IF EXISTS dbo.ic_min_writes_test;
+DROP TABLE IF EXISTS dbo.ic_unused_test;
+GO
+
+/*
+ic_min_reads_test: ix_hot (~200 reads), ix_warm (~5 reads, a key duplicate of
+ix_hot with different includes so the two pair), clustered PK (0 reads).
+*/
+CREATE TABLE
+    dbo.ic_min_reads_test
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT pk_ic_min_reads_test PRIMARY KEY CLUSTERED (id)
+);
+
+/*
+ic_min_writes_test: ix_w1 / ix_w2 are a key-duplicate pair that is never read but
+is written to. The clustered PK picks up reads from the UPDATE seeks, which lets
+the table clear the object-level filter so the index-level screen is what gets
+tested.
+*/
+CREATE TABLE
+    dbo.ic_min_writes_test
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT pk_ic_min_writes_test PRIMARY KEY CLUSTERED (id)
+);
+
+/*
+ic_unused_test: ix_never_read has distinct keys so no dedupe rule can fire on it.
+The only thing that can flag it is Rule 1.
+*/
+CREATE TABLE
+    dbo.ic_unused_test
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT pk_ic_unused_test PRIMARY KEY CLUSTERED (id)
+);
+GO
+
+INSERT INTO
+    dbo.ic_min_reads_test
+(
+    id,
+    col_a,
+    col_b,
+    col_c,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 500,
+    col_b = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 100,
+    col_c = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 250,
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+INSERT INTO
+    dbo.ic_min_writes_test
+(
+    id,
+    col_a,
+    col_b,
+    col_c,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 500,
+    col_b = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 100,
+    col_c = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 250,
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+INSERT INTO
+    dbo.ic_unused_test
+(
+    id,
+    col_a,
+    col_b,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 500,
+    col_b = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 100,
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+GO
+
+CREATE INDEX ix_hot ON dbo.ic_min_reads_test (col_a) INCLUDE (col_b);
+CREATE INDEX ix_warm ON dbo.ic_min_reads_test (col_a) INCLUDE (col_c);
+
+CREATE INDEX ix_w1 ON dbo.ic_min_writes_test (col_a) INCLUDE (col_b);
+CREATE INDEX ix_w2 ON dbo.ic_min_writes_test (col_a) INCLUDE (col_c);
+
+CREATE INDEX ix_never_read ON dbo.ic_unused_test (col_a);
+GO
+
+/*
+Drive reads with forced index hints, bounded: ix_hot ~200, ix_warm ~5, PK 0.
+Nothing reads ic_unused_test at all.
+*/
+DECLARE
+    @c bigint,
+    @i integer = 0;
+
+WHILE @i < 200
+BEGIN
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_min_reads_test AS t WITH (INDEX = ix_hot) WHERE t.col_a = @i % 500 OPTION(MAXDOP 1);
+    SELECT @i += 1;
+END;
+
+SELECT @i = 0;
+
+WHILE @i < 5
+BEGIN
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_min_reads_test AS t WITH (INDEX = ix_warm) WHERE t.col_a = @i % 500 OPTION(MAXDOP 1);
+    SELECT @i += 1;
+END;
+GO
+
+/*
+Drive writes on ic_min_writes_test. Updating col_a maintains both ix_w1 and ix_w2
+(it is the key of both), so both collect writes while collecting no reads.
+*/
+DECLARE
+    @i integer = 0;
+
+WHILE @i < 60
+BEGIN
+    UPDATE
+        t
+    SET
+        t.col_a = (t.col_a + 1) % 500
+    FROM dbo.ic_min_writes_test AS t
+    WHERE t.id = @i
+    OPTION(MAXDOP 1);
+
+    SELECT @i += 1;
+END;
+GO
+"""
+
+CLEANUP_SQL = """
+SET NOCOUNT ON;
+DROP TABLE IF EXISTS dbo.ic_min_reads_test;
+DROP TABLE IF EXISTS dbo.ic_min_writes_test;
+DROP TABLE IF EXISTS dbo.ic_unused_test;
+"""
+
+
+def run_sqlcmd(server, password, input_file=None, query=None,
+               database=TEST_DATABASE, timeout=600):
+    """Run SQL from a file or a query string and capture output."""
+    cmd = [
+        "sqlcmd", "-S", server, "-U", "sa", "-P", password,
+        "-d", database,
+        "-W",  # trim trailing spaces
+        "-s", "\t",  # tab delimiter
+    ]
+    if input_file is not None:
+        cmd += ["-i", input_file]
+    else:
+        cmd += ["-Q", query]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return result.stdout, result.stderr
+
+
+def run_sql_script(server, password, sql, timeout=600):
+    """Run a multi-batch script (one containing GO) through a temp file."""
+    path = None
+    try:
+        handle, path = tempfile.mkstemp(suffix=".sql", prefix="ic_rule_cov_")
+        with os.fdopen(handle, "w") as f:
+            f.write(sql)
+        return run_sqlcmd(server, password, input_file=path, timeout=timeout)
+    finally:
+        if path and os.path.exists(path):
+            os.remove(path)
+
+
+def parse_output(stdout):
+    """
+    Parse sp_IndexCleanup tab-delimited output into rows.
+
+    Bounded to the script result set: the procedure emits several result sets and
+    the later ones share nothing but a tab delimiter, so parsing stops at the
+    blank line that ends this one. That bound matters here because most of the
+    assertions below are assertions of absence.
+
+    Column order, verified empirically against the running procedure:
+        script_type, additional_info, database_name, schema_name, table_name,
+        index_name, consolidation_rule, target_index_name, superseded_info,
+        index_size_gb, index_rows, index_reads, index_writes,
+        original_index_definition, script
+    """
+    rows = []
+    lines = stdout.split("\n")
+    headers = None
+    started = False
+
+    for line in lines:
+        if headers is None:
+            if "script_type" in line and "index_name" in line:
+                headers = [h.strip() for h in line.split("\t")]
+            continue
+
+        if line.startswith("---"):
+            continue
+
+        if not line.strip():
+            if started:
+                break
+            continue
+
+        cols = [c.strip() for c in line.split("\t")]
+        if len(cols) >= len(headers):
+            rows.append(dict(zip(headers, cols)))
+            started = True
+
+    return rows
+
+
+def find_rows(rows, **filters):
+    """Find rows matching all filter criteria."""
+    matches = []
+    for row in rows:
+        match = True
+        for key, value in filters.items():
+            if key.endswith("__like"):
+                col = key[:-6]
+                if col not in row or value.lower() not in row[col].lower():
+                    match = False
+                    break
+            elif key.endswith("__in"):
+                col = key[:-4]
+                if col not in row or row[col] not in value:
+                    match = False
+                    break
+            else:
+                if key not in row or row[key] != value:
+                    match = False
+                    break
+        if match:
+            matches.append(row)
+    return matches
+
+
+def dedupe_rows(rows, index_name):
+    """Every dedupe-action row for an index. Compression rows are not included."""
+    return [
+        r for r in rows
+        if r.get("index_name") == index_name
+        and r.get("script_type") in DEDUPE_SCRIPT_TYPES
+    ]
+
+
+def get_uptime_days(server, password):
+    """Server uptime in days, as the procedure itself computes it."""
+    stdout, _ = run_sqlcmd(
+        server, password, database="master",
+        query="SET NOCOUNT ON; SELECT uptime = DATEDIFF(DAY, osi.sqlserver_start_time,"
+              " SYSDATETIME()) FROM sys.dm_os_sys_info AS osi;",
+    )
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if line.isdigit():
+            return int(line)
+    raise RuntimeError("Could not read server uptime:\n%s" % stdout)
+
+
+def run_proc(server, password, table_name, extra="", debug=False):
+    """Run sp_IndexCleanup scoped to one table and return (rows, stdout)."""
+    query = (
+        "EXECUTE master.dbo.sp_IndexCleanup "
+        "@database_name = '%s', @schema_name = 'dbo', @table_name = '%s'%s%s;"
+        % (TEST_DATABASE, table_name, extra, ", @debug = 1" if debug else "")
+    )
+    stdout, _ = run_sqlcmd(server, password, database="master", query=query)
+    return parse_output(stdout), stdout
+
+
+def run_tests(server, password, uptime_days):
+    """Run all assertions and return results."""
+    results = []
+
+    def assert_test(group, name, condition, detail=""):
+        results.append({
+            "group": group,
+            "name": name,
+            "passed": condition,
+            "detail": detail,
+        })
+
+    # ---- Group A: Rule 1, unused index detection ----
+
+    rows, _ = run_proc(server, password, "ic_unused_test")
+    unused_rows = [
+        r for r in rows
+        if "unused index" in (r.get("consolidation_rule") or "").lower()
+    ]
+
+    if uptime_days > 7:
+        # Rule 1 is reachable: @dedupe_only defaults to 0 and stays there.
+        matches = find_rows(rows, index_name="ix_never_read",
+                            script_type="DISABLE SCRIPT",
+                            consolidation_rule__like="Unused Index")
+        assert_test("A-Rule1", "ix_never_read disabled as Unused Index",
+                    len(matches) == 1,
+                    "found %d (uptime %d days, Rule 1 reachable)"
+                    % (len(matches), uptime_days))
+    else:
+        # Rule 1 is unreachable by design. Assert the guard instead.
+        #
+        # Positive controls first: without them "no Unused Index rows" would be
+        # true for any number of uninteresting reasons.
+        present = find_rows(rows, index_name="ix_never_read")
+        assert_test("A-Guard", "positive control: ix_never_read was analyzed",
+                    len(present) >= 1,
+                    "found %d rows for the index (%s)"
+                    % (len(present), [p["script_type"] for p in present]))
+
+        reads = present[0].get("index_reads") if present else None
+        assert_test("A-Guard", "positive control: ix_never_read has zero reads",
+                    reads == "0", "index_reads=%s" % reads)
+
+        # The procedure says so itself when asked with @debug = 1.
+        _, debug_stdout = run_proc(server, password, "ic_unused_test", debug=True)
+        assert_test("A-Guard", "@dedupe_only auto-enabled by the uptime guard",
+                    GUARD_MESSAGE in debug_stdout,
+                    "procedure reported the auto-enable"
+                    if GUARD_MESSAGE in debug_stdout
+                    else "guard message never appeared with @debug = 1")
+
+        # Therefore Rule 1 never ran, and nothing is recommended as unused.
+        assert_test("A-Guard", "no Unused Index rows while the guard is active",
+                    len(unused_rows) == 0,
+                    "found %d unused rows (expected 0)" % len(unused_rows))
+
+    # ---- Group B: @min_reads / @min_writes index-level screen ----
+
+    # B1: no floor. ix_hot and ix_warm are key duplicates and should pair up.
+    rows, _ = run_proc(server, password, "ic_min_reads_test", extra=", @min_reads = 0")
+
+    hot = dedupe_rows(rows, "ix_hot")
+    warm = dedupe_rows(rows, "ix_warm")
+    assert_test("B-MinReads", "@min_reads = 0: ix_hot/ix_warm get a dedupe recommendation",
+                len(hot) >= 1 and len(warm) >= 1,
+                "ix_hot=%s ix_warm=%s"
+                % ([h["script_type"] for h in hot], [w["script_type"] for w in warm]))
+
+    # B2: floor above ix_warm's 5 reads. ix_warm is below it, so the pair cannot
+    # be deduped -- both sides must clear the floor on their own.
+    rows, _ = run_proc(server, password, "ic_min_reads_test", extra=", @min_reads = 100")
+
+    warm = dedupe_rows(rows, "ix_warm")
+    assert_test("B-MinReads", "@min_reads = 100: ix_warm not deduped (5 reads, below floor)",
+                len(warm) == 0,
+                "found %d (%s)" % (len(warm), [w["script_type"] for w in warm]))
+
+    # And the half that actually matters: the screen gates dedupe ONLY. Losing a
+    # compression recommendation to a reads floor would be a bug -- compression
+    # eligibility has nothing to do with how often an index is read.
+    matches = find_rows(rows, index_name="ix_warm", script_type="COMPRESSION SCRIPT")
+    assert_test("B-MinReads", "@min_reads = 100: ix_warm still gets COMPRESSION SCRIPT",
+                len(matches) == 1, "found %d" % len(matches))
+
+    matches = find_rows(rows, index_name="pk_ic_min_reads_test",
+                        script_type="COMPRESSION SCRIPT")
+    assert_test("B-MinReads", "@min_reads = 100: PK still gets COMPRESSION SCRIPT",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # B3: write floor only. ix_w1/ix_w2 have 60 writes and zero reads, so they
+    # clear on the write side alone.
+    rows, _ = run_proc(server, password, "ic_min_writes_test", extra=", @min_writes = 50")
+
+    w1 = dedupe_rows(rows, "ix_w1")
+    w2 = dedupe_rows(rows, "ix_w2")
+    assert_test("B-MinWrites", "@min_writes = 50, no reads floor: write-only pair still dedupes",
+                len(w1) >= 1 and len(w2) >= 1,
+                "ix_w1=%s ix_w2=%s"
+                % ([w["script_type"] for w in w1], [w["script_type"] for w in w2]))
+
+    # B4: the same pair against a reads floor it cannot meet. Together with B3
+    # this is what makes the floors an OR rather than an AND: identical indexes,
+    # identical usage, deduped under the write floor and not under the read floor.
+    rows, _ = run_proc(server, password, "ic_min_writes_test", extra=", @min_reads = 50")
+
+    w1 = dedupe_rows(rows, "ix_w1")
+    w2 = dedupe_rows(rows, "ix_w2")
+    assert_test("B-MinWrites", "@min_reads = 50 alone: same pair not deduped (0 reads)",
+                len(w1) == 0 and len(w2) == 0,
+                "ix_w1=%s ix_w2=%s"
+                % ([w["script_type"] for w in w1], [w["script_type"] for w in w2]))
+
+    # Compression survives this screen too.
+    matches = find_rows(rows, index_name="ix_w1", script_type="COMPRESSION SCRIPT")
+    assert_test("B-MinWrites", "@min_reads = 50 alone: ix_w1 still gets COMPRESSION SCRIPT",
+                len(matches) == 1, "found %d" % len(matches))
+
+    return results
+
+
+def main():
+    server = "SQL2022"
+    password = "L!nt0044"
+
+    # Parse args
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--server" and i + 1 < len(args):
+            server = args[i + 1]
+        elif arg == "--password" and i + 1 < len(args):
+            password = args[i + 1]
+
+    print("Running rule coverage tests against %s..." % server)
+    print()
+
+    uptime_days = get_uptime_days(server, password)
+    print("Server uptime: %d days" % uptime_days)
+
+    if uptime_days > 7:
+        print("Uptime is over 7 days, so @dedupe_only stays off and Rule 1 is")
+        print("reachable. Asserting that the never-read index is flagged unused.")
+    else:
+        print("Uptime is 7 days or less, so sp_IndexCleanup auto-enables")
+        print("@dedupe_only and Rule 1 cannot run. This is deliberate: usage data")
+        print("from a freshly started instance is not worth acting on. Rule 1")
+        print("itself is therefore not testable on this instance, so what gets")
+        print("asserted instead is THE GUARD -- that @dedupe_only really was")
+        print("auto-enabled and that no index is recommended as unused. This is a")
+        print("verification, not a skip.")
+    print()
+
+    print("Building synthetic fixture in %s..." % TEST_DATABASE)
+    stdout, stderr = run_sql_script(server, password, SETUP_SQL)
+
+    if "Msg " in stdout or ("Msg " in stderr and "Level 16" in stderr):
+        print("ERROR: SQL errors during fixture setup:")
+        print(stdout[-2000:])
+        print(stderr[:500] if stderr else "(empty stderr)")
+        sys.exit(1)
+
+    print()
+
+    try:
+        results = run_tests(server, password, uptime_days)
+    finally:
+        run_sql_script(server, password, CLEANUP_SQL)
+
+    # Report
+    passed = sum(1 for r in results if r["passed"])
+    failed = sum(1 for r in results if not r["passed"])
+
+    for r in results:
+        status = "PASS" if r["passed"] else "FAIL"
+        print("  [%s] %s: %s  (%s)" % (status, r["group"], r["name"], r["detail"]))
+
+    print()
+    print("Results: %d passed, %d failed, %d total" % (passed, failed, len(results)))
+
+    if failed > 0:
+        print()
+        print("FAILED TESTS:")
+        for r in results:
+            if not r["passed"]:
+                print("  %s: %s  (%s)" % (r["group"], r["name"], r["detail"]))
+        sys.exit(1)
+    else:
+        print("All tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug

Merged include lists were built by splitting `included_columns` apart on `', '` and reassembling the fragments. **A column name may legally contain a comma and a space**, so that delimiter was ambiguous:

```sql
CREATE TABLE dbo.t (col_a int, col_b int, [Last, First] int, [zzz] int);
CREATE UNIQUE INDEX uq ON dbo.t (col_a) INCLUDE (col_b);
CREATE INDEX ix ON dbo.t (col_a) INCLUDE ([Last, First], [zzz]);
```

`[Last, First]` tore into `[Last` and `First]`, and the `DISTINCT` sort slotted `[zzz]` between the halves:

```
INCLUDE ([col_b], [Last, [zzz], First])
Msg 102, Level 15, State 1: Incorrect syntax near ']'.
```

Dead merge script, live `DISABLE` — the same silent include loss as the Msg 1907 / 1911 / 9411 / 103 defects fixed previously. Fifth instance of one failure mode.

## The fix

All four merge sites (Rule 6, Rule 7.6, and both Key Duplicate paths) now read `#index_details`, which already holds **one row per column**, instead of parsing a delimited string.

There is nothing left to split, so the entity escaping and widened XML extractions those sites needed are **gone with it** — the delimiter, Msg 9411 and Msg 103 bug classes are retired rather than patched. Excluding a column already in the superset's key is now an exact column-name match rather than a `CHARINDEX` search of the `key_columns` string. Net **-358 lines**.

Output is **byte-identical** to the previous build across all eight invocations of the capture suite against the real `StackOverflow2013.dbo.Users` fixtures. The only behavior change is that hostile column names work.

## Tests

**`fixture_cases_test.py`** drives `fixtures_more_dupe_indexes.sql`, asserts the `Expected:` comments (cases 1–8d), and **executes every generated MERGE/DISABLE script inside a rolled-back transaction**.

That execute check is the point. Every defect found in this procedure has been a script that reads correctly and cannot run — which compiling and eyeballing both miss. Pointed at the pre-fix build, the suite goes red on exactly the historical bugs:

```
[FAIL] 3-Unique-Index: uq_test_1 merged and script has CREATE UNIQUE  (found 0 merge rows)
[FAIL] 7c-UC-Wider: uq_test_c3 gets no dedupe action  (found 1 (['MERGE SCRIPT']))
[FAIL] 9-Executable: uq_test_c3 (MERGE SCRIPT) executes
       (ERROR: Msg 1907 - Cannot recreate index 'uq_test_c3'. The new index
        definition does not match the constraint being enforced by the existing index.)
```

Msg 1907 surfaces from the execute check **alone**. `SET PARSEONLY ON` would sail straight past it — 1907 is semantic, not syntactic.

**`rule_coverage_test.py`** covers unused-index detection and the `@min_reads`/`@min_writes` index-level screen, neither of which had any assertion.

## Uptime guard (worth knowing)

`sp_IndexCleanup` auto-enables `@dedupe_only` when uptime is <= 7 days, so **Rule 1 is unreachable on a freshly restarted instance** and unused-index detection looks broken when it is working exactly as designed. The procedure says so under `@debug`: *"Server uptime is less than 7 days. Automatically enabling @dedupe_only mode."*

Rather than skip, `rule_coverage_test.py` asserts whichever is true — Rule 1 firing on a long-uptime server, or the guard suppressing it on a fresh one — after first proving the index was analyzed and genuinely has zero reads, so an absent `Unused Index` row means the guard rather than an invisible index. Documented in the README.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] `run_tests.py` 28/28 · `fixture_cases_test.py` 31/31 · `rule_coverage_test.py` 11/11 · `no_access_test.py` 4/4
- [x] Negative control: new suite goes **27/5 red** against the pre-fix build, catching the exact historical bugs
- [x] `[Last, First]`, `[A&B]`, `[L<T]`, and a 128-char column all generate scripts that **execute**, includes verified landed
- [x] Baseline diff vs previous build: byte-identical on all eight invocations
- [x] Harnesses self-clean; no leftover indexes, constraints, logins, or tables
- [x] No version/date bumps; `Install-All/DarlingData.sql` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)