### PR TITLE
sp_IndexCleanup: keep key-subset includes through Rule 7.6; unbreak the harness

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -4490,8 +4490,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         ia_winner
     SET
         /*
-        Merge the disabled Key Duplicates' includes into the index being made
-        unique.
+        Merge the includes of every index being disabled in this winner's favor
+        into the index being made unique.
 
         Sourced from #index_details, one row per column, rather than splitting
         included_columns on ', '. A column name may legally contain a comma and
@@ -4499,9 +4499,21 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         fragments the DISTINCT sort could separate, producing a broken INCLUDE
         list on a script whose paired DISABLE still ran.
 
-        Winner and losers are key duplicates, so their keys match and SQL Server
-        would not allow a key column to also be an include. No key exclusion is
-        needed.
+        Both loser rules matter, and missing one is not a cosmetic error. Rule 7.5
+        can rewrite a row Rule 6 already processed as a Key Superset into MAKE
+        UNIQUE, so a winner arriving here may own Key SUBSET losers as well as Key
+        DUPLICATE ones. Reading only Key Duplicates discarded the subsets'
+        includes that Rule 6 had already merged in, while their DISABLE still
+        ran - a covering column silently gone, on a script that executes cleanly.
+        The old string-splitting code survived this by accident: it read the
+        accumulated included_columns, so an earlier merge carried forward.
+        Re-deriving from disk does not, which is why every loser has to be
+        gathered here explicitly.
+
+        Key duplicates share the winner's keys, but key subsets do not, so losers
+        are matched on target_index_name rather than key_filter_hash, and a column
+        already in the winner's key is excluded - SQL Server rejects an index that
+        includes its own key column (Msg 1909).
         */
         ia_winner.included_columns =
             STUFF
@@ -4516,19 +4528,32 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     (
                         /* The winner's own includes */
                         idc.index_hash = ia_winner.index_hash
-                        /* Plus those of every duplicate being disabled for it */
+                        /* Plus those of every index being disabled in its favor */
                         OR EXISTS
                            (
                                SELECT
                                    1/0
                                FROM #index_analysis AS ia_loser
                                WHERE ia_loser.scope_hash = ia_winner.scope_hash
-                               AND   ia_loser.key_filter_hash = ia_winner.key_filter_hash
                                AND   ia_loser.action = N'DISABLE'
-                               AND   ia_loser.consolidation_rule = N'Key Duplicate'
                                AND   ia_loser.target_index_name = ia_winner.index_name
+                               AND   ia_loser.consolidation_rule IN
+                                     (
+                                         N'Key Duplicate',
+                                         N'Key Subset'
+                                     )
                                AND   ia_loser.index_hash = idc.index_hash
                            )
+                    )
+                    /* A column already in the winner's key doesn't need including */
+                    AND NOT EXISTS
+                    (
+                        SELECT
+                            1/0
+                        FROM #index_details AS idk
+                        WHERE idk.index_hash = ia_winner.index_hash
+                        AND   idk.is_included_column = 0
+                        AND   idk.column_name = idc.column_name
                     )
                     GROUP BY
                         idc.column_name

--- a/sp_IndexCleanup/tests/adversarial_test.sql
+++ b/sp_IndexCleanup/tests/adversarial_test.sql
@@ -216,9 +216,21 @@ SELECT TOP (10000) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
     ABS(CHECKSUM(NEWID())) % 500, ABS(CHECKSUM(NEWID())) % 200
 FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
 
+/*
+col_c is ROW_NUMBER(), not a random value, and that matters. Group 12b creates
+uq_int_cd UNIQUE (col_c, col_d) below. With col_c and col_d drawn randomly from
+200 and 100 values across 10,000 rows, duplicate pairs were a certainty, so the
+constraint failed to create on EVERY run with Msg 1505, Msg 1750 followed, and
+the read loop's forced hint on the missing index aborted the usage batch with
+Msg 308. Group 12b was never actually tested, and the suite could not see any of
+it because the runner checked stderr while go-sqlcmd reports errors on stdout.
+
+A unique col_c makes (col_c, col_d) unique regardless of col_d. col_a and col_b
+stay duplicated on purpose - the subset chain in 12a needs repeated values.
+*/
 INSERT INTO dbo.test_ic_interact (col_a, col_b, col_c, col_d, col_e)
 SELECT TOP (10000) ABS(CHECKSUM(NEWID())) % 1000, ABS(CHECKSUM(NEWID())) % 500,
-    ABS(CHECKSUM(NEWID())) % 200, ABS(CHECKSUM(NEWID())) % 100, LEFT(NEWID(), 20)
+    ROW_NUMBER() OVER (ORDER BY (SELECT NULL)), ABS(CHECKSUM(NEWID())) % 100, LEFT(NEWID(), 20)
 FROM sys.all_objects AS a CROSS JOIN sys.all_objects AS b;
 GO
 
@@ -301,9 +313,29 @@ CREATE INDEX ix_int_ab ON dbo.test_ic_interact (col_a, col_b);
 CREATE INDEX ix_int_abc ON dbo.test_ic_interact (col_a, col_b, col_c);
 
 /* 12b: UC exact match AND UC superset on same table */
+/*
+This group is the one shape where three rules meet, and every piece of it is
+load-bearing:
+
+  uq_int_cd   the unique CONSTRAINT that Rule 7.5 wants to replace
+  ix_int_cd   a key duplicate of it, with its own include
+  ix_int_cd2  a SECOND key duplicate with a DIFFERENT include, which is what
+              routes the winner through Rule 7.6 at all
+  ix_int_c    a key SUBSET carrying an include of its own
+
+Rule 6 merges ix_int_c's col_b into the winner as a Key Subset. Rule 7.5 then
+rewrites that same row to MAKE UNIQUE. Rule 7.6 recomputes the winner's includes,
+and if it gathers only Key Duplicate losers it silently drops col_b while
+ix_int_c's DISABLE still runs - a covering column gone, on scripts that all
+execute cleanly, which the execute check cannot see.
+
+Drop ix_int_cd2 and the interaction stops firing: with one duplicate there is no
+7.6 pass to lose anything. That is why a fixture without it looked healthy.
+*/
 ALTER TABLE dbo.test_ic_interact ADD CONSTRAINT uq_int_cd UNIQUE (col_c, col_d);
 CREATE INDEX ix_int_cd ON dbo.test_ic_interact (col_c, col_d) INCLUDE (col_e);
-CREATE INDEX ix_int_c ON dbo.test_ic_interact (col_c);
+CREATE INDEX ix_int_cd2 ON dbo.test_ic_interact (col_c, col_d) INCLUDE (col_a);
+CREATE INDEX ix_int_c ON dbo.test_ic_interact (col_c) INCLUDE (col_b);
 
 /* Group 13: @min_reads filter — run separately in Python */
 GO

--- a/sp_IndexCleanup/tests/fixture_cases_test.py
+++ b/sp_IndexCleanup/tests/fixture_cases_test.py
@@ -487,9 +487,20 @@ def main():
         stdout, stderr = run_sqlcmd(server, password, input_file=FIXTURE_FILE,
                                     timeout=600)
 
-        if "Msg " in stderr and "Level 16" in stderr:
-            print("ERROR: SQL errors detected:")
-            print(stderr)
+        # go-sqlcmd reports SQL errors on STDOUT, so checking stderr alone made
+        # this decorative: a fixture could fail partway through and the suite
+        # would still go green, asserting against a half-built schema. Match any
+        # severity 16+ on both streams.
+        errors = (re.findall(r"Msg \d+, Level 1[6-9][^\n]*", stdout or "") +
+                  re.findall(r"Msg \d+, Level 1[6-9][^\n]*", stderr or ""))
+
+        if errors:
+            print("ERROR: SQL errors detected while building the fixture:")
+            for e in errors:
+                print("  " + e)
+            print()
+            print("The fixture did not build correctly, so the assertions below")
+            print("would be testing something other than what they claim.")
             sys.exit(1)
 
         rows = parse_output(stdout)

--- a/sp_IndexCleanup/tests/run_tests.py
+++ b/sp_IndexCleanup/tests/run_tests.py
@@ -12,6 +12,19 @@ import sys
 import re
 
 
+def find_sql_errors(text):
+    """Return any SQL errors of severity 16 or higher found in text.
+
+    go-sqlcmd reports errors on stdout, so both streams have to be checked.
+    Matching the severity numerically catches Level 16 through 19 rather than
+    only the literal "Level 16".
+    """
+    if not text:
+        return []
+
+    return re.findall(r"Msg \d+, Level 1[6-9][^\n]*", text)
+
+
 def run_sqlcmd(server, password):
     """Run the test SQL and capture output."""
     cmd = [
@@ -309,10 +322,52 @@ def run_tests(rows):
                 len(matches) == 0, f"found {len(matches)} (expected 0)")
 
     # 12b: UC + NC + subset on same table
-    # KNOWN ISSUE: uq_int_cd, ix_int_cd, and ix_int_c don't appear in
-    # output at all — needs investigation with @debug = 1 to determine
-    # if they're excluded at collection or rule processing stage.
-    # Skipping assertion for now — tracked as issue for investigation.
+    # 12b: UC + key-duplicate NC + key-subset NC on the same table.
+    #
+    # This was skipped for a long time with a comment saying these three indexes
+    # "don't appear in output at all -- needs investigation". They were absent
+    # because the FIXTURE was broken, not the procedure: col_c and col_d were
+    # random values from 200 and 100 buckets across 10,000 rows, so
+    # uq_int_cd UNIQUE (col_c, col_d) failed to create on every run (Msg 1505),
+    # and the read loop then aborted hinting the missing index (Msg 308). The
+    # runner could not see any of it because it checked stderr and go-sqlcmd
+    # reports errors on stdout. Both are fixed; on clean data the procedure gets
+    # this group right.
+
+    # 12b: the constraint is replaced by its nonclustered twin
+    matches = find_rows(rows, table_name="test_ic_interact", index_name="uq_int_cd",
+                        script_type="DISABLE CONSTRAINT SCRIPT")
+    assert_test("12-Interact", "12b: uq_int_cd constraint dropped for ix_int_cd",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # 12b: that twin is made unique
+    matches = find_rows(rows, table_name="test_ic_interact", index_name="ix_int_cd",
+                        script_type="MERGE SCRIPT")
+    has_unique = any("CREATE UNIQUE" in m.get("script", "") for m in matches)
+    assert_test("12-Interact", "12b: ix_int_cd made unique to replace the constraint",
+                has_unique, f"found {len(matches)} merge rows, unique={has_unique}")
+
+    # 12b: the key subset is disabled into it
+    matches = find_rows(rows, table_name="test_ic_interact", index_name="ix_int_c",
+                        script_type="DISABLE SCRIPT")
+    assert_test("12-Interact", "12b: ix_int_c (key subset) disabled",
+                len(matches) == 1, f"found {len(matches)}")
+
+    # 12b: THE load-bearing one. ix_int_c is being disabled, so whatever it
+    # covered has to survive in the index replacing it. Rule 6 merges col_b in as
+    # a Key Subset; Rule 7.5 then rewrites the row to MAKE UNIQUE and Rule 7.6
+    # recomputes the includes. A 7.6 that gathers only Key Duplicate losers drops
+    # col_b here while ix_int_c's DISABLE still runs -- coverage silently gone on
+    # scripts that all execute cleanly, which the execute check cannot see.
+    matches = find_rows(rows, table_name="test_ic_interact", index_name="ix_int_cd",
+                        script_type="MERGE SCRIPT")
+    script = matches[0].get("script", "") if matches else ""
+    include = script[script.find("INCLUDE"):script.find(")", script.find("INCLUDE")) + 1] if "INCLUDE" in script else ""
+    kept_subset_col = "col_b" in include
+    kept_own_col = "col_e" in include
+    assert_test("12-Interact", "12b: merge keeps BOTH its own include and the disabled subset's",
+                kept_subset_col and kept_own_col,
+                f"INCLUDE={include or '(none)'} col_b={kept_subset_col} col_e={kept_own_col}")
 
     return results
 
@@ -334,9 +389,20 @@ def main():
 
     stdout, stderr = run_sqlcmd(server, password)
 
-    if "Msg " in stderr and "Level 16" in stderr:
-        print("ERROR: SQL errors detected:")
-        print(stderr)
+    # go-sqlcmd writes SQL errors to STDOUT, not stderr. Checking stderr alone
+    # made this detection decorative: adversarial_test.sql was failing partway
+    # through on every run (Msg 1505 on test_ic_interact) and the suite stayed
+    # green, so group 12 was never really tested. Check both streams, and match
+    # any severity 16+ rather than the literal string "Level 16".
+    errors = find_sql_errors(stdout) + find_sql_errors(stderr)
+
+    if errors:
+        print("ERROR: SQL errors detected while running the fixture:")
+        for e in errors:
+            print("  " + e)
+        print()
+        print("The fixture did not build correctly, so the assertions below")
+        print("would be testing something other than what they claim.")
         sys.exit(1)
 
     rows = parse_output(stdout)


### PR DESCRIPTION
Fixes a regression **currently on `dev`** (introduced by #821) and the reason nothing caught it.

## The regression

Rule 7.6 recomputes the winner's includes from `#index_details`, but gathered only **Key Duplicate** losers. Rule 7.5 can rewrite a row Rule 6 already processed as a Key **Superset** into MAKE UNIQUE — so a winner arriving at 7.6 may own Key **Subset** losers too. Their includes, already merged in by Rule 6, were discarded while their `DISABLE` still ran:

```sql
uq_ow_cd UNIQUE (col_c, col_d)
ix_ow_cd  (col_c, col_d) INCLUDE (col_e)
ix_ow_cd2 (col_c, col_d) INCLUDE (col_a)
ix_ow_c   (col_c)        INCLUDE (col_b)
```

```
before #821:  INCLUDE ([col_a], [col_b], [col_e])
on dev now:   INCLUDE ([col_a], [col_e])     <- col_b gone, ix_ow_c still disabled
```

Every script executes cleanly. This is the **succeed-but-wrong** class — the one the execute check is structurally blind to, and the one that actually harms production. The old string-splitting code survived it *by accident*: it read the accumulated `included_columns`, so an earlier merge carried forward. Re-deriving from disk doesn't, so every loser now has to be gathered explicitly.

7.6 now matches losers on `target_index_name` rather than `key_filter_hash` (key subsets don't share the winner's keys) and excludes columns already in the winner's key (Msg 1909).

## The harness could not see SQL errors at all

`run_tests.py` and `fixture_cases_test.py` checked **stderr** for `"Msg "`. go-sqlcmd reports errors on **stdout**. The detection was decorative. Both now scan both streams for any severity 16+ and fail loudly.

That immediately surfaced what it had been hiding: **`adversarial_test.sql` failed partway through on every single run.** `test_ic_interact` drew `col_c`/`col_d` randomly from 200 and 100 buckets across 10,000 rows, so `uq_int_cd UNIQUE (col_c, col_d)` could never be created (Msg 1505 → Msg 1750), and the read loop then aborted hinting the missing index (Msg 308).

Group 12b was never tested, and the `KNOWN ISSUE` comment blaming the procedure was wrong — on clean data it gets the group right. `col_c` is now `ROW_NUMBER()`; `col_a`/`col_b` stay duplicated, which 12a needs.

## Group 12b becomes the regression test

Re-enabled and extended. It gains `ix_int_cd2`, a second key duplicate with a different include — **without it the winner never routes through 7.6 and the interaction cannot fire**, which is exactly why a fixture lacking it looked healthy. My first attempt at this fixture passed on the buggy build; that's how I know this one is real.

Verified in both directions:

```
dev build:   INCLUDE ([col_a], [col_e])            col_b=False  -> 31/1 FAIL
this build:  INCLUDE ([col_a], [col_b], [col_e])   col_b=True   -> 32/0 PASS
```

## Worth recording

This was found by independent review *after* the regression shipped. 70 assertions, a full baseline diff, and an adversarial pass all went green with the bug present, because no fixture combined a subset-with-include, a unique constraint, and two key duplicates in one group.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] `run_tests.py` **32/32** (up from 28 — group 12b is live for the first time)
- [x] `fixture_cases_test.py` 31/31 · `rule_coverage_test.py` 11/11 · `no_access_test.py` 4/4
- [x] New 12b assertion proven to fail on the `dev` build and pass on this one
- [x] Fixtures self-clean; no leftover indexes or constraints
- [x] No version/date bumps; `Install-All/DarlingData.sql` untouched

## Still open from the same review

Nonclustered PRIMARY KEYs are unprotected in the dedupe rules (`is_primary_key` is consulted only in Rule 1) — a PK can get a `DISABLE SCRIPT` that executes and silently disables an inbound foreign key. And two plausible mutations survive the whole suite. Both are being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)