### PR TITLE
sp_IndexCleanup: never dedupe a primary key; kill two surviving mutants

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -2487,6 +2487,35 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     still analyzed by the pre-filter but then dropped here unless some
     single partition cleared the floor alone - the two filters disagreed
     about what "@min_rows" means.
+
+    On is_eligible_for_dedupe below: the CASE tests i.type = 1 OR
+    i.is_primary_key = 1 FIRST, and that order is load bearing. A
+    nonclustered primary key is type = 2, so testing type = 2 first matched
+    it as an ordinary nonclustered index and the is_primary_key branch could
+    never be reached for the one kind of index it was written for. That let
+    primary keys into the dedupe rules, which check only
+    is_unique_constraint - 0 for a primary key. Rule 5 then emitted
+    CREATE UNIQUE INDEX ... WITH (DROP_EXISTING = ON) against the PK
+    (Msg 1907, while the paired DISABLE of the other index still ran), and
+    Rule 2 could emit ALTER INDEX ... DISABLE against it, which does not
+    error: it succeeds, and silently disables every inbound foreign key
+    along with it.
+
+    Primary keys are ineligible for dedupe. UNIQUE constraints deliberately
+    are NOT: they stay eligible because Rule 7 and Rule 7.5 exist to replace
+    a unique constraint with an equivalent nonclustered index, and they need
+    the row to do it. A primary key has no such replacement path - nothing
+    should ever drop one - so it is excluded here instead.
+
+    Excluding a PK does not cost it its compression recommendation. The
+    insert that backfills #index_analysis for compression already selects
+    WHERE fo.index_id = 1 OR id.is_primary_key = 1, and already renders the
+    definition as ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY
+    NONCLUSTERED. That code was unreachable until this CASE was fixed.
+
+    Keep prose out of the string literal below. Everything up to the first
+    CONVERT(nvarchar(max), ...) concatenates as nvarchar(4000), so padding
+    it silently truncates the batch mid-statement instead of failing loudly.
     */
     SELECT
         @sql = N'
@@ -2575,14 +2604,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         us.last_user_update,
         is_eligible_for_dedupe =
             CASE
-                WHEN i.type = 2
-                THEN 1
                 WHEN
                 (
                      i.type = 1
                   OR i.is_primary_key = 1
                 )
                 THEN 0
+                WHEN i.type = 2
+                THEN 1
             END
     FROM ' + QUOTENAME(@current_database_name) + N'.sys.indexes AS i
     JOIN ' + QUOTENAME(@current_database_name) + N'.sys.objects AS o
@@ -4483,6 +4512,42 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         WHERE id_uc.index_hash = ia_dup.index_hash
         AND   id_uc.is_unique_constraint = 1
     )
+    /*
+    Both sides must still be present in #index_details and eligible, exactly as
+    Rules 2, 3, 5 and 7 require. This is not redundant bookkeeping.
+
+    Under @get_all_databases, #index_details is truncated for each database
+    (see the reset list above) while #index_analysis accumulates across all of
+    them for the final output. Every rule then re-runs over rows belonging to
+    databases already processed. The sibling rules fall out harmlessly because
+    their EXISTS against #index_details finds nothing for those stale rows.
+    This rule had only a NOT EXISTS, which passes VACUOUSLY once the table is
+    empty - so it paired a previous database's leftover MAKE UNIQUE winner with
+    that database's backfilled primary key and marked the PK DISABLE. The
+    script-generation backstops read #index_details too, so they passed
+    vacuously in turn and an ALTER INDEX [pk...] DISABLE shipped: it executes
+    cleanly, silently disables every inbound foreign key, and orphan rows insert
+    afterward with no error.
+
+    An EXISTS is the correct shape here precisely because it fails closed on a
+    stale row, where a NOT EXISTS fails open.
+    */
+    AND EXISTS
+    (
+        SELECT
+            1/0
+        FROM #index_details AS id_dup
+        WHERE id_dup.index_hash = ia_dup.index_hash
+        AND   id_dup.is_eligible_for_dedupe = 1
+    )
+    AND EXISTS
+    (
+        SELECT
+            1/0
+        FROM #index_details AS id_win
+        WHERE id_win.index_hash = ia_winner.index_hash
+        AND   id_win.is_eligible_for_dedupe = 1
+    )
     OPTION(RECOMPILE);
 
     /* Merge includes from the disabled Key Duplicates into the MAKE UNIQUE index */
@@ -5500,6 +5565,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     (DROP_EXISTING = ON) can never succeed against a constraint-backed
     index (Msg 1907), so no matter what upstream rules decide, never
     emit a merge script for one.
+
+    "Constraint-backed" means a primary key as well as a unique
+    constraint. is_unique_constraint is 0 for a primary key, so testing
+    it alone left PKs unguarded here.
     */
     AND NOT EXISTS
     (
@@ -5507,7 +5576,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             1/0
         FROM #index_details AS id_uc_guard
         WHERE id_uc_guard.index_hash = ia.index_hash
-        AND   id_uc_guard.is_unique_constraint = 1
+        AND
+        (
+             id_uc_guard.is_unique_constraint = 1
+          OR id_uc_guard.is_primary_key = 1
+        )
     )
     /*
     Second backstop, behind the Rule 7 / 7.5 guards: any script that
@@ -5706,14 +5779,29 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       AND id.is_included_column = 0 /* Get only one row per index */
       AND id.key_ordinal > 0
     WHERE ia.action = N'DISABLE'
-    /* Exclude unique constraints - they are handled by DISABLE CONSTRAINT scripts */
+    /*
+    Exclude unique constraints - they are handled by DISABLE CONSTRAINT scripts.
+
+    Primary keys are excluded here too, but they are NOT rerouted to that
+    path: a unique constraint can legitimately be replaced by a promoted
+    nonclustered index and dropped, a primary key never can. Excluding one
+    here means it gets no script at all, which is the only safe answer.
+    ALTER INDEX ... DISABLE against a primary key does not error - it
+    succeeds, and silently disables every foreign key referencing it, after
+    which orphan rows insert cleanly. A script that succeeds while being
+    wrong is the worst thing this procedure can emit.
+    */
     AND NOT EXISTS
     (
         SELECT
             1/0
         FROM #index_details AS id_uc
         WHERE id_uc.index_hash = ia.index_hash
-        AND   id_uc.is_unique_constraint = 1
+        AND
+        (
+             id_uc.is_unique_constraint = 1
+          OR id_uc.is_primary_key = 1
+        )
     )
     /* Also exclude any index that is also going to be made unique in rule 7.5 */
     AND NOT EXISTS

--- a/sp_IndexCleanup/tests/rule_coverage_test.py
+++ b/sp_IndexCleanup/tests/rule_coverage_test.py
@@ -1,13 +1,30 @@
 """
 sp_IndexCleanup Rule Coverage Tests
 ===================================
-Covers two things nothing else in this directory tests: Rule 1 (unused index
-detection) and the @min_reads / @min_writes index-level screen.
+Covers things nothing else in this directory tests: Rule 1 (unused index
+detection), the @min_reads / @min_writes index-level screen, and four ways the
+procedure can emit a script that is wrong.
+
+The ranking that decides what is worth asserting here: this procedure emits DDL
+that people run against production. A script that ERRORS is nearly harmless --
+it stops, and nobody's data moves. A script that SUCCEEDS while being wrong is
+the real hazard, because there is nothing to notice. Groups C, D, E and F all
+target that class, so they assert on the script text the procedure produces
+rather than on whether some execution raised an error.
+
+Every absence assertion below is paired with a positive control. "No DISABLE
+script named the PK" is trivially true if the PK was never analyzed, so each
+group first proves the index was in play.
 
 Builds its own synthetic fixture in the Crap database -- three ~20,000 row tables,
 scoped with @table_name so each procedure run is fast. It deliberately does not
 touch StackOverflow2013: fixture_cases_test.py already spends two minutes there,
 and this one is meant to be quick. Drops its tables afterward.
+
+Group F additionally builds two throwaway databases, because the defect it
+covers only exists across the database loop and cannot be reproduced inside a
+single database. They are dropped unconditionally afterward, including when an
+assertion fails or the fixture itself does not build.
 
 (a) Rule 1, unused index detection.
 
@@ -43,17 +60,91 @@ and this one is meant to be quick. Drops its tables afterward.
     the object-level filter on its own, which means these cases exercise the
     index-level screen specifically rather than the coarser per-table filter.
 
+(c) Nonclustered PRIMARY KEYs are constraint-backed.
+
+    is_primary_key is not is_unique_constraint: the latter is 0 for a primary
+    key, so a rule that guards only on is_unique_constraint leaves PKs exposed.
+    A nonclustered PK is type = 2, which is also why it used to look like an
+    ordinary unique index to the dedupe rules.
+
+    Two proven consequences, both fixed:
+      - a key duplicate earned the PK a MERGE (CREATE UNIQUE INDEX ...
+        DROP_EXISTING against a constraint -> Msg 1907) while the paired DISABLE
+        of the other index succeeded, silently dropping a covering column.
+      - an exact duplicate with tied priorities put the PK on the losing side of
+        an alphabetical tiebreak and emitted ALTER INDEX [pk...] DISABLE. That
+        one does not error. It succeeds, disables every inbound foreign key, and
+        orphan rows insert cleanly afterward.
+
+    The compression positive controls are the other half: the fix must not work
+    by making primary keys invisible.
+
+(d) Sort direction is part of an index's identity.
+
+    Rule 2 and Rule 3 each carry an explicit is_descending_key comparison.
+    Rule 5 carries none -- the ' DESC' embedded into key_columns is the only
+    thing keeping (col_a, col_b) and (col_a, col_b DESC) from hashing alike.
+    Without it they become a false Key Duplicate whose DISABLE runs cleanly.
+
+(e) A merged index may not INCLUDE its own key column.
+
+    Rule 6 merges a subset's includes into the superset absorbing it. If the
+    subset's include is already a key of the superset, the emitted CREATE INDEX
+    lists the column twice (Msg 1909) while the subset's DISABLE still runs.
+
+(f) #index_details is per-database. #index_analysis is not.
+
+    Under @get_all_databases the procedure TRUNCATES #index_details for each
+    database in the loop, while #index_analysis ACCUMULATES across all of them
+    to build the final output. Every rule therefore re-runs over rows belonging
+    to databases that were already processed.
+
+    Rules 2/3/5/7 survive that because of their shape: each requires
+    EXISTS (#index_details ... is_eligible_for_dedupe = 1), which finds nothing
+    for a stale row and so fails CLOSED. Rule 7.6 carried only a
+    NOT EXISTS (... is_unique_constraint = 1), and a NOT EXISTS against an
+    emptied table passes VACUOUSLY. On the second database's pass it therefore
+    paired the FIRST database's leftover MAKE UNIQUE winner with that database's
+    primary key and marked the PK DISABLE. The script-generation backstops read
+    #index_details too, so they passed vacuously in turn and this shipped:
+
+        ALTER INDEX [pk_mdb] ON [CrapA].[dbo].[mdb_test] DISABLE;
+
+    It executes cleanly, silently disables every inbound foreign key, and orphan
+    rows then insert with no error. A NOT EXISTS fails open on a stale row where
+    an EXISTS fails closed, which is the whole reason the guard has that shape.
+
+    This is the only group that needs more than one database, so it builds two.
+    The defect IS the loop, and a single-database fixture cannot express it.
+
+    The positive controls carry more weight here than anywhere else in this file,
+    because every assertion is an assertion of absence and the bug has four
+    preconditions -- CrapA processed first, CrapA's table analyzed, Rule 7.5
+    actually producing the MAKE UNIQUE winner, and CrapB reached so a second
+    iteration happens. If any one of them silently stopped being true, every
+    assertion below would go green while testing nothing at all.
+
 Usage:
     python rule_coverage_test.py [--server SQL2022] [--password "L!nt0044"]
 """
 
 import os
+import re
 import subprocess
 import sys
 import tempfile
 
 
 TEST_DATABASE = "Crap"
+
+# Group F's two throwaway databases. CrapA is processed FIRST and is the one
+# whose leftover rows go stale during CrapB's pass, so CrapA owns the primary
+# key the bug used to disable. See MDB_SETUP_SQL for why the order is by
+# creation and not by name.
+MDB_DATABASE_FIRST = "CrapA"
+MDB_DATABASE_SECOND = "CrapB"
+MDB_TABLE = "mdb_test"
+MDB_PK = "pk_mdb"
 
 # Rows that represent a dedupe action. A COMPRESSION SCRIPT row is not one.
 DEDUPE_SCRIPT_TYPES = ("DISABLE SCRIPT", "MERGE SCRIPT", "DISABLE CONSTRAINT SCRIPT")
@@ -66,6 +157,10 @@ SET NOCOUNT ON;
 DROP TABLE IF EXISTS dbo.ic_min_reads_test;
 DROP TABLE IF EXISTS dbo.ic_min_writes_test;
 DROP TABLE IF EXISTS dbo.ic_unused_test;
+DROP TABLE IF EXISTS dbo.ic_pk_key_test;
+DROP TABLE IF EXISTS dbo.ic_pk_exact_test;
+DROP TABLE IF EXISTS dbo.ic_sort_dir_test;
+DROP TABLE IF EXISTS dbo.ic_key_include_test;
 GO
 
 /*
@@ -113,6 +208,97 @@ CREATE TABLE
     filler varchar(100) NOT NULL,
     CONSTRAINT pk_ic_unused_test PRIMARY KEY CLUSTERED (id)
 );
+
+/*
+ic_pk_key_test: a NONCLUSTERED primary key with a key duplicate next to it.
+Same keys, different includes, so Rule 5 pairs them. The PK is unique and the
+plain index is not, which makes the PK the "winner" and earns it MERGE
+INCLUDES -> CREATE UNIQUE INDEX ... WITH (DROP_EXISTING = ON) against a
+constraint-backed index. That fails with Msg 1907 while the paired DISABLE of
+ix_pk_key_dupe succeeds, silently dropping col_b coverage.
+
+is_primary_key is NOT is_unique_constraint: it is 0 for a primary key, so every
+rule that guards only on is_unique_constraint leaves a PK exposed.
+*/
+CREATE TABLE
+    dbo.ic_pk_key_test
+(
+    id integer NOT NULL,
+    col_b integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT pk_ic_pk_key_test PRIMARY KEY NONCLUSTERED (id)
+);
+
+/*
+ic_pk_exact_test: a NONCLUSTERED primary key with an exact duplicate.
+
+The names matter. Rule 2 breaks a priority tie alphabetically and disables the
+LATER name, so the PK is deliberately named to sort after the plain index. Both
+indexes are given exactly one seek below so their priorities genuinely tie
+(500 unique + 200 seeks) and the tiebreak is what decides -- without that the
+PK wins on its own and the bug never shows.
+
+ALTER INDEX ... DISABLE against a PK does not error. It succeeds, disables every
+inbound foreign key with it, and orphan rows then insert cleanly. A script that
+succeeds while being wrong is the worst thing this procedure can emit, which is
+why this asserts on the script text rather than on an execution error.
+*/
+CREATE TABLE
+    dbo.ic_pk_exact_test
+(
+    id integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT zz_pk_ic_pk_exact_test PRIMARY KEY NONCLUSTERED (id)
+);
+
+/*
+ic_sort_dir_test: two indexes identical but for the sort direction of the
+second key column, with different includes so they land in Rule 5 rather than
+Rule 2.
+
+Rule 2 and Rule 3 each carry an explicit is_descending_key comparison. Rule 5
+carries NONE: its only defense is that key_columns embeds ' DESC' into the
+string the key_filter_hash is built from. Delete that embedding and these two
+become a false Key Duplicate -- the DESC index gets a cleanly-executing DISABLE
+and the survivor is ASC-only, so every query depending on the DESC ordering
+silently regresses. Nothing errors.
+
+Both indexes are given reads so Rule 1 can never claim either on a
+long-uptime server, which would make the assertions below pass vacuously.
+ix_sort_asc gets seeks AND scans (200 + 100) while ix_sort_desc gets seeks
+only (200), so priorities differ and the loser is deterministic.
+*/
+CREATE TABLE
+    dbo.ic_sort_dir_test
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL,
+    col_d integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT pk_ic_sort_dir_test PRIMARY KEY CLUSTERED (id)
+);
+
+/*
+ic_key_include_test: a key subset whose include is already a key column of the
+superset that absorbs it.
+
+Rule 3 disables ix_ki_subset (col_a) in favor of ix_ki_superset (col_a, col_b),
+and Rule 6 merges the subset's includes into the superset. col_b is already in
+the superset's KEY, and SQL Server rejects an index that includes its own key
+column with Msg 1909. Rule 6's key-column exclusion is the only thing that
+keeps col_b out of the INCLUDE list.
+*/
+CREATE TABLE
+    dbo.ic_key_include_test
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    filler varchar(100) NOT NULL,
+    CONSTRAINT pk_ic_key_include_test PRIMARY KEY CLUSTERED (id)
+);
 GO
 
 INSERT INTO
@@ -169,6 +355,72 @@ SELECT TOP (20000)
 FROM sys.all_columns AS ac1
 CROSS JOIN sys.all_columns AS ac2
 OPTION(MAXDOP 1);
+
+INSERT INTO
+    dbo.ic_pk_key_test
+(
+    id,
+    col_b,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_b = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 100,
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+INSERT INTO
+    dbo.ic_pk_exact_test
+(
+    id,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+INSERT INTO
+    dbo.ic_sort_dir_test
+(
+    id,
+    col_a,
+    col_b,
+    col_c,
+    col_d,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 500,
+    col_b = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 100,
+    col_c = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 250,
+    col_d = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 50,
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+INSERT INTO
+    dbo.ic_key_include_test
+(
+    id,
+    col_a,
+    col_b,
+    filler
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 500,
+    col_b = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) % 100,
+    filler = REPLICATE('x', 100)
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
 GO
 
 CREATE INDEX ix_hot ON dbo.ic_min_reads_test (col_a) INCLUDE (col_b);
@@ -178,6 +430,64 @@ CREATE INDEX ix_w1 ON dbo.ic_min_writes_test (col_a) INCLUDE (col_b);
 CREATE INDEX ix_w2 ON dbo.ic_min_writes_test (col_a) INCLUDE (col_c);
 
 CREATE INDEX ix_never_read ON dbo.ic_unused_test (col_a);
+
+/* Key duplicate of the nonclustered PK: same key, different includes -> Rule 5 */
+CREATE INDEX ix_pk_key_dupe ON dbo.ic_pk_key_test (id) INCLUDE (col_b);
+
+/* Exact duplicate of the nonclustered PK, named to sort BEFORE it */
+CREATE UNIQUE INDEX aa_ix_pk_exact_dupe ON dbo.ic_pk_exact_test (id);
+
+/* Identical but for the direction of col_b, and with different includes */
+CREATE INDEX ix_sort_asc ON dbo.ic_sort_dir_test (col_a, col_b) INCLUDE (col_c);
+CREATE INDEX ix_sort_desc ON dbo.ic_sort_dir_test (col_a, col_b DESC) INCLUDE (col_d);
+
+/* Subset whose include (col_b) is already a key column of the superset */
+CREATE INDEX ix_ki_subset ON dbo.ic_key_include_test (col_a) INCLUDE (col_b);
+CREATE INDEX ix_ki_superset ON dbo.ic_key_include_test (col_a, col_b);
+GO
+
+/*
+Drive reads so no index below is left cold enough for Rule 1 to claim it as
+unused on a long-uptime server, which would make the absence assertions pass
+for the wrong reason.
+
+ix_sort_asc gets seeks AND scans (+200 +100) while ix_sort_desc gets seeks only
+(+200). That gap is what makes ix_sort_desc the deterministic loser if the two
+ever pair up, rather than leaving a priority tie to resolve arbitrarily.
+*/
+DECLARE
+    @c bigint,
+    @i integer = 0;
+
+WHILE @i < 10
+BEGIN
+    /* PK key-duplicate pair: both sides read */
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_pk_key_test AS t WITH (INDEX = pk_ic_pk_key_test) WHERE t.id = @i OPTION(MAXDOP 1);
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_pk_key_test AS t WITH (INDEX = ix_pk_key_dupe) WHERE t.id = @i OPTION(MAXDOP 1);
+
+    /* PK exact-duplicate pair: one seek each, so index_priority ties */
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_pk_exact_test AS t WITH (INDEX = zz_pk_ic_pk_exact_test) WHERE t.id = @i OPTION(MAXDOP 1);
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_pk_exact_test AS t WITH (INDEX = aa_ix_pk_exact_dupe) WHERE t.id = @i OPTION(MAXDOP 1);
+
+    /* Sort-direction pair: seeks on both */
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_sort_dir_test AS t WITH (INDEX = ix_sort_asc) WHERE t.col_a = @i OPTION(MAXDOP 1);
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_sort_dir_test AS t WITH (INDEX = ix_sort_desc) WHERE t.col_a = @i OPTION(MAXDOP 1);
+
+    /* Key-subset/superset pair: reads on both */
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_key_include_test AS t WITH (INDEX = ix_ki_subset) WHERE t.col_a = @i OPTION(MAXDOP 1);
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_key_include_test AS t WITH (INDEX = ix_ki_superset) WHERE t.col_a = @i OPTION(MAXDOP 1);
+
+    SELECT @i += 1;
+END;
+
+/* Scans for ix_sort_asc only, so it outranks ix_sort_desc */
+SELECT @i = 0;
+
+WHILE @i < 3
+BEGIN
+    SELECT @c = COUNT_BIG(*) FROM dbo.ic_sort_dir_test AS t WITH (INDEX = ix_sort_asc) WHERE t.col_c >= 0 OPTION(MAXDOP 1);
+    SELECT @i += 1;
+END;
 GO
 
 /*
@@ -230,7 +540,144 @@ SET NOCOUNT ON;
 DROP TABLE IF EXISTS dbo.ic_min_reads_test;
 DROP TABLE IF EXISTS dbo.ic_min_writes_test;
 DROP TABLE IF EXISTS dbo.ic_unused_test;
+DROP TABLE IF EXISTS dbo.ic_pk_key_test;
+DROP TABLE IF EXISTS dbo.ic_pk_exact_test;
+DROP TABLE IF EXISTS dbo.ic_sort_dir_test;
+DROP TABLE IF EXISTS dbo.ic_key_include_test;
 """
+
+# Group F's fixture. Unlike everything above it, this one needs two databases:
+# the defect only exists across iterations of the @get_all_databases loop.
+#
+# CrapA MUST be created before CrapB. The procedure's database cursor is
+# ORDER BY database_id, NOT by name, so processing order is CREATION order and
+# the names are a convenience rather than the mechanism. CrapA therefore has to
+# be the first database processed, so that its rows are the stale ones still
+# sitting in #index_analysis when CrapB's pass truncates #index_details out from
+# under them. run_tests asserts that this actually held rather than trusting it.
+#
+# CrapA gets PRIMARY KEY NONCLUSTERED (col_a) + UNIQUE (col_a) + ix_mdb (col_a).
+# The unique constraint is what gives Rule 7.5 something to replace, which is
+# what leaves a MAKE UNIQUE winner (ix_mdb) behind in #index_analysis. Without it
+# there is no winner for the stale PK to pair with and the bug cannot fire.
+#
+# CrapB only has to exist, contain the table so the loop does real work for it,
+# and be processed after CrapA. Its own indexes are uninteresting; the second
+# iteration itself is the point.
+#
+# Both databases are pre-dropped so a run that died before its cleanup cannot
+# leave a half-built fixture that quietly changes what is being tested.
+MDB_SETUP_SQL = """
+SET NOCOUNT ON;
+GO
+
+IF DB_ID('%(first)s') IS NOT NULL
+BEGIN
+    ALTER DATABASE %(first)s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE %(first)s;
+END;
+GO
+
+IF DB_ID('%(second)s') IS NOT NULL
+BEGIN
+    ALTER DATABASE %(second)s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE %(second)s;
+END;
+GO
+
+/* Creation order is processing order. This one has to come first. */
+CREATE DATABASE %(first)s;
+GO
+
+CREATE DATABASE %(second)s;
+GO
+
+USE %(first)s;
+GO
+
+/*
+The unique constraint is the load-bearing part: Rule 7.5 replaces it with ix_mdb
+and marks ix_mdb MAKE UNIQUE, and that leftover winner is what the stale primary
+key used to get paired against on the next database's pass.
+*/
+CREATE TABLE
+    dbo.mdb_test
+(
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    CONSTRAINT pk_mdb PRIMARY KEY NONCLUSTERED (col_a),
+    CONSTRAINT uq_mdb UNIQUE (col_a)
+);
+
+INSERT INTO
+    dbo.mdb_test
+(
+    col_a,
+    col_b
+)
+SELECT TOP (20000)
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_b = 1
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+CREATE INDEX ix_mdb ON dbo.mdb_test (col_a);
+GO
+
+USE %(second)s;
+GO
+
+/*
+Deliberately plain. All this database has to do is exist and be processed after
+CrapA, so that a second loop iteration happens at all.
+*/
+CREATE TABLE
+    dbo.mdb_test
+(
+    col_a integer NOT NULL,
+    col_b integer NOT NULL
+);
+
+INSERT INTO
+    dbo.mdb_test
+(
+    col_a,
+    col_b
+)
+SELECT TOP (20000)
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_b = 1
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+CREATE INDEX ix_mdb_b ON dbo.mdb_test (col_a);
+GO
+""" % {"first": MDB_DATABASE_FIRST, "second": MDB_DATABASE_SECOND}
+
+# Runs unconditionally, including when the fixture failed to build or an
+# assertion failed. Leaving stray databases on the instance is not acceptable,
+# so this takes them SINGLE_USER first rather than letting a stray session block
+# the drop and leak the database.
+MDB_CLEANUP_SQL = """
+SET NOCOUNT ON;
+GO
+
+IF DB_ID('%(first)s') IS NOT NULL
+BEGIN
+    ALTER DATABASE %(first)s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE %(first)s;
+END;
+GO
+
+IF DB_ID('%(second)s') IS NOT NULL
+BEGIN
+    ALTER DATABASE %(second)s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE %(second)s;
+END;
+GO
+""" % {"first": MDB_DATABASE_FIRST, "second": MDB_DATABASE_SECOND}
 
 
 def run_sqlcmd(server, password, input_file=None, query=None,
@@ -251,17 +698,31 @@ def run_sqlcmd(server, password, input_file=None, query=None,
     return result.stdout, result.stderr
 
 
-def run_sql_script(server, password, sql, timeout=600):
+def run_sql_script(server, password, sql, database=TEST_DATABASE, timeout=600):
     """Run a multi-batch script (one containing GO) through a temp file."""
     path = None
     try:
         handle, path = tempfile.mkstemp(suffix=".sql", prefix="ic_rule_cov_")
         with os.fdopen(handle, "w") as f:
             f.write(sql)
-        return run_sqlcmd(server, password, input_file=path, timeout=timeout)
+        return run_sqlcmd(server, password, input_file=path,
+                          database=database, timeout=timeout)
     finally:
         if path and os.path.exists(path):
             os.remove(path)
+
+
+def sql_errors(stdout, stderr):
+    """
+    Every SQL error worth failing a fixture over, from both streams.
+
+    go-sqlcmd reports SQL errors on stdout, and severities 17-19 matter as much
+    as 16 -- an earlier version of this looked for the literal "Level 16" on
+    stderr only, which is how adversarial_test.sql managed to fail on every run
+    for months while the suite stayed green.
+    """
+    return (re.findall(r"Msg \d+, Level 1[6-9][^\n]*", stdout or "") +
+            re.findall(r"Msg \d+, Level 1[6-9][^\n]*", stderr or ""))
 
 
 def parse_output(stdout):
@@ -354,12 +815,49 @@ def get_uptime_days(server, password):
     raise RuntimeError("Could not read server uptime:\n%s" % stdout)
 
 
+def get_database_id(server, password, database_name):
+    """
+    A database's database_id, or None if it does not exist.
+
+    Group F needs this because the procedure's database cursor is
+    ORDER BY database_id: the id, not the name, is what decides which database
+    the loop processes first.
+    """
+    stdout, _ = run_sqlcmd(
+        server, password, database="master",
+        query="SET NOCOUNT ON; SELECT database_id = DB_ID('%s');" % database_name,
+    )
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if line.isdigit():
+            return int(line)
+    return None
+
+
 def run_proc(server, password, table_name, extra="", debug=False):
     """Run sp_IndexCleanup scoped to one table and return (rows, stdout)."""
     query = (
         "EXECUTE master.dbo.sp_IndexCleanup "
         "@database_name = '%s', @schema_name = 'dbo', @table_name = '%s'%s%s;"
         % (TEST_DATABASE, table_name, extra, ", @debug = 1" if debug else "")
+    )
+    stdout, _ = run_sqlcmd(server, password, database="master", query=query)
+    return parse_output(stdout), stdout
+
+
+def run_proc_all_databases(server, password, table_name):
+    """
+    Run sp_IndexCleanup across every database on the instance, scoped to one
+    table, and return (rows, stdout).
+
+    @get_all_databases = 1 is the entire point: it is the only way to make the
+    procedure loop, and the loop is what Group F is testing. @table_name keeps it
+    cheap -- every database without that table is dismissed immediately.
+    """
+    query = (
+        "EXECUTE master.dbo.sp_IndexCleanup "
+        "@get_all_databases = 1, @schema_name = 'dbo', @table_name = '%s';"
+        % table_name
     )
     stdout, _ = run_sqlcmd(server, password, database="master", query=query)
     return parse_output(stdout), stdout
@@ -483,6 +981,236 @@ def run_tests(server, password, uptime_days):
     assert_test("B-MinWrites", "@min_reads = 50 alone: ix_w1 still gets COMPRESSION SCRIPT",
                 len(matches) == 1, "found %d" % len(matches))
 
+    # ---- Group C: nonclustered PRIMARY KEYs are constraint-backed ----
+    #
+    # A PK cannot be rebuilt via DROP_EXISTING with different includes (Msg 1907)
+    # and must never be disabled (it succeeds, and takes every inbound foreign key
+    # down with it). is_primary_key is not is_unique_constraint -- the latter is 0
+    # for a primary key -- so a PK needs its own protection everywhere a unique
+    # constraint gets it.
+
+    # C1: PK with a key duplicate. Nothing may target the PK for a rebuild.
+    rows, _ = run_proc(server, password, "ic_pk_key_test")
+
+    pk = "pk_ic_pk_key_test"
+
+    merge_rows = find_rows(rows, index_name=pk, script_type="MERGE SCRIPT")
+    assert_test("C-PrimaryKey", "PK with a key duplicate gets no MERGE SCRIPT",
+                len(merge_rows) == 0,
+                "found %d (any is CREATE UNIQUE INDEX ... DROP_EXISTING vs a PK -> Msg 1907)"
+                % len(merge_rows))
+
+    # Nothing may name the PK in ANY dedupe action, merge or disable.
+    pk_dedupe = dedupe_rows(rows, pk)
+    assert_test("C-PrimaryKey", "PK with a key duplicate gets no dedupe action at all",
+                len(pk_dedupe) == 0,
+                "found %s" % [r["script_type"] for r in pk_dedupe])
+
+    # No OTHER index may claim the PK as its merge/disable target either: that is
+    # the half that silently drops a covering column when the rebuild fails.
+    targeting = [
+        r for r in rows
+        if r.get("target_index_name") == pk
+        and r.get("script_type") in DEDUPE_SCRIPT_TYPES
+    ]
+    assert_test("C-PrimaryKey", "no script targets the PK as a consolidation winner",
+                len(targeting) == 0,
+                "found %s" % [(r["index_name"], r["script_type"]) for r in targeting])
+
+    # Positive control: proving the PK is protected is only meaningful if the
+    # procedure actually looked at it. Compression is the proof it is still in
+    # play and was not made invisible to fix the bug above.
+    matches = find_rows(rows, index_name=pk, script_type="COMPRESSION SCRIPT")
+    assert_test("C-PrimaryKey", "positive control: PK still gets COMPRESSION SCRIPT",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # C2: PK with an exact duplicate, priorities tied, PK sorting later. This is
+    # the case that used to emit ALTER INDEX [pk...] DISABLE -- a script that
+    # executes cleanly and silently turns off referential integrity.
+    rows, _ = run_proc(server, password, "ic_pk_exact_test")
+
+    pk = "zz_pk_ic_pk_exact_test"
+
+    disable_rows = find_rows(rows, index_name=pk, script_type="DISABLE SCRIPT")
+    assert_test("C-PrimaryKey", "PK with an exact duplicate gets no DISABLE SCRIPT",
+                len(disable_rows) == 0,
+                "found %d (a PK DISABLE succeeds and disables inbound FKs)"
+                % len(disable_rows))
+
+    pk_dedupe = dedupe_rows(rows, pk)
+    assert_test("C-PrimaryKey", "PK with an exact duplicate gets no dedupe action at all",
+                len(pk_dedupe) == 0,
+                "found %s" % [r["script_type"] for r in pk_dedupe])
+
+    matches = find_rows(rows, index_name=pk, script_type="COMPRESSION SCRIPT")
+    assert_test("C-PrimaryKey", "positive control: tied PK still gets COMPRESSION SCRIPT",
+                len(matches) == 1, "found %d" % len(matches))
+
+    # ---- Group D: sort direction is part of an index's identity ----
+    #
+    # Rule 5 has no is_descending_key comparison of its own. The ' DESC' embedded
+    # in key_columns is the entire reason (col_a, col_b) and (col_a, col_b DESC)
+    # do not hash alike, and a false Key Duplicate here disables a real index
+    # with a script that runs without complaint.
+    rows, _ = run_proc(server, password, "ic_sort_dir_test")
+
+    for name in ("ix_sort_asc", "ix_sort_desc"):
+        actions = dedupe_rows(rows, name)
+        assert_test("D-SortDirection",
+                    "%s: ASC/DESC pair is not a duplicate (no dedupe action)" % name,
+                    len(actions) == 0,
+                    "found %s" % [(r["script_type"], r["consolidation_rule"])
+                                  for r in actions])
+
+    # Positive control: both were analyzed, so the absence above is the direction
+    # check holding rather than the indexes never being considered.
+    for name in ("ix_sort_asc", "ix_sort_desc"):
+        matches = find_rows(rows, index_name=name)
+        assert_test("D-SortDirection", "positive control: %s was analyzed" % name,
+                    len(matches) >= 1,
+                    "found %d rows (%s)"
+                    % (len(matches), [m["script_type"] for m in matches]))
+
+    # ---- Group E: a merged index may not INCLUDE its own key column ----
+    #
+    # Rule 6 merges a subset's includes into the superset that absorbs it. When
+    # the subset's include is already a KEY of the superset, keeping it emits
+    # CREATE INDEX (col_a, col_b) INCLUDE (col_b), which SQL Server rejects with
+    # Msg 1909 -- while the paired DISABLE of the subset still runs.
+    rows, _ = run_proc(server, password, "ic_key_include_test")
+
+    merge = find_rows(rows, index_name="ix_ki_superset", script_type="MERGE SCRIPT")
+    assert_test("E-KeyInclude", "positive control: the superset gets a MERGE SCRIPT",
+                len(merge) == 1, "found %d" % len(merge))
+
+    if merge:
+        script = merge[0].get("script") or ""
+        include_part = script.split("INCLUDE", 1)[1] if "INCLUDE" in script else ""
+        assert_test("E-KeyInclude",
+                    "merged superset does not INCLUDE its own key column col_b",
+                    "[col_b]" not in include_part,
+                    "INCLUDE clause was '%s' in: %s"
+                    % (include_part.strip()[:60], script[:110]))
+
+    # And the subset really was disabled in its favor, so the merge above is the
+    # live code path rather than a rule that never fired.
+    subset = find_rows(rows, index_name="ix_ki_subset", script_type="DISABLE SCRIPT")
+    assert_test("E-KeyInclude", "positive control: the key subset is disabled",
+                len(subset) == 1, "found %d" % len(subset))
+
+    # ---- Group F: #index_details is per-database, #index_analysis is not ----
+    #
+    # Under @get_all_databases, #index_details is TRUNCATED for each database in
+    # the loop while #index_analysis ACCUMULATES across all of them for the final
+    # output, so every rule re-runs over rows belonging to databases that were
+    # already processed.
+    #
+    # Rules 2/3/5/7 survive it: each requires EXISTS (#index_details ...
+    # is_eligible_for_dedupe = 1), which finds nothing for a stale row and fails
+    # CLOSED. Rule 7.6 had only NOT EXISTS (... is_unique_constraint = 1), which
+    # passes VACUOUSLY once the table is empty -- so on CrapB's pass it paired
+    # CrapA's leftover MAKE UNIQUE winner with CrapA's primary key and marked the
+    # PK DISABLE. The script-generation backstops read #index_details too, so
+    # they passed vacuously in turn and the script shipped:
+    #
+    #     ALTER INDEX [pk_mdb] ON [CrapA].[dbo].[mdb_test] DISABLE;
+    #
+    # which runs cleanly and silently disables every inbound foreign key.
+    rows, _ = run_proc_all_databases(server, password, MDB_TABLE)
+
+    # Positive controls FIRST, because every assertion in this group is an
+    # assertion of absence and each control below is a precondition the bug needs
+    # in order to fire at all. If any of them stops holding, "no DISABLE named the
+    # PK" becomes true for a reason that has nothing to do with the guard, and
+    # this group would pass while testing nothing.
+
+    # F-PC1: CrapA has to be processed BEFORE CrapB or there is no stale-row pass.
+    # The cursor is ORDER BY database_id, not by name, so this is creation order.
+    # Asserted rather than assumed: the names sorting the "right" way is a
+    # coincidence, not the mechanism, and nothing would announce it if it flipped.
+    id_first = get_database_id(server, password, MDB_DATABASE_FIRST)
+    id_second = get_database_id(server, password, MDB_DATABASE_SECOND)
+    assert_test("F-MultiDatabase",
+                "positive control: %s is processed before %s"
+                % (MDB_DATABASE_FIRST, MDB_DATABASE_SECOND),
+                id_first is not None
+                and id_second is not None
+                and id_first < id_second,
+                "database_id %s=%s %s=%s (cursor is ORDER BY database_id)"
+                % (MDB_DATABASE_FIRST, id_first, MDB_DATABASE_SECOND, id_second))
+
+    # F-PC2: CrapA's table was really analyzed and its PK is visible to the
+    # procedure. This is the control that stops "no DISABLE named the PK" from
+    # passing because the fixture never built or the database was never reached.
+    # It is also the half that keeps the fix honest: protecting the PK must not
+    # be implemented by making primary keys invisible.
+    pk_compression = find_rows(rows, database_name=MDB_DATABASE_FIRST,
+                               index_name=MDB_PK, script_type="COMPRESSION SCRIPT")
+    assert_test("F-MultiDatabase",
+                "positive control: %s.%s gets a COMPRESSION SCRIPT"
+                % (MDB_DATABASE_FIRST, MDB_PK),
+                len(pk_compression) == 1, "found %d" % len(pk_compression))
+
+    # F-PC3: Rule 7.5 fired and left a MAKE UNIQUE winner behind. This is the
+    # precondition that matters most. The bug pairs a stale PK against exactly
+    # this winner, so if the unique constraint stopped being replaced there would
+    # be nothing to pair with and the absence assertions below would be vacuous.
+    winner = find_rows(rows, database_name=MDB_DATABASE_FIRST, index_name="ix_mdb",
+                       script_type="MERGE SCRIPT",
+                       consolidation_rule__like="Unique Constraint Replacement")
+    assert_test("F-MultiDatabase",
+                "positive control: ix_mdb is the MAKE UNIQUE winner (Rule 7.5 fired)",
+                len(winner) == 1,
+                "found %d -- without this winner the bug has nothing to pair a "
+                "stale PK against" % len(winner))
+
+    # F-PC4: CrapB was actually reached, so the loop genuinely took a second
+    # iteration. One database processed means #index_details is never truncated
+    # out from under anything and the whole scenario evaporates.
+    second_db = find_rows(rows, database_name=MDB_DATABASE_SECOND)
+    assert_test("F-MultiDatabase",
+                "positive control: %s was reached (a second loop iteration happened)"
+                % MDB_DATABASE_SECOND,
+                len(second_db) >= 1,
+                "found %d rows for %s (%s)"
+                % (len(second_db), MDB_DATABASE_SECOND,
+                   [r["index_name"] for r in second_db]))
+
+    # The assertions. Not scoped to a database: a primary key must not be
+    # disabled in ANY of them, and the bug's victim is whichever database the
+    # loop happened to process first.
+    disable_rows = find_rows(rows, index_name=MDB_PK, script_type="DISABLE SCRIPT")
+    assert_test("F-MultiDatabase",
+                "no DISABLE SCRIPT names the primary key, in any database",
+                len(disable_rows) == 0,
+                "found %d (a PK DISABLE succeeds and disables inbound FKs) %s"
+                % (len(disable_rows),
+                   [(r["database_name"], r["consolidation_rule"]) for r in disable_rows]))
+
+    # Broader than the DISABLE above: no dedupe action of any kind may name the
+    # PK. A MERGE against a constraint-backed index is Msg 1907, and a DISABLE
+    # CONSTRAINT would drop the key outright.
+    pk_dedupe = dedupe_rows(rows, MDB_PK)
+    assert_test("F-MultiDatabase",
+                "no dedupe action of any kind targets the primary key",
+                len(pk_dedupe) == 0,
+                "found %s"
+                % [(r["database_name"], r["script_type"], r["consolidation_rule"])
+                   for r in pk_dedupe])
+
+    # And nothing may claim the PK as its consolidation winner either -- the
+    # other direction of the same pairing.
+    targeting = [
+        r for r in rows
+        if r.get("target_index_name") == MDB_PK
+        and r.get("script_type") in DEDUPE_SCRIPT_TYPES
+    ]
+    assert_test("F-MultiDatabase",
+                "no script targets the primary key as a consolidation winner",
+                len(targeting) == 0,
+                "found %s" % [(r["database_name"], r["index_name"], r["script_type"])
+                              for r in targeting])
+
     return results
 
 
@@ -520,18 +1248,44 @@ def main():
     print("Building synthetic fixture in %s..." % TEST_DATABASE)
     stdout, stderr = run_sql_script(server, password, SETUP_SQL)
 
-    if "Msg " in stdout or ("Msg " in stderr and "Level 16" in stderr):
+    # Same check the other harnesses use.
+    errors = sql_errors(stdout, stderr)
+
+    if errors:
         print("ERROR: SQL errors during fixture setup:")
-        print(stdout[-2000:])
-        print(stderr[:500] if stderr else "(empty stderr)")
+        for e in errors:
+            print("  " + e)
+        print()
+        print("The fixture did not build, so the assertions below would be")
+        print("testing something other than what they claim.")
         sys.exit(1)
 
+    print("Building multi-database fixture (%s, %s) for Group F..."
+          % (MDB_DATABASE_FIRST, MDB_DATABASE_SECOND))
     print()
 
+    # Everything from here down is inside the try. The databases must come off
+    # this instance whatever happens next -- a failed assertion, a failed fixture
+    # build, or an exception nobody predicted. sys.exit raises SystemExit, so the
+    # error path below unwinds through the same finally as a passing run does.
     try:
+        stdout, stderr = run_sql_script(server, password, MDB_SETUP_SQL,
+                                        database="master")
+        errors = sql_errors(stdout, stderr)
+
+        if errors:
+            print("ERROR: SQL errors during multi-database fixture setup:")
+            for e in errors:
+                print("  " + e)
+            print()
+            print("Group F's fixture did not build, so its assertions of absence")
+            print("would pass for the wrong reason.")
+            sys.exit(1)
+
         results = run_tests(server, password, uptime_days)
     finally:
         run_sql_script(server, password, CLEANUP_SQL)
+        run_sql_script(server, password, MDB_CLEANUP_SQL, database="master")
 
     # Report
     passed = sum(1 for r in results if r["passed"])


### PR DESCRIPTION
## The bug

Nonclustered primary keys were unprotected:

```sql
is_eligible_for_dedupe =
    CASE WHEN i.type = 2 THEN 1
         WHEN (i.type = 1 OR i.is_primary_key = 1) THEN 0 END
```

A nonclustered PK is **type 2**, so it matched the first branch and entered dedupe as an ordinary unique index. The `is_primary_key` branch was unreachable for exactly the indexes it was written for. Proven live:

- Rule 5 emitted `CREATE UNIQUE INDEX [pk...] ... WITH (DROP_EXISTING = ON)` against the PK → **Msg 1907**, while the paired `DISABLE` of the duplicate succeeded. Silent include loss.
- A PK could receive `ALTER INDEX [pk...] DISABLE`. **That one does not error** — it succeeds, silently disables every inbound FOREIGN KEY, and orphan rows then insert with no complaint. Referential integrity off, nothing reported. Success *is* the failure mode.

## The fix

Reordering the CASE fixes both at the source. A unique **constraint** stays eligible on purpose — Rules 7/7.5 exist to replace one with an equivalent nonclustered index and need the row — but nothing should ever drop a **primary key**, so it's excluded instead.

Excluding it costs nothing: the compression backfill already selected `WHERE fo.index_id = 1 OR id.is_primary_key = 1` and already rendered `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY NONCLUSTERED`. That code was unreachable until now — which is also why the old build silently **lost** a PK's compression recommendation whenever a dedupe rule consumed its row.

### Rule 7.6's vacuous guard (found reviewing the above)

Under `@get_all_databases`, `#index_details` is truncated per database while `#index_analysis` accumulates for final output, so every rule re-runs over already-processed databases. Rules 2/3/5/7 fall out harmlessly — their `EXISTS` finds nothing for stale rows. **Rule 7.6 had only a `NOT EXISTS`, which passes vacuously against an empty table**, so it paired a prior database's leftover MAKE UNIQUE winner with that database's backfilled PK and marked it DISABLE. Both script-generation backstops read `#index_details` too, so they passed vacuously in turn:

```
PK fix WITHOUT the guard:  DISABLE SCRIPT  pk_mdb  ALTER INDEX [pk_mdb] ... DISABLE;
PK fix WITH the guard:     COMPRESSION SCRIPT  pk_mdb  (only)
```

An `EXISTS` fails **closed** on a stale row where a `NOT EXISTS` fails **open**.

## Known trade-off (accepted)

A plain index that exactly duplicates a nonclustered PK is no longer recommended for removal. That's a **lost** recommendation, never a wrong one, and it's the same trade already documented for unique constraints. A PK can't absorb includes via `DROP_EXISTING`, so recovering it needs a design decision rather than a patch.

## Tests: `rule_coverage_test.py` 11 → 32

- **Group C** — PK with a key duplicate, and with an exact duplicate. Asserts no merge targets it, no DISABLE names it, nothing claims it as a winner — with **positive controls proving the PK still gets its COMPRESSION SCRIPT**, so the fix can't pass by making PKs invisible. **18/7 red** against the pre-fix build.
- **Groups D and E** — kill two mutants that previously survived all 74 assertions: removing the `' DESC'` embedding from `key_columns` (a false Key Duplicate whose DISABLE executes cleanly — Rule 5 has no direction check, that string is its only defence), and removing Rule 6's key-column exclusion (Msg 1909).
- **Group F** — builds two databases and runs `@get_all_databases = 1`. Its positive controls assert CrapA was processed first and Rule 7.5 actually fired, because the loop orders by `database_id` (creation order, **not** name) — if that ever flipped, the group would go green while testing nothing. **30/2 red** without the Rule 7.6 guard.

Every new assertion was watched failing against the defect it covers before being kept.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] `rule_coverage_test.py` 32/32 · `run_tests.py` 32/32 · `fixture_cases_test.py` 31/31 · `no_access_test.py` 4/4
- [x] Every new assertion proven to fail against its defect and pass against the fix
- [x] Fixtures self-clean including both databases, on pass and on failure; verified zero strays
- [x] No version/date bumps; `Install-All/DarlingData.sql` untouched

## Note for reviewers

`Group F` drops and recreates `CrapA`/`CrapB` unconditionally — consistent with the existing `Crap` scratch-database convention, but a bigger hammer than the other groups' `DROP TABLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)