### PR TITLE
sp_IndexCleanup: scope per-database work to @current_database_id

### DIFF
--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -1610,6 +1610,32 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         RAISERROR('Generating #filtered_object insert', 0, 0) WITH NOWAIT;
     END;
 
+    /*
+    One pass per database. Read this before touching anything inside the loop.
+
+    #index_analysis is NOT truncated between iterations - it accumulates every
+    database's rows because the final result set is built from it after the
+    cursor finishes. Every OTHER working temp table (#index_details,
+    #partition_stats, #compression_eligibility, #merged_includes and the rest,
+    reset just below) holds only the CURRENT database.
+
+    So any statement in this loop that reads or writes #index_analysis must
+    filter to ia.database_id = @current_database_id. Without it the statement
+    also processes rows for databases already handled, whose context tables have
+    since been truncated - and that produced silent, executable, WRONG DDL:
+    merge scripts stripped of their INCLUDE lists (the recompute read an empty
+    #index_details and returned NULL) and ALTER INDEX ... DISABLE against unique
+    constraints (a NOT EXISTS guard passed vacuously against the empty table).
+    Both ship a script that runs cleanly and quietly destroys index coverage or
+    referential integrity.
+
+    The scope is free in single-database runs and semantically free in general:
+    scope_hash already encodes database plus object and every rule joins on it,
+    so no rule can legitimately pair rows across databases anyway. For joins
+    between two #index_analysis aliases, scoping the driven side is enough - the
+    join carries the partner along. Statements that intentionally roll up across
+    ALL databases live AFTER the loop and are not scoped.
+    */
     WHILE @@FETCH_STATUS = 0
     BEGIN
         /*Truncate temp tables between database iterations*/
@@ -3425,6 +3451,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 THEN 50  /* Indexes with includes get priority over those without */
                 ELSE 0
             END /* Prefer indexes with included columns */
+    WHERE #index_analysis.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -3464,6 +3491,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             AND   id.is_eligible_for_dedupe = 1 /* Only eligible indexes */
         )
         AND #index_analysis.index_id <> 1 /* Don't disable clustered indexes */
+        AND #index_analysis.database_id = @current_database_id
         OPTION(RECOMPILE);
     END;
 
@@ -3532,6 +3560,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 )
             )
         )
+        AND   ia.database_id = @current_database_id
         OPTION(RECOMPILE);
 
         SET @rc = ROWCOUNT_BIG();
@@ -3620,6 +3649,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
            AND id1.is_descending_key <> id2.is_descending_key
            /* Different sort direction */
     )
+    AND   ia1.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -3750,6 +3780,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   id2.index_hash = ia2.index_hash  /* Specific index from ia2 */
         AND   id1.is_descending_key <> id2.is_descending_key  /* Different sort direction */
     )
+    AND   ia1.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     DECLARE @rule3_rowcount bigint = ROWCOUNT_BIG();
@@ -3785,7 +3816,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   ia2.consolidation_rule = N'Key Subset'
         AND   ia2.action = N'DISABLE'
         AND   ia2.target_index_name IS NOT NULL
-        AND   ia1.target_index_name <> ia2.target_index_name;
+        AND   ia1.target_index_name <> ia2.target_index_name
+        AND   ia1.database_id = @current_database_id;
 
         SET @chains_resolved = ROWCOUNT_BIG();
     END;
@@ -3824,6 +3856,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     WHERE ia1.consolidation_rule = N'Key Subset'
     AND   ia1.action = N'DISABLE'
     AND   ia2.consolidation_rule IS NULL  /* Not already processed */
+    AND   ia2.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -3923,6 +3956,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         WHERE id2.index_hash = ia2.index_hash
         AND   id2.is_eligible_for_dedupe = 1
     )
+    AND   ia1.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     DECLARE @rule5_rowcount bigint = ROWCOUNT_BIG();
@@ -4041,6 +4075,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     FROM #index_analysis AS superset
     WHERE superset.action = N'MERGE INCLUDES'
     AND   superset.consolidation_rule = N'Key Superset'
+    AND   superset.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Apply the pre-computed merged includes */
@@ -4052,6 +4087,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     JOIN #merged_includes AS mi
       ON  mi.scope_hash = ia.scope_hash
       AND mi.index_name = ia.index_name
+    WHERE ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4106,6 +4142,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   ia1_check.consolidation_rule = N'Key Subset'
         AND   ia1_check.action = N'DISABLE'
     )
+    AND   ia2.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4215,6 +4252,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             AND   id2_inner.is_included_column = 0
         )
     )
+    AND   ia1.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4284,6 +4322,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         WHERE id_nc.index_hash = ia_nc.index_hash
         AND   id_nc.is_unique_constraint = 1
     )
+    AND   ia_uc.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Second, mark nonclustered indexes to be made unique */
@@ -4326,6 +4365,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         /* Check that both indexes have EXACTLY the same key columns */
         AND   ia_uc.key_columns = ia_nc.key_columns
     )
+    AND   ia_nc.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* CRITICAL: Ensure that only the unique constraints that exactly match get this treatment */
@@ -4349,6 +4389,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   ia_uc.action = N'DISABLE'
         AND   ia_uc.target_index_name = ia.index_name
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Make sure the nonclustered index has the superseded_by field set correctly */
@@ -4369,6 +4410,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       AND ia_uc.action = N'DISABLE'
       AND ia_uc.target_index_name = ia_nc.index_name
     WHERE ia_nc.action = N'MAKE UNIQUE'
+    AND   ia_nc.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4474,6 +4516,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   id_fk.is_foreign_key_reference = 1
         AND   id_fk.is_included_column = 0
     )
+    AND   ia_loser.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4513,24 +4556,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   id_uc.is_unique_constraint = 1
     )
     /*
-    Both sides must still be present in #index_details and eligible, exactly as
-    Rules 2, 3, 5 and 7 require. This is not redundant bookkeeping.
-
-    Under @get_all_databases, #index_details is truncated for each database
-    (see the reset list above) while #index_analysis accumulates across all of
-    them for the final output. Every rule then re-runs over rows belonging to
-    databases already processed. The sibling rules fall out harmlessly because
-    their EXISTS against #index_details finds nothing for those stale rows.
-    This rule had only a NOT EXISTS, which passes VACUOUSLY once the table is
-    empty - so it paired a previous database's leftover MAKE UNIQUE winner with
-    that database's backfilled primary key and marked the PK DISABLE. The
-    script-generation backstops read #index_details too, so they passed
-    vacuously in turn and an ALTER INDEX [pk...] DISABLE shipped: it executes
-    cleanly, silently disables every inbound foreign key, and orphan rows insert
-    afterward with no error.
-
-    An EXISTS is the correct shape here precisely because it fails closed on a
-    stale row, where a NOT EXISTS fails open.
+    Both sides must be present in #index_details and eligible for dedupe, the
+    same check Rules 2, 3, 5 and 7 make: a row still in #index_analysis whose
+    index is a primary key or is otherwise ineligible must not be picked up here.
+    Cross-database staleness is handled by the @current_database_id scope below,
+    not by this predicate.
     */
     AND EXISTS
     (
@@ -4548,6 +4578,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         WHERE id_win.index_hash = ia_winner.index_hash
         AND   id_win.is_eligible_for_dedupe = 1
     )
+    /*
+    Only rows for the database being processed. #index_analysis accumulates
+    across the whole cursor for the final output, so without this every rule
+    re-runs over already-processed databases whose per-database context tables
+    (#index_details and the rest) have since been truncated - which produced
+    silent, wrong DDL. See the note at the top of the cursor loop.
+    */
+    AND   ia_dup.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Merge includes from the disabled Key Duplicates into the MAKE UNIQUE index */
@@ -4696,6 +4734,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   ia_loser.consolidation_rule = N'Key Duplicate'
         AND   ia_loser.target_index_name = ia_winner.index_name
     )
+    AND   ia_winner.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4774,6 +4813,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             WHERE id1.index_hash = ia1.index_hash
             AND   id2.index_hash = ia2.index_hash
         )
+    AND   ia1.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -4977,6 +5017,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     FROM #index_analysis AS ia
     WHERE ia.action = N'MERGE INCLUDES'
       AND ia.consolidation_rule = N'Key Duplicate'
+      AND ia.database_id = @current_database_id
     GROUP BY
         ia.database_id,
         ia.object_id,
@@ -5007,6 +5048,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     WHERE ia.index_name <> kdd.winning_index_name
     AND   ia.action = N'MERGE INCLUDES'
     AND   ia.consolidation_rule = N'Key Duplicate'
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Update the winning index's superseded_by to list all other indexes */
@@ -5025,6 +5067,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       ON  ia.scope_hash = kdd.scope_hash
       AND ia.key_filter_hash = kdd.key_filter_hash
     WHERE ia.index_name = kdd.winning_index_name
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Merge all included columns from Key Duplicate indexes into the winning index */
@@ -5102,6 +5145,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         WHERE kdd.scope_hash = ia.scope_hash
         AND   kdd.winning_index_name = ia.index_name
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Insert Key Duplicate winners into #merged_includes so they get MERGE scripts */
@@ -5144,6 +5188,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   loser.included_columns IS NOT NULL
         AND   ISNULL(loser.included_columns, N'') <> ISNULL(ia.included_columns, N'')
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /*
@@ -5256,6 +5301,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             AND   loser_check.consolidation_rule = N'Key Duplicate'
             AND   loser_check.included_columns IS NOT NULL
         )
+        AND   ia.database_id = @current_database_id
     ) AS kd
     WHERE ISNULL(kd.merged_includes, N'') <> ISNULL(kd.original_includes, N'')
     OPTION(RECOMPILE);
@@ -5275,6 +5321,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     WHERE ia.action = N'MERGE INCLUDES'
     AND   ia.consolidation_rule = N'Key Duplicate'
     AND   ISNULL(ia.included_columns, N'') <> ISNULL(mi.merged_includes, N'')
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     IF @debug = 1
@@ -5333,6 +5380,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         OR ia2.included_columns IS NULL
         OR LEN(ia1.included_columns) < LEN(ia2.included_columns)
       )
+    WHERE ia1.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Update the subset indexes to be disabled, since supersets already contain their columns */
@@ -5351,6 +5399,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     JOIN #include_subset_dedupe AS isd
       ON  ia.scope_hash = isd.scope_hash
       AND ia.index_name = isd.subset_index_name
+    WHERE ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Update the superset indexes to indicate they supersede the subset indexes */
@@ -5370,6 +5419,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     JOIN #include_subset_dedupe AS isd
       ON  ia.scope_hash = isd.scope_hash
       AND ia.index_name = isd.superset_index_name
+    WHERE ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Update winning indexes that don't actually need changes to have action = N'KEEP' */
@@ -5390,6 +5440,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         WHERE mi.scope_hash = ia.scope_hash
         AND   mi.index_name = ia.index_name
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Insert merge scripts for indexes */
@@ -5603,6 +5654,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                AND   CHARINDEX(ps_uq_guard.partition_columns, ia.key_columns) = 0
            )
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Debug which indexes are getting MERGE scripts */
@@ -5813,6 +5865,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AND   ia_unique.index_name = ia.index_name
         AND   ia_unique.action = N'MAKE UNIQUE'
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Add clustered indexes to #index_analysis specifically for compression purposes */
@@ -6073,6 +6126,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       OR id.is_primary_key = 1
     )
     AND   ce.can_compress = 1 /* Only those eligible for compression */
+    AND   fo.database_id = @current_database_id
     /* Only add if not already in #index_analysis */
     AND   NOT EXISTS
     (
@@ -6091,7 +6145,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     SET
         #index_analysis.action = N'KEEP'
     WHERE #index_analysis.index_id = 1 /* Clustered indexes */
-    AND   #index_analysis.action IS NULL;
+    AND   #index_analysis.action IS NULL
+    AND   #index_analysis.database_id = @current_database_id;
 
     /* Update index priority for clustered indexes to ensure they're not chosen for deduplication */
     UPDATE
@@ -6099,7 +6154,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     SET
         #index_analysis.index_priority = 1000 /* Maximum priority */
     WHERE #index_analysis.index_id = 1 /* Clustered indexes */
-    AND   #index_analysis.index_priority IS NULL;
+    AND   #index_analysis.index_priority IS NULL
+    AND   #index_analysis.database_id = @current_database_id;
 
     IF @debug = 1
     BEGIN
@@ -6232,6 +6288,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         (ia.action IS NULL OR ia.action = N'KEEP')
         /* Only indexes eligible for compression */
     AND  ce.can_compress = 1
+    AND  ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Insert disable scripts for unique constraints */
@@ -6307,6 +6364,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         ia_uc.action = N'DISABLE'
         /* That have consolidation_rule of 'Unique Constraint Replacement' */
         AND ia_uc.consolidation_rule = N'Unique Constraint Replacement'
+        AND ia_uc.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Insert per-partition compression scripts */
@@ -6432,6 +6490,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     AND  (ia.action IS NULL OR ia.action = N'KEEP')
         /* Only indexes eligible for compression */
     AND   ce.can_compress = 1
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /* Insert compression ineligible info */
@@ -6495,6 +6554,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       AND id.is_included_column = 0 /* Get only one row per index */
       AND id.key_ordinal > 0
     WHERE ce.can_compress = 0
+    AND   ce.database_id = @current_database_id
     OPTION(RECOMPILE);
 
 
@@ -6558,6 +6618,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       AND id.is_included_column = 0 /* Get only one row per index */
       AND id.key_ordinal > 0
     WHERE ia.action = N'REVIEW'
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
 
@@ -6714,6 +6775,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           AND ia.index_id > 0
         )
     )
+    AND   ia.database_id = @current_database_id
     OPTION(RECOMPILE);
 
     /*

--- a/sp_IndexCleanup/tests/rule_coverage_test.py
+++ b/sp_IndexCleanup/tests/rule_coverage_test.py
@@ -146,6 +146,18 @@ MDB_DATABASE_SECOND = "CrapB"
 MDB_TABLE = "mdb_test"
 MDB_PK = "pk_mdb"
 
+# Group G reuses the very same CrapA/CrapB (CrapA processed first is exactly the
+# property both groups need) but adds two of its own tables. The two defects it
+# covers live in SEPARATE tables analyzed in SEPARATE @table_name scoped runs on
+# purpose: with both in one table the unique-constraint rules reshuffle the merge
+# dedup and the include strip stops being deterministic. See MDB_G_SETUP_SQL.
+MDB_MERGE_TABLE = "icg_merge"        # superset/subset include-merge pair (bug 1)
+MDB_MERGE_WINNER = "ix_merge_super"  # the Key Superset that must keep its INCLUDE
+MDB_MERGE_SUBSET = "ix_merge_sub"    # the subset it absorbs and disables
+MDB_UC_TABLE = "icg_uc"              # unique constraint + same-key index (bug 2)
+MDB_UC_CONSTRAINT = "uq_icg"         # the constraint that must not get ALTER..DISABLE
+MDB_UC_PLAIN = "ix_uc_plain"         # the index promoted to replace it
+
 # Rows that represent a dedupe action. A COMPRESSION SCRIPT row is not one.
 DEDUPE_SCRIPT_TYPES = ("DISABLE SCRIPT", "MERGE SCRIPT", "DISABLE CONSTRAINT SCRIPT")
 
@@ -676,6 +688,161 @@ BEGIN
     ALTER DATABASE %(second)s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
     DROP DATABASE %(second)s;
 END;
+GO
+""" % {"first": MDB_DATABASE_FIRST, "second": MDB_DATABASE_SECOND}
+
+
+# Group G's fixture. Runs AFTER MDB_SETUP_SQL has created CrapA and CrapB, and
+# just adds two tables to each. Kept separate from MDB_SETUP_SQL so Group F's
+# narrative stays about mdb_test alone; the shared teardown (MDB_CLEANUP_SQL drops
+# both databases) already carries these tables away.
+#
+# The bug material goes in CrapA because it is processed first, so its rows are
+# the stale ones still sitting in #index_analysis when CrapB's pass truncates
+# #index_details. CrapB gets plain copies so the loop takes a real second
+# iteration for whichever table each scoped run targets.
+#
+# icg_merge: a Key Superset (col_a, col_b) INCLUDE (col_c) over a subset
+# (col_a) INCLUDE (col_d). Rule 4/6 merges the subset's col_d into the superset,
+# whose correct merged script is INCLUDE (col_c, col_d). On CrapB's pass the
+# include-merge recomputes CrapA's superset from an emptied #index_details, gets
+# NULL, and overwrites it -- the merge-script insert then emits a stripped row
+# with no INCLUDE that can win the final ROW_NUMBER tie.
+#
+# icg_uc: a UNIQUE constraint uq_icg (col_a, id) with a same-key plain index
+# ix_uc_plain. Rule 7.5 promotes the index to replace the constraint and drops
+# the constraint. On CrapB's pass the DISABLE-script insert's
+# NOT EXISTS (#index_details ... is_unique_constraint = 1) guard passes vacuously
+# for stale uq_icg and emits ALTER INDEX [uq_icg] ... DISABLE on top of the
+# correct DROP CONSTRAINT.
+#
+# No modulo (%) anywhere in the DDL: this string is %-formatted for the database
+# names, so a literal % would be read as a format specifier.
+MDB_G_SETUP_SQL = """
+SET NOCOUNT ON;
+GO
+
+USE %(first)s;
+GO
+
+/* Bug 1: superset/subset include-merge pair. */
+CREATE TABLE
+    dbo.icg_merge
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL,
+    col_c integer NOT NULL,
+    col_d integer NOT NULL,
+    CONSTRAINT pk_icg_merge PRIMARY KEY CLUSTERED (id)
+);
+
+INSERT INTO
+    dbo.icg_merge
+(
+    id,
+    col_a,
+    col_b,
+    col_c,
+    col_d
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_b = 1,
+    col_c = 2,
+    col_d = 3
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+CREATE INDEX ix_merge_super ON dbo.icg_merge (col_a, col_b) INCLUDE (col_c);
+CREATE INDEX ix_merge_sub   ON dbo.icg_merge (col_a) INCLUDE (col_d);
+GO
+
+/* Bug 2: unique constraint + same-key plain index. */
+CREATE TABLE
+    dbo.icg_uc
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_c integer NOT NULL,
+    CONSTRAINT pk_icg_uc PRIMARY KEY CLUSTERED (id)
+);
+
+INSERT INTO
+    dbo.icg_uc
+(
+    id,
+    col_a,
+    col_c
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_c = 1
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+ALTER TABLE dbo.icg_uc ADD CONSTRAINT uq_icg UNIQUE (col_a, id);
+CREATE INDEX ix_uc_plain ON dbo.icg_uc (col_a, id) INCLUDE (col_c);
+GO
+
+USE %(second)s;
+GO
+
+/* Plain copies so the second iteration does real work for the scoped table. */
+CREATE TABLE
+    dbo.icg_merge
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_b integer NOT NULL
+);
+
+INSERT INTO
+    dbo.icg_merge
+(
+    id,
+    col_a,
+    col_b
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = 1,
+    col_b = 2
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+CREATE INDEX ix_merge_b ON dbo.icg_merge (col_a);
+GO
+
+CREATE TABLE
+    dbo.icg_uc
+(
+    id integer NOT NULL,
+    col_a integer NOT NULL,
+    col_c integer NOT NULL
+);
+
+INSERT INTO
+    dbo.icg_uc
+(
+    id,
+    col_a,
+    col_c
+)
+SELECT TOP (20000)
+    id = ROW_NUMBER() OVER (ORDER BY (SELECT NULL)),
+    col_a = 1,
+    col_c = 2
+FROM sys.all_columns AS ac1
+CROSS JOIN sys.all_columns AS ac2
+OPTION(MAXDOP 1);
+
+CREATE INDEX ix_uc_b ON dbo.icg_uc (col_a);
 GO
 """ % {"first": MDB_DATABASE_FIRST, "second": MDB_DATABASE_SECOND}
 
@@ -1211,6 +1378,122 @@ def run_tests(server, password, uptime_days):
                 "found %s" % [(r["database_name"], r["index_name"], r["script_type"])
                               for r in targeting])
 
+    # ---- Group G: include-merge scripts and unique-constraint DISABLE survive the loop ----
+    #
+    # Same defect class as Group F -- per-database temp tables are truncated each
+    # iteration while #index_analysis accumulates, so every rule and every
+    # script-generation statement re-runs over rows belonging to databases
+    # already processed. Group F caught the primary-key DISABLE. These are two
+    # other ways it surfaced before the per-database scoping fix, both in CrapA
+    # (processed first, so its rows are the stale ones during CrapB's pass):
+    #
+    #   Bug 1: the include-merge machinery recomputes CrapA's superset winner from
+    #   an emptied #index_details on CrapB's pass, gets NULL, and overwrites its
+    #   merged includes. The merge-script insert then emits a SECOND, stripped row
+    #   (no INCLUDE, no DATA_COMPRESSION, no ON [filegroup]) and the final
+    #   ROW_NUMBER ties it against the good one. Run, the stripped pair rebuilds
+    #   the winner with every covering column gone while its subset is disabled --
+    #   and it executes without error.
+    #
+    #   Bug 2: the DISABLE-script insert excludes unique constraints with
+    #   NOT EXISTS (#index_details ... is_unique_constraint = 1), which passes
+    #   VACUOUSLY for a stale row whose #index_details was truncated. So CrapA's
+    #   uq_icg got ALTER INDEX ... DISABLE in addition to its correct
+    #   DROP CONSTRAINT -- and ALTER INDEX DISABLE on a unique constraint's index
+    #   silently disables every inbound foreign key.
+    #
+    # Every assertion below is an assertion of absence, so each is preceded by
+    # positive controls: the rule fired, the winner was produced, and CrapB was
+    # reached. Without those a green result could just mean the fixture never
+    # built or the rule silently stopped matching.
+
+    # --- Bug 1: the include-merge winner must keep its INCLUDE list ---
+    merge_rows, _ = run_proc_all_databases(server, password, MDB_MERGE_TABLE)
+
+    # G-PC1: the merge winner was produced at all (Rule 4/6 fired for CrapA). If
+    # it were not, "no merge script is missing its INCLUDE" would pass vacuously.
+    merge_winner = find_rows(merge_rows, database_name=MDB_DATABASE_FIRST,
+                             index_name=MDB_MERGE_WINNER, script_type="MERGE SCRIPT")
+    assert_test("G-MultiDatabase",
+                "positive control: %s.%s gets a MERGE SCRIPT (include-merge fired)"
+                % (MDB_DATABASE_FIRST, MDB_MERGE_WINNER),
+                len(merge_winner) == 1, "found %d" % len(merge_winner))
+
+    # G-PC2: its subset really was disabled -- the other half of the pair whose
+    # includes the merge is supposed to absorb. No subset, no merge to strip.
+    merge_subset = find_rows(merge_rows, database_name=MDB_DATABASE_FIRST,
+                             index_name=MDB_MERGE_SUBSET, script_type="DISABLE SCRIPT")
+    assert_test("G-MultiDatabase",
+                "positive control: %s.%s (the subset) is disabled"
+                % (MDB_DATABASE_FIRST, MDB_MERGE_SUBSET),
+                len(merge_subset) == 1, "found %d" % len(merge_subset))
+
+    # G-PC3: CrapB was reached for this table, so the loop took a real second
+    # iteration and #index_details was truncated out from under CrapA's rows.
+    merge_second = find_rows(merge_rows, database_name=MDB_DATABASE_SECOND)
+    assert_test("G-MultiDatabase",
+                "positive control: %s was reached for %s (a second iteration happened)"
+                % (MDB_DATABASE_SECOND, MDB_MERGE_TABLE),
+                len(merge_second) >= 1,
+                "found %d rows for %s" % (len(merge_second), MDB_DATABASE_SECOND))
+
+    # The assertion. The surviving merge script must still carry an INCLUDE. The
+    # stripped row the bug produced has the INCLUDE clause gone entirely, so any
+    # merge row for the winner whose script has no INCLUDE is the defect.
+    merge_stripped = [
+        r for r in merge_winner
+        if "include" not in r.get("script", "").lower()
+    ]
+    assert_test("G-MultiDatabase",
+                "no merge script for %s is missing its INCLUDE list, in any database"
+                % MDB_MERGE_WINNER,
+                len(merge_stripped) == 0,
+                "found %d stripped (winner rebuilt without its covering columns): %s"
+                % (len(merge_stripped), [r.get("script") for r in merge_stripped]))
+
+    # --- Bug 2: a unique constraint must never get ALTER INDEX ... DISABLE ---
+    uc_rows, _ = run_proc_all_databases(server, password, MDB_UC_TABLE)
+
+    # G-PC4: the constraint really was replaced -- it gets its correct
+    # DROP CONSTRAINT. This is what makes the absence assertion meaningful:
+    # uq_icg WAS in play as a droppable constraint, the tool just must not ALSO
+    # ALTER INDEX it.
+    uc_drop = find_rows(uc_rows, database_name=MDB_DATABASE_FIRST,
+                        index_name=MDB_UC_CONSTRAINT,
+                        script_type="DISABLE CONSTRAINT SCRIPT")
+    assert_test("G-MultiDatabase",
+                "positive control: %s.%s gets a DISABLE CONSTRAINT SCRIPT"
+                % (MDB_DATABASE_FIRST, MDB_UC_CONSTRAINT),
+                len(uc_drop) == 1, "found %d" % len(uc_drop))
+
+    # G-PC5: the plain index that replaces it was promoted (Rule 7.5 fired). This
+    # is the winner the stale constraint used to get paired against.
+    uc_winner = find_rows(uc_rows, database_name=MDB_DATABASE_FIRST,
+                          index_name=MDB_UC_PLAIN, script_type="MERGE SCRIPT")
+    assert_test("G-MultiDatabase",
+                "positive control: %s.%s is the MAKE UNIQUE replacement (Rule 7.5 fired)"
+                % (MDB_DATABASE_FIRST, MDB_UC_PLAIN),
+                len(uc_winner) == 1, "found %d" % len(uc_winner))
+
+    # G-PC6: CrapB was reached for this table too.
+    uc_second = find_rows(uc_rows, database_name=MDB_DATABASE_SECOND)
+    assert_test("G-MultiDatabase",
+                "positive control: %s was reached for %s (a second iteration happened)"
+                % (MDB_DATABASE_SECOND, MDB_UC_TABLE),
+                len(uc_second) >= 1,
+                "found %d rows for %s" % (len(uc_second), MDB_DATABASE_SECOND))
+
+    # The assertion. A unique CONSTRAINT must never be named by an
+    # ALTER INDEX ... DISABLE (a DISABLE SCRIPT row), in any database.
+    uc_disable = find_rows(uc_rows, index_name=MDB_UC_CONSTRAINT,
+                           script_type="DISABLE SCRIPT")
+    assert_test("G-MultiDatabase",
+                "no DISABLE SCRIPT names the unique constraint, in any database",
+                len(uc_disable) == 0,
+                "found %d (ALTER INDEX DISABLE on a UC silently disables inbound FKs) %s"
+                % (len(uc_disable),
+                   [(r["database_name"], r["script"]) for r in uc_disable]))
+
     return results
 
 
@@ -1260,7 +1543,7 @@ def main():
         print("testing something other than what they claim.")
         sys.exit(1)
 
-    print("Building multi-database fixture (%s, %s) for Group F..."
+    print("Building multi-database fixture (%s, %s) for Groups F and G..."
           % (MDB_DATABASE_FIRST, MDB_DATABASE_SECOND))
     print()
 
@@ -1279,6 +1562,20 @@ def main():
                 print("  " + e)
             print()
             print("Group F's fixture did not build, so its assertions of absence")
+            print("would pass for the wrong reason.")
+            sys.exit(1)
+
+        # Group G's tables ride on the same CrapA/CrapB the block above created.
+        stdout, stderr = run_sql_script(server, password, MDB_G_SETUP_SQL,
+                                        database="master")
+        errors = sql_errors(stdout, stderr)
+
+        if errors:
+            print("ERROR: SQL errors during Group G fixture setup:")
+            for e in errors:
+                print("  " + e)
+            print()
+            print("Group G's fixture did not build, so its assertions of absence")
             print("would pass for the wrong reason.")
             sys.exit(1)
 


### PR DESCRIPTION
Fixes two `@get_all_databases` blockers, both **succeed-while-wrong** — a generated script that executes cleanly and quietly destroys index coverage or referential integrity. These are the kind that produce production incidents, not wrong reports.

## Root cause (one systemic pattern)

`#index_analysis` accumulates across the database cursor because the final result set is built from it after the loop. Every *other* working temp table — `#index_details`, `#partition_stats`, `#compression_eligibility`, `#merged_includes` — is truncated at the top of each iteration. So on database N+1's pass, every rule and script-generation statement re-ran over database N's leftover rows while the context tables held N+1's data.

**Blocker 1 — INCLUDE lists stripped.** The include-merge recompute read an empty `#index_details` for a stale row → NULL → overwrote `included_columns`. The merge-script insert then emitted a second row with no INCLUDE, no `DATA_COMPRESSION`, no `ON [filegroup]`; the two rows tie on the final `ROW_NUMBER`, so which one a user saw was a coin flip. Executed:

```
dev, single-DB:   INCLUDE ([col_c], [col_d])              (correct)
dev, multi-DB:    *** NO INCLUDE -- coverage stripped ***  (executes clean, coverage gone)
scoped, multi-DB: INCLUDE ([col_c], [col_d])              (fixed)
```

**Blocker 2 — `ALTER INDEX <unique constraint> DISABLE`.** The DISABLE-script insert's constraint exclusion is a `NOT EXISTS` against `#index_details`, which passes vacuously for a stale (truncated) row. It succeeds, disables inbound foreign keys, and orphan rows insert afterward.

```
dev baseline:  ALTER INDEX [uq_v] ... DISABLE;  +  DROP CONSTRAINT [uq_v];   (the DISABLE is the bug)
scoped build:  DROP CONSTRAINT [uq_v];  only
```

Both are the same shape: a statement re-running over stale rows whose context tables are gone, where `NOT EXISTS` guards fail **open** and recomputes return NULL. The earlier Rule 7.6 fix hardened *one* instance; this scopes the cause.

## The fix

Every in-loop statement touching `#index_analysis` now filters to `@current_database_id` — **42 predicates**. Semantically free: `scope_hash` already encodes database + object and every rule joins on it, so no rule can legitimately pair rows across databases. For two-alias joins, scoping the driven side is enough (the join carries the partner). Statements that roll up across all databases run *after* the loop and are not scoped. A note at the top of the cursor loop states the invariant once.

With staleness handled at the source, Rule 7.6's `EXISTS`/`is_eligible_for_dedupe` predicate is no longer the cross-database guard its comment claimed — that comment was opaque *precisely because* the protection was a side effect. The predicate stays (same eligibility check Rules 2/3/5/7 make, keeps PKs and other ineligible rows out); its comment now says only that.

## Tests: `rule_coverage_test.py` 32 → 40

New **Group G** builds two databases and asserts, with **six positive controls**, that no merge script is missing its INCLUDE list and no `ALTER INDEX ... DISABLE` names a unique constraint. Proven **38/2 red** against the pre-scope build (both bug assertions fail, all positive controls pass — so it's the bug, not a broken fixture) and **40/0** with the fix.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] **Single-database output byte-identical** to the prior build across 8 invocations (scoping is a no-op there) — verified independently, 0 positional diffs
- [x] Both blockers proven fixed with independent two-database repros (single-DB control vs multi-DB, before vs after)
- [x] `run_tests.py` 32/32 · `fixture_cases_test.py` 31/31 · `rule_coverage_test.py` 40/40 · `no_access_test.py` 4/4
- [x] Fixtures self-clean including all scratch databases; verified zero strays
- [x] No version/date bumps; `Install-All/DarlingData.sql` untouched

## Not addressed here (from the same audit, separate work)

Four mutations still survive the suite (compression `PAGE`→`NONE`; partition-rider `key_ordinal > 0`; Rule 7.5 filtered-index guards; Rule 6 superset-own-includes), and every per-partition compression script fails with Msg 155. Those are compression/partition coverage gaps, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)