### PR TITLE
Remove dead ROLLBACK boilerplate from three read-only procedures

### DIFF
--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -5300,9 +5300,12 @@ END TRY
 /*Very professional error handling*/
 BEGIN CATCH
     BEGIN
-        IF @@TRANCOUNT > 0
-            ROLLBACK TRANSACTION;
-
+            /*
+            No ROLLBACK. This procedure manages Extended Events sessions via DDL,
+            which autocommits, and opens no transaction of its own - so a ROLLBACK
+            here could only unwind the CALLER's transaction on an internal error.
+            The session cleanup below is the error handling that actually matters.
+            */
             /*Only try to drop a session if we're not outputting*/
             IF (@output_database_name = N''
                   AND @output_schema_name IN (N'', N'dbo'))

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -5191,11 +5191,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         r.check_id;
     END TRY
     BEGIN CATCH
-        IF @@TRANCOUNT > 0
-        BEGIN
-            ROLLBACK;
-        END;
-
+        /*
+        No ROLLBACK. This procedure only reads diagnostics and builds a result
+        set - it opens no transaction of its own, so a ROLLBACK here could only
+        unwind the CALLER's transaction on an internal error, destroying work it
+        had no part in. That is the standard error-handling template misapplied
+        to a read-only procedure.
+        */
         THROW;
     END CATCH;
 END;

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -5129,11 +5129,16 @@ BEGIN CATCH
         RAISERROR('%s', 10, 1, @sql) WITH NOWAIT;
     END;
 
-    IF @@TRANCOUNT > 0
-    BEGIN
-        ROLLBACK;
-    END;
-
+    /*
+    No ROLLBACK here on purpose. This procedure only reads Query Store and builds
+    strings - it opens no transaction of its own (there is no BEGIN TRANSACTION
+    anywhere in it), so a ROLLBACK could only ever unwind the CALLER's
+    transaction. That is the standard error-handling template misapplied to a
+    read-only procedure: on any internal error it would silently destroy work the
+    caller was in the middle of. It also broke INSERT ... EXECUTE against this
+    proc, where the ROLLBACK raised Msg 3915 instead of surfacing the real error.
+    sp_QuickieStore, which this was built from, carries no ROLLBACK either.
+    */
     THROW;
 END CATCH;
 


### PR DESCRIPTION
`sp_QueryReproBuilder`, `sp_PerfCheck`, and `sp_HumanEvents` each carried `IF @@TRANCOUNT > 0 ROLLBACK` in their CATCH block — the standard error-handling template — but **none of them opens a transaction of its own** (zero `BEGIN TRANSACTION` anywhere, dynamic SQL included).

## Why it's wrong

Without a `BEGIN TRANSACTION`, every statement autocommits, so `@@TRANCOUNT > 0` in the CATCH can only ever be the **caller's** transaction. On any internal error these procedures would silently roll back work the caller was in the middle of — having changed nothing themselves.

It also actively **masked errors**: calling `sp_QueryReproBuilder` via `INSERT ... EXECUTE` raised `Msg 3915` ("Cannot use the ROLLBACK statement within an INSERT-EXEC statement") from the boilerplate instead of surfacing the real error (a plain `Msg 213` column-count mismatch, which now comes through cleanly).

## Why it's safe

Five sibling read-only procs already carry no ROLLBACK — **`sp_QuickieStore` (which `sp_QueryReproBuilder` was built from)**, `sp_HealthParser`, `sp_LogHunter`, `sp_PressureDetector`, and `sp_QuickieCache`. This brings the three stragglers into line with the rest of the suite.

Each CATCH keeps its diagnostics and `THROW`; `sp_HumanEvents` keeps its Extended Events session cleanup. A comment in each records why the ROLLBACK must not come back.

## Test plan

- [x] All three compile clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] `sp_PerfCheck` runs a full health check without error
- [x] `sp_QueryReproBuilder` still generates a repro; no longer raises Msg 3915 under `INSERT ... EXECUTE` (real Msg 213 surfaces instead)
- [x] `@help` runs on all three
- [x] Zero `ROLLBACK` statements remain in the three; no version/date bumps; `Install-All/DarlingData.sql` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)