### PR TITLE
sp_QueryReproBuilder: shred each plan's parameters once (many-plan perf)

### DIFF
--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -1183,6 +1183,21 @@ CREATE TABLE
 );
 
 /*
+Landing table for the raw parameter attributes shredded straight out of each
+plan's ParameterList. Reading them once here, then cleaning the values in a
+second pass over these plain-string columns, avoids re-parsing the plan XML
+several times per parameter (see the note at the parameter-extraction step).
+*/
+CREATE TABLE
+    #parameter_shred
+(
+    plan_id bigint NOT NULL,
+    param_column sysname NULL,
+    param_data_type sysname NULL,
+    param_compiled_value nvarchar(max) NULL
+);
+
+/*
 If @query_plan_xml was supplied, seed the repro pipeline with one synthetic
 plan so the parser, warnings, and repro-builder can all run without Query
 Store. Synthetic ids are -1 so they can't collide with real Query Store ids.
@@ -4164,43 +4179,23 @@ SELECT
     @current_table = N'extracting parameters from query plans';
 
 INSERT
-    #query_parameters
+    #parameter_shred
 WITH
     (TABLOCK)
 (
     plan_id,
-    parameter_name,
-    parameter_data_type,
-    parameter_compiled_value
+    param_column,
+    param_data_type,
+    param_compiled_value
 )
 SELECT
     qsp.plan_id,
-    parameter_name =
-        LTRIM(RTRIM(cr.c.value(N'@Column', N'sysname'))),
-    parameter_data_type =
-        LTRIM(RTRIM(cr.c.value(N'@ParameterDataType', N'sysname'))),
-    parameter_compiled_value =
-        CASE
-            /*Strip parentheses from values like (13)*/
-            WHEN cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)') LIKE N'(%)'
-            THEN SUBSTRING
-                 (
-                     cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)'),
-                     2,
-                     LEN(cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)')) - 2
-                 )
-            /*Strip guid wrapper from values like {guid'...'}*/
-            WHEN cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)') LIKE N'{guid''%''}'
-            THEN N'''' +
-                 SUBSTRING
-                 (
-                     cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)'),
-                     7,
-                     LEN(cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)')) - 8
-                 ) +
-                 N''''
-            ELSE cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)')
-        END
+    param_column =
+        cr.c.value(N'@Column', N'sysname'),
+    param_data_type =
+        cr.c.value(N'@ParameterDataType', N'sysname'),
+    param_compiled_value =
+        cr.c.value(N'@ParameterCompiledValue', N'nvarchar(MAX)')
 FROM #query_store_plan AS qsp
 CROSS APPLY
 (
@@ -4229,6 +4224,59 @@ CROSS APPLY
 CROSS APPLY x.parameter_list_xml.nodes(N'//ParameterList/ColumnReference') AS cr(c)
 WHERE CHARINDEX(N'<ParameterList>', qsp.query_plan) > 0
 AND   x.parameter_list_xml IS NOT NULL
+OPTION(RECOMPILE);
+
+/*
+Clean the parameter values in a second pass over the materialized columns.
+
+The earlier version read cr.c.value(N'@ParameterCompiledValue') four times in
+this one statement, plus @Column and @ParameterDataType - nine .value() calls on
+the same node. Against untyped XML the optimizer builds a separate XML Reader
+table-valued function per call, ten of them stacked in nested-loop joins, and
+each one re-parses the plan from scratch. That made this the procedure's single
+largest cost on many-plan workloads (measured 13x slower on 500 plans than the
+shred-once form below). Reading each attribute once into #parameter_shred and
+applying the cleanup here on plain strings produces identical values.
+*/
+INSERT
+    #query_parameters
+WITH
+    (TABLOCK)
+(
+    plan_id,
+    parameter_name,
+    parameter_data_type,
+    parameter_compiled_value
+)
+SELECT
+    ps.plan_id,
+    parameter_name =
+        LTRIM(RTRIM(ps.param_column)),
+    parameter_data_type =
+        LTRIM(RTRIM(ps.param_data_type)),
+    parameter_compiled_value =
+        CASE
+            /*Strip parentheses from values like (13)*/
+            WHEN ps.param_compiled_value LIKE N'(%)'
+            THEN SUBSTRING
+                 (
+                     ps.param_compiled_value,
+                     2,
+                     LEN(ps.param_compiled_value) - 2
+                 )
+            /*Strip guid wrapper from values like {guid'...'}*/
+            WHEN ps.param_compiled_value LIKE N'{guid''%''}'
+            THEN N'''' +
+                 SUBSTRING
+                 (
+                     ps.param_compiled_value,
+                     7,
+                     LEN(ps.param_compiled_value) - 8
+                 ) +
+                 N''''
+            ELSE ps.param_compiled_value
+        END
+FROM #parameter_shred AS ps
 OPTION(RECOMPILE);
 
 /*


### PR DESCRIPTION
## The bottleneck (measured, not guessed)

The parameter-extraction step read `cr.c.value(N'@ParameterCompiledValue')` **four times** in a single INSERT — inside the LIKE tests, the SUBSTRINGs, and the LENs of the value-cleanup CASE — plus `@Column` and `@ParameterDataType`, for **nine `.value()` calls on the same XML node**. Against untyped plan XML the optimizer builds one XML Reader table-valued function per call; the actual execution plan showed **ten stacked in nested-loop joins**, each re-parsing the plan from scratch. On many-plan Query Store workloads this was the procedure's single largest cost.

## The fix

Shred each `ColumnReference`'s three attributes once into a `#parameter_shred` temp table, then apply the existing paren-strip / guid-strip cleanup in a second pass over those plain-string columns. It's a straight **common-subexpression elimination** — the CASE logic and the `LTRIM`/`RTRIM` are unchanged, just computed once on materialized strings instead of re-read from the XML.

## Measured result

On a **497-plan** Query Store database (frozen `READ_ONLY` so the plan set is stable across runs):

| build | time | output |
|---|---:|---|
| dev baseline | 25,687 ms | — |
| this fix | 1,996 ms | **byte-identical** |

~13x faster, zero output change.

## Scope

- The **deep single-plan** case (`@query_plan_xml` up to ~4.7 MB) was measured separately and is already sub-linear — no change needed.
- The identical repeated-`.value()` pattern in the adjacent "fill in missing parameters" step is **left alone**: it operates on a tiny query-text fragment with rarely any rows and is not a measured bottleneck. Minimal diff on a correctness-critical proc pre-release.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] `tests/run_tests.py` generate-and-execute harness stays **237/237** (identical repros)
- [x] Full output **byte-identical** to the prior build across all 497 plans (verified with Query Store frozen to rule out capture-timing noise)
- [x] Perf fixture database dropped; no version/date bumps; `Install-All/DarlingData.sql` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)