### PR TITLE
sp_PerfCheck: tolerate NULL is_accelerated_database_recovery_on (inaccessible dbs)

### DIFF
--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -467,7 +467,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         is_cdc_enabled bit NOT NULL,
         target_recovery_time_in_seconds integer NULL,
         delayed_durability_desc nvarchar(60) NULL,
-        is_accelerated_database_recovery_on bit NOT NULL,
+        /*
+        Nullable on purpose. A database that is closed (AUTO_CLOSE), OFFLINE, or
+        otherwise inaccessible returns NULL for is_accelerated_database_recovery_on
+        in sys.databases - ADR state lives with the database, not in master
+        metadata, so it can't be read while the database is shut. The collection
+        below has no state filter, so a single inaccessible database would
+        otherwise fail this INSERT with Msg 515 and abort the whole check. NULL
+        flows through harmlessly: the ADR finding tests "= 0", which NULL never
+        satisfies, so a database we cannot assess simply gets no recommendation.
+        */
+        is_accelerated_database_recovery_on bit NULL,
         is_ledger_on bit NULL
     );
 

--- a/sp_PerfCheck/tests/README.md
+++ b/sp_PerfCheck/tests/README.md
@@ -160,21 +160,23 @@ Statistics) to exercise the per-database cursor path and the `database_name`
 scoping without turning the suite into an exhaustive per-setting matrix. See the
 Auto-Close note below for why that specific one was dropped.
 
-### A real fragility this harness surfaced: AUTO_CLOSE on SQL Server 2025
+### A real fragility this harness surfaced, now fixed and asserted
 
 The database-scoped group was originally written to force **AUTO_CLOSE** as its
-second toggle. On **SQL Server 2025**, forcing `AUTO_CLOSE ON` and then scoping
-`sp_PerfCheck` to that (now closed) database makes `sys.databases` return `NULL`
-for `collation_name`, `target_recovery_time_in_seconds`, and
-`delayed_durability_desc`, which the procedure's `#databases` insert rejects with
-`Msg 515` (`Cannot insert the value NULL`). The database is never analyzed and
-the run aborts. On 2016-2022 the same test passed, so this is a genuine,
-version-dependent fragility in `sp_PerfCheck` itself, not a test artifact.
+second toggle, and it uncovered a crash: a closed (`AUTO_CLOSE`) or `OFFLINE`
+database returns `NULL` for `is_accelerated_database_recovery_on` in
+`sys.databases` -- ADR state lives with the database, not master metadata, so it
+cannot be read while the database is shut -- and that column was `NOT NULL` in the
+procedure's `#databases` table, so the collection `INSERT` rejected the `NULL`
+with `Msg 515` and aborted the whole run. Because the collection has no state
+filter, a single inaccessible database could take down a full-instance run. It
+showed up on SQL Server 2025 first, but the mechanism is version-independent.
 
-Rather than assert around a procedure error (which would make the suite flake by
-version) or edit the procedure, the harness **switched its second toggle to
-AUTO_UPDATE_STATISTICS**, which keeps the database open and behaves identically
-on every version. The AUTO_CLOSE behavior is documented here so it is not lost.
+The column is now nullable, and the `Inaccessible` group asserts the fix stays in:
+it closes and then offlines a scratch database and confirms scoped runs and a
+whole-instance run all complete without `Msg 515`. The database-scoped toggle
+group uses `AUTO_UPDATE_STATISTICS` instead of `AUTO_CLOSE` for a separate reason
+-- it keeps the database open, so the finding it forces is actually assessable.
 
 ## Not wired into CI
 

--- a/sp_PerfCheck/tests/run_tests.py
+++ b/sp_PerfCheck/tests/run_tests.py
@@ -398,13 +398,12 @@ def database_scoped_tests(server, password, R):
     DATABASE settings, so a scratch database can force each on and off
     deterministically, and both leave the database OPEN.
 
-    (AUTO_CLOSE was deliberately NOT used. Forcing AUTO_CLOSE on and scoping the
-    procedure to the closed database makes sys.databases return NULL for
-    collation_name / target_recovery_time_in_seconds / delayed_durability_desc
-    on SQL Server 2025, which sp_PerfCheck's #databases insert rejects with
-    Msg 515. That is a real, version-dependent fragility in the procedure, not a
-    test artifact; it is documented in README.md rather than asserted, so this
-    harness stays deterministic across versions.)
+    (AUTO_CLOSE is deliberately NOT used for the ON/OFF finding toggles here,
+    because closing the database changes which findings are even assessable. The
+    crash it used to cause -- a closed or offline database made sys.databases
+    return NULL for is_accelerated_database_recovery_on, which the #databases
+    insert rejected with Msg 515 -- is now fixed, and inaccessible_database_tests
+    below asserts it stays fixed.)
 
     The design keeps every absence assertion non-vacuous WITHOUT relying on any
     volatile finding: in each run one toggle is set to its finding-producing
@@ -494,6 +493,69 @@ def database_scoped_tests(server, password, R):
                 not DB_marker(server, password, db), "scratch database still exists")
 
 
+def inaccessible_database_tests(server, password, R):
+    """Regression test for a Msg 515 crash on inaccessible databases.
+
+    sp_PerfCheck's #databases collection has no state filter, so it inspects
+    every user database regardless of accessibility. A database that is closed
+    (AUTO_CLOSE) or OFFLINE returns NULL for is_accelerated_database_recovery_on
+    in sys.databases -- ADR state lives with the database, not master metadata,
+    so it cannot be read while the database is shut. That column used to be
+    NOT NULL in #databases, so the collection INSERT rejected the NULL with
+    Msg 515 and aborted the entire check. One inaccessible database could take
+    down a whole-instance run. The column is now nullable; these assertions prove
+    the procedure completes cleanly instead of crashing.
+    """
+    db = "perfcheck_test_inaccessible"
+    grp = "Inaccessible"
+
+    drop_sql = (
+        "SET NOCOUNT ON; "
+        "IF DB_ID('%s') IS NOT NULL "
+        "BEGIN "
+        "ALTER DATABASE [%s] SET ONLINE; "
+        "ALTER DATABASE [%s] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; "
+        "DROP DATABASE [%s]; "
+        "END;"
+    ) % (db, db, db, db)
+
+    out, err = _sqlcmd(server, password, drop_sql + " CREATE DATABASE [%s];" % db)
+    R.check(grp, "setup: scratch database created",
+            not (find_sql_errors(out) + find_sql_errors(err))
+            and DB_marker(server, password, db),
+            "scratch database not created")
+
+    try:
+        # AUTO_CLOSE, then force it shut with an offline/online cycle so the next
+        # metadata read sees a closed database.
+        _sqlcmd(server, password, "ALTER DATABASE [%s] SET AUTO_CLOSE ON;" % db)
+        _sqlcmd(server, password,
+                "ALTER DATABASE [%s] SET OFFLINE; "
+                "ALTER DATABASE [%s] SET ONLINE;" % (db, db))
+        out, err = run_perfcheck(server, password, "@database_name = N'%s'" % db)
+        errs = find_sql_errors(out) + find_sql_errors(err)
+        R.check(grp, "AUTO_CLOSE-closed database scoped run does not crash (Msg 515)",
+                not errs, str(errs))
+
+        # OFFLINE is the more severe case, and the one a whole-instance run hits.
+        _sqlcmd(server, password, "ALTER DATABASE [%s] SET OFFLINE;" % db)
+        out, err = run_perfcheck(server, password, "@database_name = N'%s'" % db)
+        errs = find_sql_errors(out) + find_sql_errors(err)
+        R.check(grp, "OFFLINE database scoped run does not crash (Msg 515)",
+                not errs, str(errs))
+
+        # The load-bearing case: a whole-instance run must not be aborted by one
+        # inaccessible database sitting on the server.
+        out, err = run_perfcheck(server, password)
+        errs = find_sql_errors(out) + find_sql_errors(err)
+        R.check(grp, "whole-instance run with an OFFLINE database present does not crash",
+                not errs, str(errs))
+    finally:
+        _sqlcmd(server, password, drop_sql)
+        R.check(grp, "cleanup: scratch database dropped",
+                not DB_marker(server, password, db), "scratch database still exists")
+
+
 def DB_marker(server, password, db):
     """True if the named database currently exists."""
     out, _ = _sqlcmd(
@@ -539,6 +601,7 @@ def main():
     structural_tests(args.server, args.password, R)
     forced_condition_tests(args.server, args.password, R)
     database_scoped_tests(args.server, args.password, R)
+    inaccessible_database_tests(args.server, args.password, R)
 
     for r in R.items:
         status = "PASS" if r["passed"] else "FAIL"


### PR DESCRIPTION
## The bug

`sp_PerfCheck`'s `#databases` collection has **no state filter** — it inspects every user database regardless of accessibility. A database that is closed (`AUTO_CLOSE`) or `OFFLINE` returns **NULL for `is_accelerated_database_recovery_on`** in `sys.databases` — ADR state lives with the database, not master metadata, so it can't be read while the database is shut. That column was `NOT NULL` in `#databases`, so the collection `INSERT` rejected the NULL with **Msg 515** and aborted the entire check.

Because there's no state filter, **a single inaccessible database could take down a whole-instance run.**

```
Msg 515, Level 16, State 2, Procedure dbo.sp_PerfCheck, Line 3906
Cannot insert the value NULL into column 'is_accelerated_database_recovery_on' ... column does not allow nulls.
```

## The fix

Made the column nullable, matching its already-nullable siblings (`collation_name`, `target_recovery_time_in_seconds`, `delayed_durability_desc`, `is_ledger_on` — all of which `sys.databases` also NULLs out for a closed database). NULL flows through harmlessly: the only finding that reads the column tests `= 0`, which NULL never satisfies, so a database that can't be assessed simply gets no ADR recommendation — the correct outcome.

I confirmed via live testing that this is the **only** `NOT NULL` column that goes NULL even for an OFFLINE database (the rest live in master metadata and stay available), so it's a genuine one-column fix.

## Regression test

Added an `Inaccessible` group to `tests/run_tests.py`: it closes and then offlines a scratch database and asserts scoped runs **and a whole-instance run** all complete without Msg 515. Proven **bidirectionally** — the group fails against the pre-fix procedure (51/2, Msg 515 at the `#databases` insert) and passes against this one (53/0).

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] Reproduction (scoped + whole-instance runs against a closed/offline database) no longer raises Msg 515
- [x] Full harness **53/53**; the new group proven to fail on the old proc, pass on the fix
- [x] Scratch database cleaned up; no version/date bumps; `Install-All/DarlingData.sql` untouched

Surfaced on SQL Server 2025 by the `sp_PerfCheck` test harness added in #828, but the mechanism is version-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)