### PR TITLE
sp_PerfCheck: normalize storage-finding granularity (proven template)

### DIFF
--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -2844,7 +2844,26 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         finding = N'Slow Read Latency',
         database_name = i.database_name,
         object_name =
-            i.file_name +
+            /*
+            Drive/volume plus the physical file name on disk. This makes a file
+            finding self-contained, tells apart every file (logical names repeat
+            across databases and don't say where the file lives), and lines up
+            with the drive-level rollup (check_id 3003), which shows the same
+            drive. For blob storage drive_location already holds the whole URL, so
+            use it as-is; otherwise take the last path segment after the final
+            separator.
+            */
+            CASE
+                WHEN i.drive_location = i.physical_name
+                THEN i.physical_name
+                ELSE
+                    ISNULL(i.drive_location + N' ', N'') +
+                    RIGHT
+                    (
+                        i.physical_name,
+                        CHARINDEX(N'\', REVERSE(i.physical_name) + N'\') - 1
+                    )
+            END +
             N' (' +
             i.type_desc +
             N')',
@@ -2887,7 +2906,26 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         finding = N'Slow Write Latency',
         database_name = i.database_name,
         object_name =
-            i.file_name +
+            /*
+            Drive/volume plus the physical file name on disk. This makes a file
+            finding self-contained, tells apart every file (logical names repeat
+            across databases and don't say where the file lives), and lines up
+            with the drive-level rollup (check_id 3003), which shows the same
+            drive. For blob storage drive_location already holds the whole URL, so
+            use it as-is; otherwise take the last path segment after the final
+            separator.
+            */
+            CASE
+                WHEN i.drive_location = i.physical_name
+                THEN i.physical_name
+                ELSE
+                    ISNULL(i.drive_location + N' ', N'') +
+                    RIGHT
+                    (
+                        i.physical_name,
+                        CHARINDEX(N'\', REVERSE(i.physical_name) + N'\') - 1
+                    )
+            END +
             N' (' +
             i.type_desc +
             N')',
@@ -2913,6 +2951,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         priority,
         category,
         finding,
+        object_name,
         details,
         url
     )
@@ -2920,9 +2959,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         check_id = 3003,
         priority = 20, /* High: systemic storage problem */
         category = N'Storage Performance',
-        finding =
-            N'Multiple Slow Files on Storage Location ' +
-            i.drive_location,
+        /*
+        Stable label; the drive/volume that varies per row goes in object_name so
+        this finding groups and the identity lives in a column, not the sentence.
+        */
+        finding = N'Multiple Slow Files on Storage Location',
+        object_name = i.drive_location,
         details =
             N'Storage location ' +
             i.drive_location +


### PR DESCRIPTION
First cluster of the finding-granularity cleanup, and the proven template for the rest. The storage/I/O checks reported the same data at three grains with the level expressed inconsistently.

## What changes

Applies the three rules from the [findings-inventory audit](https://claude.ai/code/artifact/b6466490-9aa8-4444-bd54-e1b9c1d57a19):

- **`finding` is a stable label.** `3003` becomes `Multiple Slow Files on Storage Location` (no drive appended).
- **The thing it's about goes in `object_name`.** `3003` now sets `object_name` to the drive; `3001`/`3002` prefix the drive onto the physical file name.
- **The level reads off the columns** — `3001`/`3002` carry a database + file (reads as File), `3003` carries a drive and no database (reads as Drive). No new column.

| | check_id | Before | After |
|---|---|---|---|
| finding | 3003 | `Multiple Slow Files on Storage Location C:` | `Multiple Slow Files on Storage Location` |
| object_name | 3003 | `N/A` | `C:` |
| object_name | 3001/3002 | `Crap (ROWS)` | `C: Crap.mdf (ROWS)` |

`object_name` for a file finding is `<drive> <physical file name> (<type>)`, e.g. **`C: StackOverflow2013_2.ndf (ROWS)`** — the physical file name differentiates every file (logical names repeat across databases and don't say where the file lives), stays short, and carries the drive so it lines up with the `3003` rollup. Blob-storage paths (where `drive_location` already holds the whole URL) are shown as-is.

**Output shape is unchanged** — no new column; only the `finding`/`object_name` values change, and only for these three findings.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] Existing harness stays 53/53
- [x] Live output inspected with lowered thresholds: new values confirmed, including two data files on one database differentiated by physical file name
- [x] No `COLLATE` needed (reads `#io_stats`, server-default collation, not `sys.master_files` directly)
- [x] No version/date bumps; `Install-All/DarlingData.sql` untouched

## Note

Storage-finding *content* isn't deterministically forceable through the public interface (needs real slow I/O), so it stays in the manually-verified bucket the README documents. Verified by hand here. Making `@slow_read_ms`/`@slow_write_ms` parameters would let the harness force these findings and assert the format automatically — happy to do that as a follow-up if you want it locked in CI.

Config and database clusters follow, same three rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)