### PR TITLE
sp_PerfCheck: normalize config and database finding granularity

### DIFF
--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -974,7 +974,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             check_id = 4101,
             priority = 20, /* High: active memory spills */
             category = N'Memory Pressure',
-            finding = N'Memory-Starved Queries Detected',
+            finding = N'Memory-Starved Queries: Forced Grants',
             details =
                 N'dm_exec_query_resource_semaphores has ' +
                 CONVERT(nvarchar(10), MAX(ders.forced_grant_count)) +
@@ -1001,7 +1001,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             check_id = 4103,
             priority = 20, /* High: queries can't get memory */
             category = N'Memory Pressure',
-            finding = N'Memory-Starved Queries Detected',
+            finding = N'Memory-Starved Queries: Grant Timeouts',
             details =
                 N'dm_exec_query_resource_semaphores has ' +
                 CONVERT(nvarchar(10), MAX(ders.timeout_error_count)) +
@@ -2073,6 +2073,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             priority,
             category,
             finding,
+            object_name,
             details,
             url
         )
@@ -2089,8 +2090,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     ELSE 40 /* Low: >=10% of uptime */
                 END,
             category = N'Wait Statistics',
-            finding =
-                N'High Impact Wait Type: ' +
+            finding = N'High Impact Wait Type',
+            object_name =
                 ws.wait_type +
                 N' (' +
                 ws.category +
@@ -2467,6 +2468,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     priority,
                     category,
                     finding,
+                    object_name,
                     details,
                     url
                 )
@@ -2474,9 +2476,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     check_id = 6003,
                     priority = 50, /* Informational: memory context */
                     category = N'Memory Usage',
-                    finding =
-                        N'Top Memory Consumer: ' +
-                        domc.type,
+                    finding = N'Top Memory Consumer',
+                    object_name = domc.type,
                     details =
                         N'Memory clerk "' +
                         domc.type +
@@ -3166,6 +3167,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             priority,
             category,
             finding,
+            object_name,
             details,
             url
         )
@@ -3173,7 +3175,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             check_id = 1000,
             priority = 50, /* Informational: non-default config */
             category = N'Server Configuration',
-            finding = N'Non-Default Configuration: ' + c.name,
+            /*
+            Stable label; the setting name that varies per row goes in
+            object_name so this finding groups and the setting is filterable.
+            */
+            finding = N'Non-Default Configuration',
+            object_name = c.name,
             details =
                 N'Configuration option "' + c.name +
                 N'" has been changed from the default. Current: ' +
@@ -3215,11 +3222,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             OR (c.name = N'ADR cleaner retry timeout (min)' AND c.value_in_use NOT IN (0, 15, 120))
             OR (c.name = N'ADR Cleaner Thread Count' AND c.value_in_use <> 1)
             OR (c.name = N'ADR Preallocation Factor' AND c.value_in_use NOT IN (0, 4))
-            /* Affinity settings */
-            OR (c.name = N'affinity mask' AND c.value_in_use <> 0)
-            OR (c.name = N'affinity I/O mask' AND c.value_in_use <> 0)
-            OR (c.name = N'affinity64 mask' AND c.value_in_use <> 0)
-            OR (c.name = N'affinity64 I/O mask' AND c.value_in_use <> 0)
+            /*
+            Affinity masks (1008-1011), priority boost (1005), and lightweight
+            pooling (1006) have their own dedicated checks that fire on exactly
+            the same non-default condition, so they are excluded here - otherwise
+            each would be reported twice, once generically and once specifically.
+            */
             /* Common performance settings */
             OR (c.name = N'cost threshold for parallelism' AND c.value_in_use <> 5)
             OR (c.name = N'max degree of parallelism' AND c.value_in_use <> 0)
@@ -3228,11 +3236,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             OR (c.name = N'min memory per query (KB)' AND c.value_in_use <> 1024)
             OR (c.name = N'min server memory (MB)' AND c.value_in_use NOT IN (0, 16))
             OR (c.name = N'optimize for ad hoc workloads' AND c.value_in_use <> 0)
-            OR (c.name = N'priority boost' AND c.value_in_use <> 0)
             OR (c.name = N'query governor cost limit' AND c.value_in_use <> 0)
             OR (c.name = N'recovery interval (min)' AND c.value_in_use <> 0)
-            OR (c.name = N'tempdb metadata memory-optimized' AND c.value_in_use <> 0)
-            OR (c.name = N'lightweight pooling' AND c.value_in_use <> 0);
+            OR (c.name = N'tempdb metadata memory-optimized' AND c.value_in_use <> 0);
 
         /*
         TempDB Configuration Checks (not applicable to Azure SQL DB)
@@ -4339,6 +4345,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             category,
             finding,
             database_name,
+            object_name,
             details,
             url
         )
@@ -4346,10 +4353,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             check_id = 7003,
             priority = 20, /* High: apps can't connect */
             category = N'Database Configuration',
-            finding =
-                N'Restricted Access Mode: ' +
-                d.user_access_desc,
+            finding = N'Restricted Access Mode',
             database_name = d.name,
+            object_name = d.user_access_desc,
             details =
                 N'Database is not in MULTI_USER mode. Current mode: ' +
                 d.user_access_desc +
@@ -4884,6 +4890,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             category,
             finding,
             database_name,
+            object_name,
             details,
             url
         )
@@ -4891,8 +4898,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             check_id = 7008,
             priority = 30, /* Medium: data loss risk on crash */
             category = N'Database Configuration',
-            finding = N'Delayed Durability: ' + d.delayed_durability_desc,
+            finding = N'Delayed Durability',
             database_name = d.name,
+            object_name = d.delayed_durability_desc,
             details =
                 N'Database uses ' +
                 d.delayed_durability_desc +

--- a/sp_PerfCheck/tests/run_tests.py
+++ b/sp_PerfCheck/tests/run_tests.py
@@ -198,10 +198,11 @@ def parse_result_rows(stdout):
 
 def find_config_finding(rows, option_name):
     """Return the #results row for a Non-Default Configuration finding on the
-    given option, or None."""
-    want = "Non-Default Configuration: " + option_name
+    given option, or None. finding is a stable label; the option name lives in
+    object_name (column 6), so matching here also proves that convention holds."""
     for r in rows:
-        if r[4] == want:
+        if (r[4] == "Non-Default Configuration"
+                and len(r) > 6 and r[6] == option_name):
             return r
     return None
 
@@ -356,11 +357,14 @@ def forced_condition_tests(server, password, R):
                     row is not None, "finding not emitted when forced")
             if row is not None:
                 well_formed = (row[0] == "1000" and row[1] == "50"
-                               and row[3] == "Server Configuration")
+                               and row[3] == "Server Configuration"
+                               and row[4] == "Non-Default Configuration"
+                               and row[6] == name)
                 R.check(grp, "forced finding row well-formed "
-                        "(check_id 1000, priority 50, Server Configuration)",
+                        "(stable finding, setting name in object_name)",
                         well_formed,
-                        "check_id=%s priority=%s category=%s" % (row[0], row[1], row[3]))
+                        "check_id=%s finding=%r object_name=%r"
+                        % (row[0], row[4], row[6]))
                 details = row[7] if len(row) > 7 else ""
                 names_option = (name in details
                                 and ("Current: %d" % forced_value) in details)


### PR DESCRIPTION
Rolls the storage-cluster convention (#831) across the remaining findings that baked a per-row identifier into the finding text. The finding becomes a stable, groupable label; the identifier moves to `object_name`. **Output shape unchanged** — no new column.

## Normalized findings

| check_id | finding before | finding after | object_name after |
|---|---|---|---|
| 1000 | `Non-Default Configuration: max degree of parallelism` | `Non-Default Configuration` | `max degree of parallelism` |
| 7003 | `Restricted Access Mode: RESTRICTED_USER` | `Restricted Access Mode` | `RESTRICTED_USER` |
| 7008 | `Delayed Durability: FORCED` | `Delayed Durability` | `FORCED` |
| 6001 | `High Impact Wait Type: CXPACKET (CPU)` | `High Impact Wait Type` | `CXPACKET (CPU)` |
| 6003 | `Top Memory Consumer: CACHESTORE_...` | `Top Memory Consumer` | `CACHESTORE_...` |

## Dedup

1000 overlapped several specific checks. Priority boost (1005), lightweight pooling (1006), and the four affinity masks (1008–1011) each have a dedicated check firing on the **identical** non-default condition, so a setting was reported twice — they're now excluded from the 1000 scan.

**MAXDOP, cost threshold, and max/min memory are deliberately kept in 1000**: their specific checks have *narrower* conditions (1003 fires when MAXDOP = 0; 1000 fires when MAXDOP is any *other* non-default value), so removing them would lose coverage, not just a duplicate. That's the safety line — dedup only where the specific check fully covers 1000's condition.

## Duplicate rows

4101/4103 both emitted the literal `Memory-Starved Queries Detected` and rendered as duplicate rows. Now `Memory-Starved Queries: Forced Grants` and `Memory-Starved Queries: Grant Timeouts` — two distinct, stable per-check labels.

## Harness

The forced-config group now matches the stable finding **plus** `object_name` = the setting name, which locks the convention — a regression to the baked-in `Non-Default Configuration: <name>` form fails it.

## Test plan

- [x] Compiles clean on 2016 / 2017 / 2019 / 2022 / 2025
- [x] Harness 53/53 (forced-config group exercises the 1000 normalize and locks it)
- [x] 7003 / 7008 confirmed live against a scratch database (stable finding, value in `object_name`)
- [x] 1000 dedup sound by construction — the six removed settings are each fully covered by a specific check on the same condition; harness confirms the non-deduped 1000 settings still fire
- [x] No version/date bumps; `Install-All/DarlingData.sql` untouched

6001 (wait type) and 6003 (memory clerk) content is volatile/not deterministically forceable, so those were verified by reading the generated SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)