### PR TITLE
Updates_20260801 release prep: version bumps

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -80,8 +80,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.7',
-        @version_date = '20260701';
+        @version = '3.8',
+        @version_date = '20260801';
 
     IF @help = 1
     BEGIN

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -89,8 +89,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.7',
-    @version_date = '20260701';
+    @version = '7.8',
+    @version_date = '20260801';
 
 IF @help = 1
 BEGIN

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -94,8 +94,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.7',
-    @version_date = '20260701';
+    @version = '5.8',
+    @version_date = '20260801';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -75,8 +75,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.7',
-        @version_date = '20260701';
+        @version = '2.8',
+        @version_date = '20260801';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,8 +73,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.7',
-        @version_date = '20260701';
+        @version = '3.8',
+        @version_date = '20260801';
 
     IF @help = 1
     BEGIN

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -81,8 +81,8 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.7',
-        @version_date = N'20260701';
+        @version = N'2.8',
+        @version_date = N'20260801';
 
     /*
     Help section, for help.

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,8 +78,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.7',
-    @version_date = '20260701';
+    @version = '6.8',
+    @version_date = '20260801';
 
 
 IF @help = 1

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -90,8 +90,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.7',
-    @version_date = '20260701';
+    @version = '1.8',
+    @version_date = '20260801';
 
 /*Help*/
 IF @help = 1

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -78,8 +78,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.7',
-        @version_date = '20260701';
+        @version = '1.8',
+        @version_date = '20260801';
 
     /*
     ╔══════════════════════════════════════════════════╗

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -128,8 +128,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.7',
-    @version_date = '20260701';
+    @version = '6.8',
+    @version_date = '20260801';
 
 /*
 Helpful section! For help.


### PR DESCRIPTION
## Summary

August 2026 release version bumps: all ten combined-install procs changed since Updates_20260701 move to the .8 minor with @version_date = 20260801. Follows the ten per-proc audit-fix commits already on dev (every proc audited by a dedicated agent plus a cross-proc consistency sweep; all blockers fixed and verified, harnesses green: QuickieStore 157/157, ReproBuilder 239/239, HumanEvents 195/195, PerfCheck 39/39).

sp_QueryStoreCleanup keeps 1.6/20260501: it is not in the combined install.

## Test plan

- Version stamps verified by grep across all ten (PerfCheck's N-prefixed literals preserved)
- Spot installs on SQL Server 2022 with @version/@version_date OUTPUT verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)