### PR TITLE
Fix wait sort orders counting waits across all of Query Store history (#850)

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -10633,8 +10633,16 @@ BEGIN
         total_query_wait_time_ms =
             SUM(qsws.total_query_wait_time_ms)
     FROM ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
+    /*
+    Joining on plan_id alone would sum waits across all of
+    Query Store history, multiplied by the number of in-window
+    runtime stats rows. Interval and execution type scope the
+    waits to the rows the WHERE clause qualifies.
+    */
     JOIN ' + @database_name_quoted + N'.sys.query_store_wait_stats AS qsws
-      ON qsrs.plan_id = qsws.plan_id
+      ON  qsrs.plan_id = qsws.plan_id
+      AND qsrs.runtime_stats_interval_id = qsws.runtime_stats_interval_id
+      AND qsrs.execution_type = qsws.execution_type
     WHERE 1 = 1
     '
    + CASE WHEN @regression_mode = 1
@@ -10760,8 +10768,15 @@ BEGIN
         total_query_wait_time_ms =
             MAX(qsws.total_query_wait_time_ms)
     FROM ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
+    /*
+    Joining on plan_id alone would take the max wait across
+    all of Query Store history rather than the requested
+    time window.
+    */
     JOIN ' + @database_name_quoted + N'.sys.query_store_wait_stats AS qsws
-      ON qsrs.plan_id = qsws.plan_id
+      ON  qsrs.plan_id = qsws.plan_id
+      AND qsrs.runtime_stats_interval_id = qsws.runtime_stats_interval_id
+      AND qsrs.execution_type = qsws.execution_type
     WHERE 1 = 1
     AND qsws.wait_category = '  +
     CASE @sort_order


### PR DESCRIPTION
Fixes #850 — full verification details in [this comment](https://github.com/erikdarlingdata/DarlingData/issues/850#issuecomment-5172517492). Credit to @ReeceGoding for spotting it from the `@debug` output.

## What was wrong

Both populates of `#plan_ids_with_total_waits` (the `'total waits'` SUM branch and the per-category MAX branch) joined `query_store_runtime_stats` to `query_store_wait_stats` on `plan_id` alone. `@where_clause` only constrains `qsrs`, so the date range decided *which plans qualified* while the wait numbers came from every interval the plan ever ran in. The SUM branch was worse: the many-to-many join multiplied the all-history total by the number of in-window runtime stats rows.

## The fix

Add `runtime_stats_interval_id` and `execution_type` to both joins, scoping wait rows to the runtime stats rows the WHERE clause qualifies. `execution_type` matters for the SUM branch (both views break rows out by execution type within an interval, so interval alone still double-counts plans with regular + aborted executions in the same interval) and keeps waits aligned with the `@execution_type_desc` filter.

## Validation

Reproduced with Reece's scenario from the issue on SQL Server 2022 (RTM-CU26): Query Store with `INTERVAL_LENGTH_MINUTES = 1`, `WAIT_STATS_CAPTURE_MODE = ON`, then two lock-wait phases against the same query in different intervals — ~82 s of lock waits in phase A, ~5 s in phase B, with two clean interval boundaries between them.

Ground truth in `sys.query_store_wait_stats`:

| interval | lock waits |
|---|---|
| 22:51 (phase A) | 81,980 ms |
| 22:53 (phase B) | 4,989 ms |

`total_wait_time_from_sort_order_ms` reported for the query, before and after:

| sort order | window | before | after |
|---|---|---|---|
| `lock waits` | phase B only | 81,980 ❌ (phase A's wait) | 4,989 ✅ |
| `lock waits` | both phases | 81,980 | 81,980 ✅ (max interval, unchanged semantics) |
| `total waits` | phase B only | 86,969 ❌ (all-history total) | 4,989 ✅ |
| `total waits` | both phases | 173,938 ❌ (exactly 2× — row multiplication) | 86,969 ✅ (true window sum) |

The before column reproduces the issue exactly as predicted: identical results for the narrow and wide windows, and the SUM branch shows the multiplication effect (2 in-window runtime stats rows × 86,969 all-history total).

### Tested

- Both changed code paths (`'total waits'` and a per-category wait sort) executed against SQL Server 2022, non-regression mode, with the window comparison above.
- Proc installs clean (both branches of the dynamic SQL compile and run).

### Not tested

- Regression mode with wait sort orders (the changed SQL text is shared with regression mode, but I didn't build a baseline-window repro; the join change affects it identically since `@regression_where_clause` also only constrains `qsrs`).
- `@get_all_databases = 1` (no code path difference — the same dynamic SQL runs per database).
- Case-sensitive collations, older SQL Server versions (2017/2019). The new join columns exist in `sys.query_store_wait_stats`/`sys.query_store_runtime_stats` on every version that has wait stats (2017+), and the proc already gates wait sorts on `query_store_wait_stats` existing.

## Out of scope

The pre-existing `@wait_filter` populate has the same all-history character (no interval or date restriction at all) — noted in the issue comment; happy to file/fix separately if wanted.
