### PR TITLE
Fix @wait_filter matching waits from all of Query Store history (#852)

### DIFF
--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -10096,7 +10096,21 @@ BEGIN
 SELECT TOP (@top)
     qsws.plan_id
 FROM  ' + @database_name_quoted + N'.sys.query_store_wait_stats AS qsws
+/*
+Restricting waits to the runtime stats rows the date range
+qualifies keeps the filter from matching queries whose waits
+of this category happened entirely outside of it, and keeps
+the TOP ranked by in-range wait totals rather than
+all-history ones. Matches the date semantics of the main
+where clause and the wait sort order joins.
+*/
+JOIN  ' + @database_name_quoted + N'.sys.query_store_runtime_stats AS qsrs
+  ON  qsws.plan_id = qsrs.plan_id
+  AND qsws.runtime_stats_interval_id = qsrs.runtime_stats_interval_id
+  AND qsws.execution_type = qsrs.execution_type
 WHERE 1 = 1
+AND   qsrs.last_execution_time >= @start_date
+AND   qsrs.last_execution_time <  @end_date
 AND   qsws.wait_category = ' +
 CASE @wait_filter
      WHEN 'cpu' THEN N'1'
@@ -10140,8 +10154,12 @@ OPTION(RECOMPILE, OPTIMIZE FOR (@top = 9223372036854775807));' + @nc10;
     )
     EXECUTE sys.sp_executesql
         @sql,
-      N'@top bigint',
-        @top;
+      N'@top bigint,
+        @start_date datetimeoffset(7),
+        @end_date datetimeoffset(7)',
+        @top,
+        @start_date,
+        @end_date;
 
     IF @troubleshoot_performance = 1
     BEGIN


### PR DESCRIPTION
Fixes #852 — the sibling of #850/#851, found while verifying that fix.

## What was wrong

The `#wait_filter` populate aggregated `sys.query_store_wait_stats` per `plan_id` with no date or interval restriction at all, then fed the plan_ids into an `EXISTS` against the date-windowed runtime stats. Two consequences:

1. A query whose waits of the requested category happened entirely **outside** the requested window still passed the filter, as long as it executed at all inside the window.
2. The `TOP (@top)` was ranked by **all-history** wait totals, so plans with big waits long ago could crowd out plans that actually waited inside the window — wrong in both directions.

## The fix

Join `query_store_wait_stats` to `query_store_runtime_stats` on `(plan_id, runtime_stats_interval_id, execution_type)` and filter `qsrs.last_execution_time` by `@start_date`/`@end_date` — the same join grain as #851 and the same date semantics as the proc's main `@where_clause`. The block's `sp_executesql` call previously only passed `@top`; it now passes the date parameters too.

## Validation

SQL Server 2022 (RTM-CU26), Query Store with 1-minute intervals, two queries against the same table:

- **Q1**: ~62 s of lock waits in interval 03:00 (phase A), then executed again *unblocked* in interval 03:08 — so it has an in-window execution but no in-window lock waits.
- **Q2**: ~5 s of lock waits in interval 03:08 (phase B) only.

`@wait_filter = 'lock'` results:

| window | before | after |
|---|---|---|
| phase B only | Q1 + Q2 ❌ (Q1's lock waits were entirely in phase A) | Q2 only ✅ |
| both phases | Q1 + Q2 | Q1 + Q2 ✅ |

### Tested

- The changed code path executed on SQL Server 2022 with the window comparison above; ground truth confirmed per-interval from `sys.query_store_wait_stats`.
- Proc installs clean.
- A first draft of this fix scoped intervals by `qsrsi.start_time >= @start_date` and the repro caught it dropping the partial interval at the window's leading edge (false negative for a query that waited *inside* the window). The final shape filters on `qsrs.last_execution_time` instead, which has no such boundary mismatch and matches the rest of the proc.

### Not tested

- Regression mode and `@get_all_databases = 1` (no code path difference — same dynamic SQL per database; `#wait_filter` is truncated per database iteration).
- Older SQL Server versions locally; the join columns exist on every version that has `query_store_wait_stats` (2017+), and CI runs 2017/2019/2022/2025.
