### PR TITLE
sp_QuickieStore: @find_parameter_sensitive fixes from prod dogfooding

### DIFF
--- a/.github/workflows/dev-installall-artifact.yml
+++ b/.github/workflows/dev-installall-artifact.yml
@@ -1,0 +1,54 @@
+name: Publish Dev Install-All Build
+# Install-All/DarlingData.sql is only regenerated and committed on main:
+# rebuilding it on dev used to make every dev -> main merge conflict inside a
+# 2+ MB generated file. This workflow gives dev a fresh compiled build WITHOUT
+# committing anything: it regenerates the file and publishes it as an asset on
+# a rolling 'dev-latest' prerelease. The tracked copy on dev stays untouched
+# (and stale), so merges never see it change.
+#
+# Consumers:
+#   gh release download dev-latest -p DarlingData.sql -R erikdarlingdata/DarlingData
+# or the stable URL:
+#   https://github.com/erikdarlingdata/DarlingData/releases/download/dev-latest/DarlingData.sql
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - '**/*.sql'
+      - '.github/workflows/dev-installall-artifact.yml'
+permissions:
+  contents: write
+jobs:
+  publish-dev-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compile SQL File
+        shell: pwsh
+        run: |
+          cd Install-All
+          ./Merge-All.ps1
+
+      - name: Point the dev-latest tag at this commit
+        run: |
+          git config user.name 'Darling Data'
+          git config user.email 'erik@erikdarling.com'
+          git tag -f dev-latest
+          git push -f origin dev-latest
+
+      - name: Publish as rolling prerelease asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view dev-latest --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create dev-latest \
+              --repo "$GITHUB_REPOSITORY" \
+              --prerelease \
+              --title "Dev build (rolling)" \
+              --notes "Automatically compiled Install-All from the latest dev push. Not a release: main's tagged releases remain the supported builds."
+          fi
+          gh release upload dev-latest Install-All/DarlingData.sql \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/sp_QuickieStore/README.md
+++ b/sp_QuickieStore/README.md
@@ -127,7 +127,11 @@ EXECUTE dbo.sp_QuickieStore
 
 -- Find parameter sensitive plan shapes: same plan, wildly different runtimes.
 -- Results are one row per query_hash + query_plan_hash, ranked by how
--- volatile the @sort_order metric is (coefficient of variation)
+-- volatile the @sort_order metric is (coefficient of variation), weighted
+-- by the log of the shape's total work so trivial-cost queries with big
+-- relative swings don't crowd out expensive ones. The hash-based
+-- include/ignore lists are honored, so recurring noise (maintenance
+-- queries, known offenders) can be filtered out
 EXECUTE dbo.sp_QuickieStore
     @find_parameter_sensitive = 1;
 

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -99,7 +99,7 @@ ALTER PROCEDURE
     @regression_baseline_end_date datetimeoffset(7) = NULL, /*the end date of the baseline that you are checking for regressions against (if any), will be converted to UTC internally*/
     @regression_comparator varchar(20) = NULL, /*what difference to use ('relative' or 'absolute') when comparing @sort_order's metric for the normal time period with the regression time period.*/
     @regression_direction varchar(20) = NULL, /*when comparing against the regression baseline, what do you want the results sorted by ('magnitude', 'improved', or 'regressed')?*/
-    @include_query_hash_totals bit = 0, /*will add an additional column to final output with total resource usage by query hash, may be skewed by query_hash and query_plan_hash bugs with forced plans/plan guides*/
+    @include_query_hash_totals bit = 0, /*will add additional columns to final output with total resource usage by query hash within the requested date window, may be skewed by query_hash and query_plan_hash bugs with forced plans/plan guides*/
     @include_maintenance bit = 0, /*Set this bit to 1 to add maintenance operations such as index creation to the result set*/
     @find_high_impact bit = 0, /*finds the vital few queries consuming disproportionate resources across cpu, duration, reads, writes, memory, and executions*/
     @primary_window nvarchar(20) = NULL, /*with @find_high_impact, restricts results to queries whose majority activity is in this window: business, off-hours, or weekend*/
@@ -203,7 +203,7 @@ BEGIN
                 WHEN N'@regression_baseline_end_date' THEN 'the end date of the baseline that you are checking for regressions against (if any), will be converted to UTC internally'
                 WHEN N'@regression_comparator' THEN 'what difference to use (''relative'' or ''absolute'') when comparing @sort_order''s metric for the normal time period with any regression time period.'
                 WHEN N'@regression_direction' THEN 'when comparing against any regression baseline, what do you want the results sorted by (''magnitude'', ''improved'', or ''regressed'')?'
-                WHEN N'@include_query_hash_totals' THEN N'will add an additional column to final output with total resource usage by query hash, may be skewed by query_hash and query_plan_hash bugs with forced plans/plan guides'
+                WHEN N'@include_query_hash_totals' THEN N'will add additional columns to final output with total resource usage by query hash within the requested date window, may be skewed by query_hash and query_plan_hash bugs with forced plans/plan guides'
                 WHEN N'@include_maintenance' THEN N'Set this bit to 1 to add maintenance operations such as index creation to the result set'
                 WHEN N'@find_high_impact' THEN N'finds the vital few queries consuming disproportionate resources across cpu, duration, reads, writes, memory, and executions'
                 WHEN N'@primary_window' THEN N'with @find_high_impact, restricts results to queries whose majority activity is in this window (business, off-hours, or weekend)'
@@ -419,8 +419,14 @@ BEGIN
         high_impact_columns =
            'when using @find_high_impact = 1, the result set contains these columns:' UNION ALL
     SELECT REPLICATE('-', 100) UNION ALL
-    SELECT 'this mode honors @top, @sort_order (as a tiebreak), @work_start/@work_end, and @primary_window; the other' UNION ALL
-    SELECT '    filter parameters (@procedure_name, @query_text_search, include/ignore lists, etc.) do not apply here.' UNION ALL
+    SELECT 'this mode honors @top, @sort_order (as a tiebreak), @work_start/@work_end, @primary_window, and the' UNION ALL
+    SELECT '    query-hash include/ignore lists (@include_query_hashes, @ignore_query_hashes), which filter before' UNION ALL
+    SELECT '    the top-N picks so filtered-out hashes do not consume slots. Shares and percentiles are still' UNION ALL
+    SELECT '    computed over the FULL workload: ignoring a query does not change what percent of the server' UNION ALL
+    SELECT '    another query consumed. Results here are query_hash-grained, so the plan-hash lists and the other' UNION ALL
+    SELECT '    filter parameters do not apply.' UNION ALL
+    SELECT '    @top is per resource dimension (top N by cpu, by duration, by reads, etc., unioned), so the result' UNION ALL
+    SELECT '    set typically contains several times @top rows.' UNION ALL
     SELECT REPLICATE('-', 100) UNION ALL
     SELECT 'database_name: the database being analyzed' UNION ALL
     SELECT 'start_date, end_date: the time window analyzed (UTC)' UNION ALL
@@ -447,6 +453,9 @@ BEGIN
     SELECT 'cpu_share, duration_share, physical_reads_share, writes_share, memory_share, executions_share:' UNION ALL
     SELECT '    what percentage of the server''s total for that metric this single query_hash consumed.' UNION ALL
     SELECT '    This is the 80/20 answer: "this one query is X% of all CPU on the server."' UNION ALL
+    SELECT 'total_cpu_ms, total_duration_ms, total_physical_reads_mb, total_writes_mb, total_memory_mb,' UNION ALL
+    SELECT '    total_tempdb_mb, total_rows, max_dop: absolute window totals, so a big share on a quiet server' UNION ALL
+    SELECT '    is not mistaken for a big number. Shares answer "how dominant"; these answer "how much".' UNION ALL
     SELECT 'resource_metrics: clickable XML rollup of total/avg/min/max for cpu, duration, physical reads, writes, memory,' UNION ALL
     SELECT '    tempdb, executions, rows, and max DOP. Click the column in SSMS to see the full breakdown.' UNION ALL
     SELECT REPLICATE('-', 100) UNION ALL
@@ -457,7 +466,7 @@ BEGIN
     SELECT '        Classic parameter sniffing: one plan shape that works for some parameter values but not others.' UNION ALL
     SELECT '    plan instability (N plans) - multiple plans with fewer than 5 executions per plan, excluding RECOMPILE hints.' UNION ALL
     SELECT '        The optimizer keeps recompiling frequently, which usually means inconsistent performance.' UNION ALL
-    SELECT '    spills/spools (N MB/exec) - writes detected on a SELECT-like query (no INSERT/UPDATE/DELETE/MERGE).' UNION ALL
+    SELECT '    spills/spools (N MB/exec) - at least 1 MB/exec of writes on a SELECT-like query (no INSERT/UPDATE/DELETE/MERGE).' UNION ALL
     SELECT '        This typically means tempdb spills from underestimated memory grants, or worktable spools.' UNION ALL
     SELECT REPLICATE('-', 100) UNION ALL
     SELECT 'volatile_metrics: flags metrics with extreme variance: (max - min) / avg > 10x.' UNION ALL
@@ -5039,6 +5048,69 @@ BEGIN
         max_dop bigint NULL
     );
 
+    CREATE TABLE
+        #hi_eligible
+    (
+        query_hash binary(8) NOT NULL
+            PRIMARY KEY CLUSTERED
+    );
+
+    /*
+    The query-hash include and ignore lists apply in this mode (results
+    are query_hash-grained, so the plan-hash lists do not). They are
+    parsed locally with the same splitter (the main filter-processing
+    section is never reached from here: this mode returns at the end of
+    its block). The lists gate which hashes are ELIGIBLE for the top-N
+    picks in step 2 — before the TOP, so a filtered-out hash does not
+    consume a slot. Shares and percentiles in step 3 are still computed
+    over the full workload on purpose: ignoring a query must not change
+    what percent of the server another query consumed.
+    */
+    IF
+    (
+       @include_query_hashes IS NOT NULL
+    OR @ignore_query_hashes  IS NOT NULL
+    )
+    BEGIN
+        SELECT
+            @include_query_hashes =
+                REPLACE(REPLACE(REPLACE(REPLACE(
+                LTRIM(RTRIM(@include_query_hashes)),
+                CHAR(10), N''), CHAR(13), N''),
+                NCHAR(10), N''), NCHAR(13), N''),
+            @ignore_query_hashes =
+                REPLACE(REPLACE(REPLACE(REPLACE(
+                LTRIM(RTRIM(@ignore_query_hashes)),
+                CHAR(10), N''), CHAR(13), N''),
+                NCHAR(10), N''), NCHAR(13), N'');
+
+        IF @include_query_hashes IS NOT NULL
+        BEGIN
+            INSERT
+                #include_query_hashes WITH (TABLOCK)
+            (
+                query_hash_s
+            )
+            EXECUTE sys.sp_executesql
+                @string_split_strings,
+              N'@ids nvarchar(4000)',
+                @include_query_hashes;
+        END;
+
+        IF @ignore_query_hashes IS NOT NULL
+        BEGIN
+            INSERT
+                #ignore_query_hashes WITH (TABLOCK)
+            (
+                query_hash_s
+            )
+            EXECUTE sys.sp_executesql
+                @string_split_strings,
+              N'@ids nvarchar(4000)',
+                @ignore_query_hashes;
+        END;
+    END;
+
     /*Step 1a: Stage interval IDs for the time window*/
     CREATE TABLE
         #hi_intervals
@@ -5383,6 +5455,43 @@ OPTION(RECOMPILE);' + @nc10;
             @current_table;
     END;
 
+    /*
+    Stage the hashes eligible for the top-N picks. With no lists set this
+    is every hash; the include/ignore lists narrow it here, before the
+    TOP picks, so a filtered-out hash never consumes a slot.
+    */
+    INSERT
+        #hi_eligible WITH (TABLOCK)
+    (
+        query_hash
+    )
+    SELECT
+        qs.query_hash
+    FROM #hi_query_stats AS qs
+    WHERE
+    (
+        NOT EXISTS
+        (
+            SELECT
+                1/0
+            FROM #include_query_hashes AS iqh
+        )
+     OR EXISTS
+        (
+            SELECT
+                1/0
+            FROM #include_query_hashes AS iqh
+            WHERE iqh.query_hash = qs.query_hash
+        )
+    )
+    AND NOT EXISTS
+    (
+        SELECT
+            1/0
+        FROM #ignore_query_hashes AS igh
+        WHERE igh.query_hash = qs.query_hash
+    );
+
     /*Step 2: Top N per metric (static SQL, temp tables only)*/
     INSERT
         #hi_interesting WITH (TABLOCK)
@@ -5396,6 +5505,13 @@ OPTION(RECOMPILE);' + @nc10;
         SELECT TOP (@top)
             qs.query_hash
         FROM #hi_query_stats AS qs
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_cpu_ms DESC
 
         UNION
@@ -5403,6 +5519,13 @@ OPTION(RECOMPILE);' + @nc10;
         SELECT TOP (@top)
             qs.query_hash
         FROM #hi_query_stats AS qs
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_duration_ms DESC
 
         UNION
@@ -5410,6 +5533,13 @@ OPTION(RECOMPILE);' + @nc10;
         SELECT TOP (@top)
             qs.query_hash
         FROM #hi_query_stats AS qs
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_physical_reads_mb DESC
 
         UNION
@@ -5417,6 +5547,13 @@ OPTION(RECOMPILE);' + @nc10;
         SELECT TOP (@top)
             qs.query_hash
         FROM #hi_query_stats AS qs
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_writes_mb DESC
 
         UNION
@@ -5424,6 +5561,13 @@ OPTION(RECOMPILE);' + @nc10;
         SELECT TOP (@top)
             qs.query_hash
         FROM #hi_query_stats AS qs
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_memory_mb DESC
 
         UNION
@@ -5431,6 +5575,13 @@ OPTION(RECOMPILE);' + @nc10;
         SELECT TOP (@top)
             qs.query_hash
         FROM #hi_query_stats AS qs
+        WHERE EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_executions DESC
 
         UNION
@@ -5439,6 +5590,13 @@ OPTION(RECOMPILE);' + @nc10;
             qs.query_hash
         FROM #hi_query_stats AS qs
         WHERE qs.total_tempdb_mb > 0
+        AND   EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_tempdb_mb DESC
 
         UNION
@@ -5447,6 +5605,13 @@ OPTION(RECOMPILE);' + @nc10;
             qs.query_hash
         FROM #hi_query_stats AS qs
         WHERE qs.total_rows > 0
+        AND   EXISTS
+        (
+            SELECT
+                1/0
+            FROM #hi_eligible AS e
+            WHERE e.query_hash = qs.query_hash
+        )
         ORDER BY qs.total_rows DESC
     ) AS qs;
 
@@ -6552,7 +6717,12 @@ OPTION(RECOMPILE);' + @nc10;
                 (
                     N' | ' +
                     CASE
-                        WHEN s.total_writes_mb > 0
+                        /*
+                        The per-exec floor keeps this from firing as
+                        "spills/spools (0.0 MB/exec)" when a huge execution
+                        count carries a few stray KB of writes.
+                        */
+                        WHEN s.total_writes_mb / NULLIF(s.total_executions, 0) >= 1
                          AND rt.query_sql_text NOT LIKE N'%INSERT%'
                          AND rt.query_sql_text NOT LIKE N'%UPDATE%'
                          AND rt.query_sql_text NOT LIKE N'%DELETE%'
@@ -6937,6 +7107,14 @@ SELECT
     o.executions_share,
     o.tempdb_share,
     o.rows_share,
+    o.total_cpu_ms,
+    o.total_duration_ms,
+    o.total_physical_reads_mb,
+    o.total_writes_mb,
+    o.total_memory_mb,
+    o.total_tempdb_mb,
+    o.total_rows,
+    o.max_dop,
     o.diagnostics,
     o.volatile_metrics,
     o.resource_metrics
@@ -12618,6 +12796,15 @@ BEGIN
         FROM #query_store_query AS qsq2
         WHERE qsq2.query_hash = qsq.query_hash
     )
+    /*
+    Without the date restriction these totals sum every runtime stats row
+    in Query Store history for the hash, which sits next to window-scoped
+    columns in the same output row and inflates by however long Query
+    Store retention is. Matches the date semantics of the main where
+    clause and the wait sort order joins.
+    */
+    AND qsrs.last_execution_time >= @start_date
+    AND qsrs.last_execution_time < @end_date
     GROUP BY
         qsq.query_hash
     OPTION(RECOMPILE);
@@ -12651,8 +12838,12 @@ BEGIN
     )
     EXECUTE sys.sp_executesql
         @sql,
-      N'@database_id integer',
-        @database_id;
+      N'@database_id integer,
+        @start_date datetimeoffset(7),
+        @end_date datetimeoffset(7)',
+        @database_id,
+        @start_date,
+        @end_date;
 
     IF @troubleshoot_performance = 1
     BEGIN

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -490,8 +490,10 @@ BEGIN
     SELECT '    so recompiles of the same plan are analyzed together. Wild metric swings within one shape mean' UNION ALL
     SELECT '    the same plan is fast for some parameter values and slow for others: classic parameter sensitivity.' UNION ALL
     SELECT '    Only regular executions feed the statistics; aborted and exception executions are counted separately.' UNION ALL
-    SELECT '    This mode honors @top, @sort_order, @execution_count, and @duration_ms; the other filter' UNION ALL
-    SELECT '    parameters (@procedure_name, @query_text_search, include/ignore lists, etc.) do not apply here.' UNION ALL
+    SELECT '    This mode honors @top, @sort_order, @execution_count, @duration_ms, and the hash-based' UNION ALL
+    SELECT '    include/ignore lists (@include_query_hashes, @ignore_query_hashes, @include_plan_hashes,' UNION ALL
+    SELECT '    @ignore_plan_hashes), which filter shapes before the top-N cut. The other filter parameters' UNION ALL
+    SELECT '    (@procedure_name, @query_text_search, the id-based lists, etc.) do not apply here.' UNION ALL
     SELECT REPLICATE('-', 100) UNION ALL
     SELECT 'database_name: the database being analyzed' UNION ALL
     SELECT 'start_date, end_date: the time window analyzed' UNION ALL
@@ -507,15 +509,22 @@ BEGIN
     SELECT 'query_id_list, plan_id_list: comma-separated IDs for drilling into Query Store views' UNION ALL
     SELECT REPLICATE('-', 100) UNION ALL
     SELECT 'ranked_on, volatility_score: results are ranked by the coefficient of variation (stdev / average) of the' UNION ALL
-    SELECT '    @sort_order metric (cpu, duration, physical reads, writes, memory, rows, tempdb; anything else = cpu).' UNION ALL
-    SELECT '    The stdev is properly combined across runtime stat intervals, weighted by executions, so one weird' UNION ALL
-    SELECT '    interval does not dominate. 0 = perfectly stable, 1 = the stdev equals the average, bigger = wilder.' UNION ALL
+    SELECT '    @sort_order metric (cpu, duration, physical reads, writes, memory, rows, tempdb; anything else = cpu),' UNION ALL
+    SELECT '    multiplied by the log of the total work the shape did in the window for that metric. Volatility alone' UNION ALL
+    SELECT '    is scale-blind (a 3ms query that sometimes hits 60ms would outrank a 2 second query that sometimes' UNION ALL
+    SELECT '    hits 40 seconds), so a shape has to be both volatile and expensive to rank highly.' UNION ALL
+    SELECT '    volatility_score is the raw coefficient of variation: the stdev is properly combined across runtime' UNION ALL
+    SELECT '    stat intervals, weighted by executions, so one weird interval does not dominate.' UNION ALL
+    SELECT '    0 = perfectly stable, 1 = the stdev equals the average, bigger = wilder.' UNION ALL
     SELECT 'signals: rule-based reads on the swings. Nx means max is N times min for that metric' UNION ALL
-    SELECT '    (tiny mins are floored at 0.001 ms / 1 row first, so extreme ratios are lower bounds):' UNION ALL
+    SELECT '    (tiny mins are floored at 0.001 ms / 1 row first, so extreme ratios are lower bounds; displayed' UNION ALL
+    SELECT '    ratios cap at 9999+, and "rows flat" means the shape never returned a row):' UNION ALL
     SELECT '    parameter sensitive (cpu Nx, rows Nx) - big cpu swings while rows barely move. The plan does wildly' UNION ALL
     SELECT '        different amounts of work for similar-sized results: the strongest sniffing signal.' UNION ALL
     SELECT '    row driven (cpu Nx, rows Nx) - cpu swings track row count swings. Work scales with honest data volume,' UNION ALL
     SELECT '        so this is probably not a parameter sensitivity problem.' UNION ALL
+    SELECT '    mixed swings (cpu Nx, rows Nx) - cpu moves more than the row count swings alone explain, but not' UNION ALL
+    SELECT '        decisively; look for parameter sensitivity layered on top of honest data-volume variance.' UNION ALL
     SELECT '    intermittent waits (duration Nx, cpu Nx) - duration swings without cpu swings: blocking, grants, or I/O,' UNION ALL
     SELECT '        not parameter sensitivity. Check top_waits.' UNION ALL
     SELECT '    memory grant swings (Nx) / tempdb swings (Nx) - grant or spill behavior varies between executions.' UNION ALL
@@ -538,9 +547,10 @@ BEGIN
     SELECT 'SHAPE VOLATILITY SUMMARY (separate result set, returned before the query details):' UNION ALL
     SELECT 'total_shapes: how many plan shapes had regular executions in the time window' UNION ALL
     SELECT 'shapes_past_floors: how many cleared the noise floors (executions and minimum cpu/duration)' UNION ALL
-    SELECT 'surfaced_shapes: how many made it into the detail result set after top-N ranking' UNION ALL
+    SELECT 'surfaced_shapes: how many made it into the detail result set after hash filters and top-N ranking' UNION ALL
     SELECT 'multi_shape_query_hashes: how many query_hashes compiled to more than one plan shape in the window' UNION ALL
-    SELECT 'ranked_on: which metric''s volatility ranked the results, from @sort_order';
+    SELECT 'wait_stats: whether the per-shape top_waits column is available, and why not when it is not' UNION ALL
+    SELECT 'ranked_on: which metric''s volatility ranked the results, from @sort_order (work-weighted)';
 
     /*
     Limitations
@@ -858,7 +868,10 @@ END;
 /*
 @find_parameter_sensitive is a takeover mode like @find_high_impact,
 so the two of them can't be combined, and it can't be combined with
-the things @find_high_impact can't be combined with either
+the things @find_high_impact can't be combined with either.
+The hash-based include and ignore lists are honored in this mode
+(shapes are keyed by query_hash + query_plan_hash); the id-based
+lists and text filters are not
 */
 IF
 (
@@ -7215,6 +7228,7 @@ BEGIN
         rows_volatility decimal(19, 4) NULL,
         last_execution_time datetimeoffset(7) NULL,
         variance_metrics xml NULL,
+        sort_value float NULL,
         PRIMARY KEY CLUSTERED
             (query_hash, query_plan_hash)
     );
@@ -7242,6 +7256,97 @@ BEGIN
                 THEN @sort_order
                 ELSE N'cpu'
             END;
+
+    /*
+    The hash-based include and ignore lists apply in this mode, because
+    plan shapes are keyed by the same columns (query_hash + query_plan_hash).
+    The main filter-processing section is never reached from here (this mode
+    returns at the end of its block), so the lists are parsed locally with
+    the same splitter. The id-based lists and text filters do not apply:
+    shapes aggregate across query and plan ids.
+    */
+    IF
+    (
+       @include_query_hashes IS NOT NULL
+    OR @ignore_query_hashes  IS NOT NULL
+    OR @include_plan_hashes  IS NOT NULL
+    OR @ignore_plan_hashes   IS NOT NULL
+    )
+    BEGIN
+        SELECT
+            @include_query_hashes =
+                REPLACE(REPLACE(REPLACE(REPLACE(
+                LTRIM(RTRIM(@include_query_hashes)),
+                CHAR(10), N''), CHAR(13), N''),
+                NCHAR(10), N''), NCHAR(13), N''),
+            @ignore_query_hashes =
+                REPLACE(REPLACE(REPLACE(REPLACE(
+                LTRIM(RTRIM(@ignore_query_hashes)),
+                CHAR(10), N''), CHAR(13), N''),
+                NCHAR(10), N''), NCHAR(13), N''),
+            @include_plan_hashes =
+                REPLACE(REPLACE(REPLACE(REPLACE(
+                LTRIM(RTRIM(@include_plan_hashes)),
+                CHAR(10), N''), CHAR(13), N''),
+                NCHAR(10), N''), NCHAR(13), N''),
+            @ignore_plan_hashes =
+                REPLACE(REPLACE(REPLACE(REPLACE(
+                LTRIM(RTRIM(@ignore_plan_hashes)),
+                CHAR(10), N''), CHAR(13), N''),
+                NCHAR(10), N''), NCHAR(13), N'');
+
+        IF @include_query_hashes IS NOT NULL
+        BEGIN
+            INSERT
+                #include_query_hashes WITH (TABLOCK)
+            (
+                query_hash_s
+            )
+            EXECUTE sys.sp_executesql
+                @string_split_strings,
+              N'@ids nvarchar(4000)',
+                @include_query_hashes;
+        END;
+
+        IF @ignore_query_hashes IS NOT NULL
+        BEGIN
+            INSERT
+                #ignore_query_hashes WITH (TABLOCK)
+            (
+                query_hash_s
+            )
+            EXECUTE sys.sp_executesql
+                @string_split_strings,
+              N'@ids nvarchar(4000)',
+                @ignore_query_hashes;
+        END;
+
+        IF @include_plan_hashes IS NOT NULL
+        BEGIN
+            INSERT
+                #include_plan_hashes WITH (TABLOCK)
+            (
+                plan_hash_s
+            )
+            EXECUTE sys.sp_executesql
+                @string_split_strings,
+              N'@ids nvarchar(4000)',
+                @include_plan_hashes;
+        END;
+
+        IF @ignore_plan_hashes IS NOT NULL
+        BEGIN
+            INSERT
+                #ignore_plan_hashes WITH (TABLOCK)
+            (
+                plan_hash_s
+            )
+            EXECUTE sys.sp_executesql
+                @string_split_strings,
+              N'@ids nvarchar(4000)',
+                @ignore_plan_hashes;
+        END;
+    END;
 
     /*Step 1a: Stage interval IDs for the time window*/
     SELECT
@@ -7689,10 +7794,17 @@ OPTION(RECOMPILE, HASH JOIN);' + @nc10;
         ps.query_hash;
 
     /*
-    Step 3: Pick the top N shapes by volatility of the ranking metric.
+    Step 3: Pick the top N shapes by the volatility of the ranking metric,
+    weighted by the log of the total work the shape did in the window.
+    The coefficient of variation alone is scale-blind: a 3ms query that
+    sometimes hits 60ms would outrank a 2 second query that sometimes hits
+    40 seconds. On a quiet system where every shape is tiny the weight is
+    nearly uniform and ranking stays effectively pure volatility; on a busy
+    system a shape has to be both volatile and expensive to make the cut.
     The noise floors keep trivia out: a shape must have enough executions
     for variance to mean anything, and must have done a measurable amount
     of work at least once. @duration_ms takes over the work floor when set.
+    The hash-based include and ignore lists filter here, before the top-N.
     */
     INSERT
         #ps_interesting WITH (TABLOCK)
@@ -7721,6 +7833,52 @@ OPTION(RECOMPILE, HASH JOIN);' + @nc10;
             )
         )
     )
+    AND
+    (
+        NOT EXISTS
+        (
+            SELECT
+                1/0
+            FROM #include_query_hashes AS iqh
+        )
+     OR EXISTS
+        (
+            SELECT
+                1/0
+            FROM #include_query_hashes AS iqh
+            WHERE iqh.query_hash = ps.query_hash
+        )
+    )
+    AND
+    (
+        NOT EXISTS
+        (
+            SELECT
+                1/0
+            FROM #include_plan_hashes AS iph
+        )
+     OR EXISTS
+        (
+            SELECT
+                1/0
+            FROM #include_plan_hashes AS iph
+            WHERE iph.plan_hash = ps.query_plan_hash
+        )
+    )
+    AND NOT EXISTS
+    (
+        SELECT
+            1/0
+        FROM #ignore_query_hashes AS igh
+        WHERE igh.query_hash = ps.query_hash
+    )
+    AND NOT EXISTS
+    (
+        SELECT
+            1/0
+        FROM #ignore_plan_hashes AS igp
+        WHERE igp.plan_hash = ps.query_plan_hash
+    )
     ORDER BY
         CASE @ps_rank_metric
             WHEN N'duration' THEN ps.duration_volatility
@@ -7730,7 +7888,24 @@ OPTION(RECOMPILE, HASH JOIN);' + @nc10;
             WHEN N'rows' THEN ps.rows_volatility
             WHEN N'tempdb' THEN ps.tempdb_volatility
             ELSE ps.cpu_volatility
-        END DESC,
+        END *
+        LOG10
+        (
+            10. +
+            ISNULL
+            (
+                CASE @ps_rank_metric
+                    WHEN N'duration' THEN ps.total_duration_ms
+                    WHEN N'physical reads' THEN ps.avg_physical_reads_mb * ps.total_executions
+                    WHEN N'writes' THEN ps.avg_writes_mb * ps.total_executions
+                    WHEN N'memory' THEN ps.avg_memory_mb * ps.total_executions
+                    WHEN N'rows' THEN ps.avg_rows * ps.total_executions
+                    WHEN N'tempdb' THEN ps.avg_tempdb_mb * ps.total_executions
+                    ELSE ps.total_cpu_ms
+                END,
+                0.
+            )
+        ) DESC,
         ps.total_cpu_ms DESC,
         ps.query_hash,
         ps.query_plan_hash;
@@ -7779,8 +7954,16 @@ OPTION(RECOMPILE, HASH JOIN);' + @nc10;
                 FROM #ps_query_rollup AS qr
                 WHERE qr.shape_count > 1
             ),
+        wait_stats =
+            CASE
+                WHEN @new = 0
+                THEN N'top_waits is not available before SQL Server 2017; the column is omitted'
+                WHEN @query_store_waits_enabled = 0
+                THEN N'query store wait stats capture is off for this database; the top_waits column is omitted'
+                ELSE N'top_waits shows the top 3 wait categories per shape'
+            END,
         ranked_on =
-            @ps_rank_metric + N' volatility';
+            @ps_rank_metric + N' volatility, work-weighted';
 
     /*
     Step 4: Stage query and plan ids for the interesting shapes.
@@ -8315,7 +8498,8 @@ OPTION(RECOMPILE);' + @nc10;
         max_rows,
         rows_volatility,
         last_execution_time,
-        variance_metrics
+        variance_metrics,
+        sort_value
     )
     SELECT
         qi.object_name,
@@ -8335,7 +8519,7 @@ OPTION(RECOMPILE);' + @nc10;
         qi.query_id_list,
         qi.plan_id_list,
         ranked_on =
-            @ps_rank_metric + N' volatility',
+            @ps_rank_metric + N' volatility, work-weighted',
         volatility_score =
             CASE @ps_rank_metric
                 WHEN N'duration' THEN ps.duration_volatility
@@ -8357,10 +8541,20 @@ OPTION(RECOMPILE);' + @nc10;
                          AND ps.max_cpu_ms >= 10
                          AND sw.cpu_ratio >= sw.rows_ratio * 10
                         THEN N'parameter sensitive (cpu ' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.cpu_ratio)) +
+                             CASE
+                                 WHEN sw.cpu_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.cpu_ratio))
+                             END +
                              N'x, rows ' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.rows_ratio)) +
-                             N'x)'
+                             CASE
+                                 WHEN ps.max_rows = 0
+                                 THEN N'flat'
+                                 WHEN sw.rows_ratio > 9999.
+                                 THEN N'9999+x'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.rows_ratio)) + N'x'
+                             END +
+                             N')'
                     END,
                     N''
                 ) +
@@ -8371,9 +8565,45 @@ OPTION(RECOMPILE);' + @nc10;
                         WHEN sw.rows_ratio >= 20
                          AND sw.cpu_ratio <= sw.rows_ratio * 2
                         THEN N'row driven (cpu ' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.cpu_ratio)) +
+                             CASE
+                                 WHEN sw.cpu_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.cpu_ratio))
+                             END +
                              N'x, rows ' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.rows_ratio)) +
+                             CASE
+                                 WHEN sw.rows_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.rows_ratio))
+                             END +
+                             N'x)'
+                    END,
+                    N''
+                ) +
+                ISNULL
+                (
+                    N' | ' +
+                    CASE
+                        WHEN sw.cpu_ratio >= 20
+                         AND ps.max_cpu_ms >= 10
+                         AND sw.cpu_ratio < sw.rows_ratio * 10
+                         AND
+                         (
+                              sw.rows_ratio < 20
+                           OR sw.cpu_ratio > sw.rows_ratio * 2
+                         )
+                        THEN N'mixed swings (cpu ' +
+                             CASE
+                                 WHEN sw.cpu_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.cpu_ratio))
+                             END +
+                             N'x, rows ' +
+                             CASE
+                                 WHEN sw.rows_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.rows_ratio))
+                             END +
                              N'x)'
                     END,
                     N''
@@ -8386,7 +8616,11 @@ OPTION(RECOMPILE);' + @nc10;
                          AND ps.max_duration_ms >= 1000
                          AND sw.cpu_ratio < 3
                         THEN N'intermittent waits (duration ' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.duration_ratio)) +
+                             CASE
+                                 WHEN sw.duration_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.duration_ratio))
+                             END +
                              N'x, cpu ' +
                              CONVERT(nvarchar(20), CONVERT(decimal(5, 1), sw.cpu_ratio)) +
                              N'x)'
@@ -8400,7 +8634,11 @@ OPTION(RECOMPILE);' + @nc10;
                         WHEN sw.memory_ratio >= 10
                          AND ps.max_memory_mb >= 8
                         THEN N'memory grant swings (' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.memory_ratio)) +
+                             CASE
+                                 WHEN sw.memory_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.memory_ratio))
+                             END +
                              N'x)'
                     END,
                     N''
@@ -8412,7 +8650,11 @@ OPTION(RECOMPILE);' + @nc10;
                         WHEN sw.tempdb_ratio >= 10
                          AND ps.max_tempdb_mb >= 8
                         THEN N'tempdb swings (' +
-                             CONVERT(nvarchar(20), CONVERT(bigint, sw.tempdb_ratio)) +
+                             CASE
+                                 WHEN sw.tempdb_ratio > 9999.
+                                 THEN N'9999+'
+                                 ELSE CONVERT(nvarchar(20), CONVERT(bigint, sw.tempdb_ratio))
+                             END +
                              N'x)'
                     END,
                     N''
@@ -8507,7 +8749,39 @@ OPTION(RECOMPILE);' + @nc10;
                 XML
                 PATH(N'metrics'),
                 TYPE
-        )
+        ),
+        /*
+        The same work-weighted volatility expression that picked the top-N
+        in step 3, kept so the final result set presents in rank order.
+        volatility_score stays the raw coefficient of variation.
+        */
+        sort_value =
+            CASE @ps_rank_metric
+                WHEN N'duration' THEN ps.duration_volatility
+                WHEN N'physical reads' THEN ps.physical_reads_volatility
+                WHEN N'writes' THEN ps.writes_volatility
+                WHEN N'memory' THEN ps.memory_volatility
+                WHEN N'rows' THEN ps.rows_volatility
+                WHEN N'tempdb' THEN ps.tempdb_volatility
+                ELSE ps.cpu_volatility
+            END *
+            LOG10
+            (
+                10. +
+                ISNULL
+                (
+                    CASE @ps_rank_metric
+                        WHEN N'duration' THEN ps.total_duration_ms
+                        WHEN N'physical reads' THEN ps.avg_physical_reads_mb * ps.total_executions
+                        WHEN N'writes' THEN ps.avg_writes_mb * ps.total_executions
+                        WHEN N'memory' THEN ps.avg_memory_mb * ps.total_executions
+                        WHEN N'rows' THEN ps.avg_rows * ps.total_executions
+                        WHEN N'tempdb' THEN ps.avg_tempdb_mb * ps.total_executions
+                        ELSE ps.total_cpu_ms
+                    END,
+                    0.
+                )
+            )
     FROM #ps_shape_stats AS ps
     JOIN #ps_interesting AS i
         ON  i.query_hash = ps.query_hash
@@ -8700,7 +8974,7 @@ OUTER APPLY
     WHERE qp0.n = 1
 ) AS qp
 ORDER BY
-    o.volatility_score DESC,
+    o.sort_value DESC,
     o.query_hash,
     o.query_plan_hash
 OPTION(RECOMPILE);' + @nc10;

--- a/sp_QuickieStore/tests/README.md
+++ b/sp_QuickieStore/tests/README.md
@@ -32,7 +32,10 @@ each run *executes* what it built:
 - The **`@expert_mode` x `@format_output` grid**, which rewrites the column list,
   plus several sort orders combined with expert mode.
 - **`@find_parameter_sensitive`**, the plan-shape volatility mode: ranking by
-  each volatility metric, the mode grids, floors, mode-conflict guard errors,
+  each volatility metric (work-weighted), the mode grids, floors,
+  mode-conflict guard errors, the hash-based include/ignore lists filtering
+  shapes bidirectionally (ignore removes the sniffed shape's hash from the
+  detail rows, include keeps only it, a hash nobody has returns zero shapes),
   and a fixture procedure (`qs_sniff_proc`) skewed hard enough that the
   `parameter sensitive` signal must fire on a real conviction.
 

--- a/sp_QuickieStore/tests/run_tests.py
+++ b/sp_QuickieStore/tests/run_tests.py
@@ -415,6 +415,99 @@ def bidirectional_tests(server, password, R):
 
 PS_SUMMARY_MARKER = "multi_shape_query_hashes"
 
+HI_SUMMARY_MARKER = "workload_profile"
+
+
+def hash_totals_tests(server, password, R):
+    """@include_query_hash_totals adds *_by_query_hash columns whose totals
+    are scoped to the requested date window (they used to sum all of Query
+    Store history, which sat next to window-scoped columns in the same row)."""
+    out, combined = run_qs(server, password, ", @include_query_hash_totals = 1")
+    errs = find_sql_errors(combined)
+    R.check("HashTotals", "@include_query_hash_totals executes cleanly",
+            not errs and completed(out), str(errs[:2]))
+    R.check("HashTotals", "by_query_hash columns are in the output",
+            "count_executions_by_query_hash" in out
+            and "total_cpu_time_ms_by_query_hash" in out,
+            "by_query_hash columns missing")
+
+    # Window scoping: a window that predates the fixture workload returns no
+    # rows at all, so the totals cannot be sourcing outside the window.
+    out, combined = run_qs(server, password,
+                           ", @include_query_hash_totals = 1, "
+                           "@start_date = '2001-01-01', @end_date = '2001-01-02'")
+    errs = find_sql_errors(combined)
+    R.check("HashTotals",
+            "empty window with hash totals completes cleanly",
+            not errs, str(errs[:2]))
+    R.check("HashTotals", "empty window returns no detail rows",
+            ps_detail_rows(out) == 0, "got %d rows" % ps_detail_rows(out))
+
+
+def hi_detail_rows(stdout):
+    """Detail rows from @find_high_impact output: one per query_hash, each
+    beginning with the analyzed database name."""
+    return sum(1 for line in stdout.splitlines()
+               if line.startswith(TEST_DB + "\t"))
+
+
+def high_impact_tests(server, password, R):
+    """@find_high_impact is the other takeover mode: a workload concentration
+    summary plus one row per query_hash, top-N per resource dimension. These
+    are its first assertions: clean execution, output shape (including the
+    absolute total_* columns), the query-hash include/ignore lists filtering
+    before the top-N picks, and the zero-value spills diagnostic staying
+    quiet."""
+    out, combined = run_qs(server, password, ", @find_high_impact = 1")
+    errs = find_sql_errors(combined)
+    R.check("HighImpact", "default run executes cleanly", not errs, str(errs[:2]))
+    R.check("HighImpact", "default run returns the summary result set",
+            HI_SUMMARY_MARKER in out, "summary header missing")
+    R.check("HighImpact", "default run returns detail rows",
+            hi_detail_rows(out) > 0, "no hashes surfaced from the workload")
+    R.check("HighImpact", "absolute total columns are in the output",
+            "total_cpu_ms" in out and "total_duration_ms" in out,
+            "total_* columns missing")
+    R.check("HighImpact", "spills diagnostic does not fire at 0.0 MB/exec",
+            "(0.0 MB/exec)" not in out, "zero-value spills diagnostic fired")
+
+    # Query-hash include/ignore: extract a surfaced hash (first 0x token in a
+    # detail row is query_hash) and prove both directions on the hash VALUE.
+    line = next((l for l in out.splitlines()
+                 if l.startswith(TEST_DB + "\t") and "0x" in l), "")
+    hashes = re.findall(r"0x[0-9A-Fa-f]{16}", line)
+    R.check("HighImpact", "a surfaced hash is extractable",
+            len(hashes) >= 1, "no hash token found in detail rows")
+    if hashes:
+        query_hash = hashes[0]
+        out, combined = run_qs(server, password,
+                               ", @find_high_impact = 1, "
+                               "@ignore_query_hashes = '%s'" % query_hash)
+        errs = find_sql_errors(combined)
+        R.check("HighImpact", "@ignore_query_hashes executes cleanly",
+                not errs and HI_SUMMARY_MARKER in out, str(errs[:2]))
+        R.check("HighImpact", "@ignore_query_hashes removes the ignored hash",
+                not any(query_hash in l for l in out.splitlines()
+                        if l.startswith(TEST_DB + "\t")),
+                "ignored query_hash still present in detail rows")
+        out, combined = run_qs(server, password,
+                               ", @find_high_impact = 1, "
+                               "@include_query_hashes = '%s'" % query_hash)
+        detail = [l for l in out.splitlines() if l.startswith(TEST_DB + "\t")]
+        R.check("HighImpact", "@include_query_hashes keeps only the included hash",
+                len(detail) >= 1 and all(query_hash in l for l in detail),
+                "got %d detail rows, not all matching the included hash"
+                % len(detail))
+    out, combined = run_qs(server, password,
+                           ", @find_high_impact = 1, "
+                           "@include_query_hashes = '0xDEADBEEFDEADBEEF'")
+    R.check("HighImpact",
+            "@include_query_hashes nobody has: summary still returned "
+            "(positive control for the absence below)",
+            HI_SUMMARY_MARKER in out, "summary header missing")
+    R.check("HighImpact", "@include_query_hashes nobody has returns no hashes",
+            hi_detail_rows(out) == 0, "got %d rows" % hi_detail_rows(out))
+
 
 def ps_detail_rows(stdout):
     """Detail rows from @find_parameter_sensitive output: one per plan shape,
@@ -607,7 +700,9 @@ def main():
             mode_matrix(args.server, args.password, R)
             filter_matrix(args.server, args.password, R)
             bidirectional_tests(args.server, args.password, R)
+            hash_totals_tests(args.server, args.password, R)
             parameter_sensitive_tests(args.server, args.password, R)
+            high_impact_tests(args.server, args.password, R)
     finally:
         out, err = _sqlcmd(args.server, args.password, CLEANUP_SQL)
         R.check("Fixture", "scratch database dropped",

--- a/sp_QuickieStore/tests/run_tests.py
+++ b/sp_QuickieStore/tests/run_tests.py
@@ -479,6 +479,65 @@ def parameter_sensitive_tests(server, password, R):
     R.check("ParamSensitive", "@execution_count impossibly high returns no shapes",
             ps_detail_rows(out) == 0, "got %d rows" % ps_detail_rows(out))
 
+    # The hash-based include/ignore lists are honored in this mode: shapes are
+    # keyed by (query_hash, query_plan_hash), so the lists filter shapes
+    # directly, before the top-N cut. Extract the sniffed shape's query_hash
+    # from a default run's detail row (the first two 0x tokens in a detail row
+    # are query_hash and query_plan_hash), then prove both directions on the
+    # hash VALUE in detail rows -- object names can also appear in other
+    # shapes' query text, hash values cannot.
+    out, combined = run_qs(server, password, ", @find_parameter_sensitive = 1")
+    sniff_line = next((line for line in out.splitlines()
+                       if line.startswith(TEST_DB + "\t")
+                       and "qs_sniff_proc" in line), "")
+    hashes = re.findall(r"0x[0-9A-Fa-f]{16}", sniff_line)
+    R.check("ParamSensitive", "sniffed shape's hashes are extractable",
+            len(hashes) >= 2, "found %d hash tokens" % len(hashes))
+    if len(hashes) >= 2:
+        query_hash = hashes[0]
+        out, combined = run_qs(server, password,
+                               ", @find_parameter_sensitive = 1, "
+                               "@ignore_query_hashes = '%s'" % query_hash)
+        errs = find_sql_errors(combined)
+        R.check("ParamSensitive", "@ignore_query_hashes executes cleanly",
+                not errs and PS_SUMMARY_MARKER in out, str(errs[:2]))
+        R.check("ParamSensitive",
+                "@ignore_query_hashes removes the ignored shape",
+                not any(query_hash in line for line in out.splitlines()
+                        if line.startswith(TEST_DB + "\t")),
+                "ignored query_hash still present in detail rows")
+        out, combined = run_qs(server, password,
+                               ", @find_parameter_sensitive = 1, "
+                               "@include_query_hashes = '%s'" % query_hash)
+        detail = [line for line in out.splitlines()
+                  if line.startswith(TEST_DB + "\t")]
+        R.check("ParamSensitive",
+                "@include_query_hashes keeps only the included shape",
+                len(detail) >= 1
+                and all(query_hash in line for line in detail),
+                "got %d detail rows, not all matching the included hash"
+                % len(detail))
+    out, combined = run_qs(server, password,
+                           ", @find_parameter_sensitive = 1, "
+                           "@include_query_hashes = '0xDEADBEEFDEADBEEF'")
+    R.check("ParamSensitive",
+            "@include_query_hashes nobody has: summary still returned "
+            "(positive control for the absence below)",
+            PS_SUMMARY_MARKER in out, "summary header missing")
+    R.check("ParamSensitive",
+            "@include_query_hashes nobody has returns no shapes",
+            ps_detail_rows(out) == 0, "got %d rows" % ps_detail_rows(out))
+
+    # Ranking is work-weighted volatility; the summary explains top_waits
+    # availability; the internal sort_value column must not leak into output.
+    out, combined = run_qs(server, password, ", @find_parameter_sensitive = 1")
+    R.check("ParamSensitive", "ranked_on says the ranking is work-weighted",
+            "volatility, work-weighted" in out, "work-weighted marker missing")
+    R.check("ParamSensitive", "summary explains top_waits availability",
+            "wait_stats" in out, "wait_stats summary column missing")
+    R.check("ParamSensitive", "internal sort_value column does not leak",
+            "sort_value" not in out, "sort_value column leaked into output")
+
     for extra, what in (
             (", @find_parameter_sensitive = 1, @find_high_impact = 1",
              "@find_high_impact"),


### PR DESCRIPTION
## What

Five changes to `@find_parameter_sensitive`, all driven by dogfooding the mode against an 11-database production fleet (SQL Server 2019/2022 on RDS, Query Store catalogs with 4K–15K plan shapes per 72h window), plus a CI workflow that gives dev a fresh compiled Install-All without recreating the old merge-conflict problem.

### 1. Work-weighted ranking
Coefficient of variation alone is scale-blind: in the fleet run, sub-1s-max-CPU shapes held 91 of 162 top-15 slots because a 3ms→60ms swing out-CoVs a 2s→40s one. Selection and presentation now rank on `volatility * LOG10(10 + total work in the window for the ranked metric)`. On quiet systems the weight is near-uniform (log of tiny totals ≈ 1) so behavior is effectively unchanged; on busy systems a shape must be both volatile and expensive. `volatility_score` still shows the raw CoV; `ranked_on` says `work-weighted` so output describes itself. The internal `sort_value` column stays internal (test asserts it doesn't leak).

**Prod evidence** (same params, same fleet, old vs. patched build side by side): window CPU represented by the surfaced top-15 rose from 295s → 4,170s on one tenant and 829s → 2,884s on another, with only 2–4 swaps per database — the swapped-in shapes included a 3,507 CPU-s parameter-sensitive adhoc (96K execs) and a 2,177 CPU-s shape (461K execs) that pure CoV had ranked below sub-second queries.

### 2. Hash-based include/ignore lists are honored
Shapes are keyed by `query_hash + query_plan_hash`, so `@include_query_hashes` / `@ignore_query_hashes` / `@include_plan_hashes` / `@ignore_plan_hashes` map directly. They're parsed locally in the mode block (the main filter section is never reached from the takeover mode) and filter in step 3, before the top-N cut. Motivation: an index-maintenance frag query occupied a top-15 slot on **11 of 11** production databases in both runs — it's genuinely volatile *and* expensive, so no honest ranking can drop it, and there was previously no way to exclude it. With `@ignore_query_hashes` it disappears on 11/11 (verified live).

### 3. `mixed swings` signal closes the classification gap
`cpu_ratio >= 20` that fails both the parameter-sensitive test (`>= 10x` rows ratio) and the row-driven test (`<= 2x` rows ratio) previously produced no verdict at all — 25 of 162 surfaced shapes in the fleet run had a blank signals column, which reads as "nothing to see" on a row the mode itself just ranked top-15.

### 4. Ratio display caps
Floored mins produced `cpu 2850350x`, which stops carrying information; displays now cap at `9999+`, and shapes that never returned a row read `rows flat` instead of `rows 0x`.

### 5. `wait_stats` column in the shape volatility summary
`top_waits` is silently omitted when wait stats capture is off (or pre-2017) — easy to misread as "no waits" (only 1 of the 11 prod databases had capture on, and the silent omission fooled the harness that found these issues). The summary now says which case applies, verified live on both a capture-on and capture-off database.

### CI: rolling dev Install-All build (separable — happy to drop from this PR)
Install-All is intentionally only regenerated on main because dev rebuilds made every dev→main merge conflict inside the generated 2+ MB file. The new `dev-installall-artifact.yml` compiles it on dev pushes and publishes to a rolling `dev-latest` prerelease asset — nothing is ever committed to the branch, so merges stay clean, and a current dev build is `gh release download dev-latest -p DarlingData.sql` away. Context: the two wait-accounting fixes merged 8/04 weren't in any compiled build, which forced a manual overlay when updating a 54-instance fleet this week.

## Tests

`sp_QuickieStore/tests/run_tests.py`: 157 → **166 passing** (SQL Server 2022 container). New assertions: bidirectional hash include/ignore proof against the sniffed shape's actual `query_hash` value in detail rows, work-weighted `ranked_on` marker, `wait_stats` summary presence, and a `sort_value` no-leak guard.

Harness portability note observed while testing: classic ODBC `sqlcmd` (17.x, macOS homebrew `mssql-tools`) rejects the harness's `-W -y 200` flag pair as mutually exclusive; go-sqlcmd (what CI installs) accepts it. Ran locally with `SQLCMD_BIN` pointed at go-sqlcmd v1.10.0. Left as-is, flagging in case a follow-up portability tweak is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)