### PR TITLE
Updates_20260901 release prep: version bumps

### DIFF
--- a/sp_HealthParser/sp_HealthParser.sql
+++ b/sp_HealthParser/sp_HealthParser.sql
@@ -80,8 +80,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '3.8',
-        @version_date = '20260801';
+        @version = '3.9',
+        @version_date = '20260901';
 
     IF @help = 1
     BEGIN

--- a/sp_HumanEvents/sp_HumanEvents.sql
+++ b/sp_HumanEvents/sp_HumanEvents.sql
@@ -89,8 +89,8 @@ SET XACT_ABORT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '7.8',
-    @version_date = '20260801';
+    @version = '7.9',
+    @version_date = '20260901';
 
 IF @help = 1
 BEGIN

--- a/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
+++ b/sp_HumanEvents/sp_HumanEventsBlockViewer.sql
@@ -94,8 +94,8 @@ SET XACT_ABORT OFF;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
-    @version = '5.8',
-    @version_date = '20260801';
+    @version = '5.9',
+    @version_date = '20260901';
 
 IF @help = 1
 BEGIN

--- a/sp_IndexCleanup/sp_IndexCleanup.sql
+++ b/sp_IndexCleanup/sp_IndexCleanup.sql
@@ -75,8 +75,8 @@ BEGIN
 SET NOCOUNT ON;
 BEGIN TRY
     SELECT
-        @version = '2.8',
-        @version_date = '20260801';
+        @version = '2.9',
+        @version_date = '20260901';
 
     IF
     /* Check SQL Server 2012+ for FORMAT and CONCAT functions */

--- a/sp_LogHunter/sp_LogHunter.sql
+++ b/sp_LogHunter/sp_LogHunter.sql
@@ -73,8 +73,8 @@ SET DATEFORMAT MDY;
 
 BEGIN
     SELECT
-        @version = '3.8',
-        @version_date = '20260801';
+        @version = '3.9',
+        @version_date = '20260901';
 
     IF @help = 1
     BEGIN

--- a/sp_PerfCheck/sp_PerfCheck.sql
+++ b/sp_PerfCheck/sp_PerfCheck.sql
@@ -83,8 +83,8 @@ BEGIN
         Set version information
         */
     SELECT
-        @version = N'2.8',
-        @version_date = N'20260801';
+        @version = N'2.9',
+        @version_date = N'20260901';
 
     /*
     Help section, for help.

--- a/sp_PressureDetector/sp_PressureDetector.sql
+++ b/sp_PressureDetector/sp_PressureDetector.sql
@@ -78,8 +78,8 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SET LANGUAGE us_english;
 
 SELECT
-    @version = '6.8',
-    @version_date = '20260801';
+    @version = '6.9',
+    @version_date = '20260901';
 
 
 IF @help = 1

--- a/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
+++ b/sp_QueryReproBuilder/sp_QueryReproBuilder.sql
@@ -90,8 +90,8 @@ BEGIN TRY
 
 /*Version*/
 SELECT
-    @version = '1.8',
-    @version_date = '20260801';
+    @version = '1.9',
+    @version_date = '20260901';
 
 /*Help*/
 IF @help = 1

--- a/sp_QuickieCache/sp_QuickieCache.sql
+++ b/sp_QuickieCache/sp_QuickieCache.sql
@@ -78,8 +78,8 @@ BEGIN
     SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
     SELECT
-        @version = '1.8',
-        @version_date = '20260801';
+        @version = '1.9',
+        @version_date = '20260901';
 
     /*
     ╔══════════════════════════════════════════════════╗

--- a/sp_QuickieStore/sp_QuickieStore.sql
+++ b/sp_QuickieStore/sp_QuickieStore.sql
@@ -128,8 +128,8 @@ BEGIN TRY
 These are for your outputs.
 */
 SELECT
-    @version = '6.8',
-    @version_date = '20260801';
+    @version = '6.9',
+    @version_date = '20260901';
 
 /*
 Helpful section! For help.


### PR DESCRIPTION
Version bumps for `Updates_20260901`. All ten procs move to `.9`, version date `20260901`.

| Proc | Version |
|---|---|
| sp_HealthParser | 3.9 |
| sp_HumanEvents | 7.9 |
| sp_HumanEventsBlockViewer | 5.9 |
| sp_IndexCleanup | 2.9 |
| sp_LogHunter | 3.9 |
| sp_PerfCheck | 2.9 |
| sp_PressureDetector | 6.9 |
| sp_QueryReproBuilder | 1.9 |
| sp_QuickieCache | 1.9 |
| sp_QuickieStore | 6.9 |

Two lines per file, twenty lines total, nothing else touched. ProtectSession, TestBackupPerformance and sp_QueryStoreCleanup keep their own cadence, as in previous releases.
