### PR TITLE
Add project skills for release prep and T-SQL style review

### DIFF
--- a/.claude/skills/darlingdata-release/SKILL.md
+++ b/.claude/skills/darlingdata-release/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: darlingdata-release
+description: Prepare a DarlingData stored procedure for release with full audit
+argument-hint: [procedure-name-or-file-path]
+disable-model-invocation: false
+---
+
+# DarlingData Release Prep
+
+Prepare a stored procedure for public release by running a comprehensive audit.
+
+Target: `$ARGUMENTS` (procedure name or file path)
+
+## Steps
+
+### 1. Locate the Procedure
+- If a file path is given, read it directly
+- If a procedure name is given, search under the repository root and common locations
+- Read the full source code
+
+### 2. Style Guide Compliance Audit
+Run the full checklist from the review-sql skill:
+- Keywords and functions UPPERCASE
+- Data types lowercase, never abbreviated
+- sysname for object names
+- 4-space indentation
+- Trailing commas
+- Column aliases as `name = expression`
+- Schema prefixes on all non-temp objects
+- Table aliases with AS keyword
+- Block comments only
+- COUNT_BIG, ROWCOUNT_BIG, CONVERT (not CAST)
+- Proper BEGIN TRY/CATCH pattern
+- No MERGE, no explicit temp table drops
+- Semicolons on statements
+
+### 3. SET Options Audit
+Verify the file has proper SET options:
+- `SET ANSI_NULLS ON;` before the procedure
+- `SET QUOTED_IDENTIFIER ON;` before the procedure
+- `SET NOCOUNT ON;` inside the procedure
+- `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;` if appropriate
+- Check for `SET XACT_ABORT ON;` where transactions are used
+
+### 4. Parameter Review
+- All parameters have inline comments describing their purpose
+- Default values are sensible
+- @help and @debug parameters present
+- Parameter validation section exists
+
+### 5. Help Section Review
+- Help section exists and is triggered by `@help = 1`
+- Help text accurately describes the procedure's purpose and parameters
+
+### 6. Error Handling Review
+- BEGIN TRY / BEGIN CATCH present
+- ROLLBACK in CATCH if transactions are used
+- THROW used to re-raise errors
+
+### 7. Dependency Check
+- Verify no external helper functions, procedures, or views are referenced
+- All logic is self-contained within the procedure
+- Only references to system DMVs, catalog views, and standard system procedures
+
+### 8. Version and Header
+- Check for version information
+- Check for copyright/attribution comments
+
+## Output Format
+
+Present as a release readiness report:
+
+1. **Release Readiness**: READY / NOT READY (with blocking issues)
+2. **Issues Found**: Grouped by severity (Blocking / Warning / Suggestion)
+3. **Checklist Summary**: Table showing pass/fail for each audit category
+4. **Recommended Fixes**: Specific changes needed before release, with line numbers
+
+If the procedure is NOT READY, list exactly what needs to change. If it IS READY, confirm it and suggest committing.

--- a/.claude/skills/review-sql/SKILL.md
+++ b/.claude/skills/review-sql/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: review-sql
+description: Review a T-SQL file against Erik Darling's coding style guide
+argument-hint: [file-path]
+disable-model-invocation: false
+allowed-tools: Read, Grep, Glob
+---
+
+# T-SQL Style Review
+
+Review a T-SQL file against the coding conventions defined in CLAUDE.md. This is a **read-only** analysis -- do not modify files.
+
+Read the file at `$ARGUMENTS` and check for violations of every rule below.
+
+## Checklist
+
+### Keywords & Functions
+- [ ] All SQL keywords UPPERCASE (SELECT, FROM, WHERE, JOIN, EXECUTE, TRANSACTION, PROCEDURE)
+- [ ] All SQL functions UPPERCASE (CONVERT, ISNULL, OBJECT_ID, DATEADD, COUNT_BIG)
+- [ ] Never abbreviated keywords (EXECUTE not EXEC, TRANSACTION not TRAN, PROCEDURE not PROC)
+- [ ] TOP always has parentheses: `TOP (100)` not `TOP 100`
+
+### Data Types
+- [ ] All data types lowercase (varchar, nvarchar, datetime2, bigint, integer)
+- [ ] Never abbreviated data types (integer not int)
+- [ ] Length specs lowercase: nvarchar(max) not nvarchar(MAX)
+- [ ] sysname used for SQL Server object names, not nvarchar(128)
+
+### Formatting
+- [ ] 4 spaces for indentation, no tabs
+- [ ] Trailing commas on multi-line column lists
+- [ ] Column aliases use `column_name = expression` pattern (not `expression AS column_name`)
+- [ ] Statements terminated with semicolons
+- [ ] Block comments `/* */` used, not double dash `--`
+- [ ] Single quotes for strings, N-prefix for Unicode (N'string')
+
+### Query Structure
+- [ ] Tables always have aliases, using AS keyword: `FROM dbo.table AS t`
+- [ ] Columns always qualified with table alias
+- [ ] Schema prefix on all objects except temp tables
+- [ ] WHERE conditions with AND aligned: `AND   ` (with spacing)
+- [ ] EXISTS uses `SELECT 1/0` pattern
+- [ ] JOINs use ANSI syntax with ON conditions indented
+- [ ] Subqueries never one-liners
+
+### Best Practices
+- [ ] COUNT_BIG() used instead of COUNT()
+- [ ] ROWCOUNT_BIG() used instead of @@ROWCOUNT
+- [ ] CONVERT used instead of CAST (except TRY_CAST)
+- [ ] IS NULL / IS NOT NULL for null comparisons, never = NULL
+- [ ] No MERGE statements (unless absolutely necessary)
+- [ ] Cursor variables instead of normal cursors
+- [ ] Temp tables preferred over table variables for relational use
+- [ ] Temp tables not explicitly dropped at end of procedures
+- [ ] Date literals in yyyymmdd format
+- [ ] TABLOCK hint on temp table inserts
+
+### Procedure Structure (if applicable)
+- [ ] SET NOCOUNT, XACT_ABORT ON at the top
+- [ ] Parameter validation before main logic
+- [ ] Help section for @help = 1
+- [ ] BEGIN TRY / BEGIN CATCH with proper ROLLBACK pattern
+- [ ] No additional dependency objects (all logic self-contained)
+
+## Output Format
+
+Present findings as:
+
+1. **Summary**: Overall compliance rating (e.g., "12 issues found across 3 categories")
+2. **Issues**: List each violation with:
+   - Line number(s)
+   - What's wrong
+   - What it should be
+3. **Good Practices**: Note anything done particularly well
+
+Group issues by category (Keywords, Data Types, Formatting, Structure, Best Practices). Order by severity within each group.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.vsidx
 *.lock
 .DS_Store
-.claude/
+.claude/*
+!.claude/skills/
 __pycache__/
 *.pyc


### PR DESCRIPTION
## What

Moves `darlingdata-release` and `review-sql` out of the personal `~/.claude/skills` directory into `.claude/skills` so they travel with the repo. Personal skills are machine-local, and cloud sessions do not read them at all, so a skill living only in `~/.claude/skills` is unavailable to every session outside the one machine it was written on.

`.gitignore` goes from `.claude/` to `.claude/*` plus `!.claude/skills/`, which exposes skills and nothing else. `settings.local.json`, `commands/`, `scripts/`, `worktrees/`, and the findings notes stay ignored.

## Portability

- `darlingdata-release` searched under an absolute `C:\GitHub\DarlingData\` path. It now searches from the repository root.
- `review-sql` reads the T-SQL style guide out of `CLAUDE.md`, which is tracked in this repo, so the skill resolves the guide on any clone. Worth noting that this is load-bearing: gitignoring `CLAUDE.md` here would break `review-sql` everywhere except the machine that wrote it.

## Not touched

Neither skill reads or writes `Install-All/DarlingData.sql`. That file stays CI-owned and regenerated on `main`.

## Test plan

- [x] `git check-ignore` confirms `.claude/skills` is tracked while `settings.local.json`, `commands/`, `scripts/`, and the findings notes stay ignored
- [x] Credential scan clean across both skills
- [x] No absolute paths or single-machine assumptions remain
- [x] Frontmatter `name` parses on both `SKILL.md` files
- [ ] Clone on a second machine and confirm both skills list in `/skills`

Docs and config only. No T-SQL or product changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbYty5EYQwd4YGTDcJfEkE
